### PR TITLE
CLN: Cleanup send-recv-py-obj

### DIFF
--- a/tests/send-recv-py-obj.py
+++ b/tests/send-recv-py-obj.py
@@ -26,8 +26,6 @@ import sys
 
 import ucp_py as ucp
 
-msg_size = 1024
-
 
 def get_msg(base, obj_type):
     """
@@ -64,15 +62,15 @@ async def talk_to_client(ep, listener):
 
     print("about to send")
 
-    base = b"0" * msg_size
+    base = b"0" * args.n_bytes
     send_msg = get_msg(base, args.object_type)
-    dest_msg = get_msg(b"0" * msg_size, args.object_type)
+    dest_msg = get_msg(b"0" * args.n_bytes, args.object_type)
     await ep.send_obj(send_msg, sys.getsizeof(send_msg))
 
     print("about to recv")
 
     if not args.blind_recv:
-        recv_req = await ep.recv_obj(dest_msg, msg_size)
+        recv_req = await ep.recv_obj(dest_msg, args.n_bytes)
         recv_msg = get_msg(recv_req.get_obj(), args.object_type)
     else:
         recv_req = await ep.recv_future()
@@ -92,10 +90,10 @@ async def talk_to_client(ep, listener):
 async def talk_to_server(ip, port):
     # recv, send
     ep = ucp.get_endpoint(ip, port)
-    dest_msg = get_msg(b"0" * msg_size, args.object_type)
+    dest_msg = get_msg(b"0" * args.n_bytes, args.object_type)
 
     if not args.blind_recv:
-        recv_req = await ep.recv_obj(dest_msg, msg_size)
+        recv_req = await ep.recv_obj(dest_msg, args.n_bytes)
     else:
         recv_req = await ep.recv_future()
 
@@ -123,6 +121,11 @@ parser.add_argument(
 )
 parser.add_argument(
     "-v", "--validate", help="Validate data. Default = false", action="store_true"
+)
+parser.add_argument(
+    '-n', '--n-bytes', help="Size of the messages (in bytes)", type=int,
+    default=1024
+
 )
 args = parser.parse_args()
 


### PR DESCRIPTION
Some cleanup of this test

1. Removes `str` as an message type option (noncontiguous). A followup PR will fix memory view, numpy, and cuda arrays
2. Changes how validation is done. The old way did an `assert`, which will fail for numpy or cupy arrays.
```pytb
In [2]: assert np.array([1, 2]) == np.array([1, 2])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-5c049897b7ef> in <module>
----> 1 assert np.array([1, 2]) == np.array([1, 2])

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
3. some re-formatting / linting.