### PR TITLE
TST: Fix text hang when running multiple tests

### DIFF
--- a/tests/test_multiple_listeners.py
+++ b/tests/test_multiple_listeners.py
@@ -19,3 +19,5 @@ def test_multiple_listeners():
 
     lf1.coroutine.close()
     lf2.coroutine.close()
+    ucp.stop_listener(lf1)
+    ucp.stop_listener(lf2)


### PR DESCRIPTION
Two issues:

1. I think test_multiple_listeners.py failed to cleanup properly
2. When we run next `test_send_recv_obj.py`, we try to bind to
   13337 again, and fail since we didn't clean up properly.