### PR TITLE
Use full shape in buffer protocol

### DIFF
--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -73,7 +73,7 @@ def ucp_logger(fxn):
     else:
         return fxn
     LOGGER.debug('done with ucxpy init')
-    
+
 
     return wrapper
 

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -9,6 +9,7 @@ cdef extern from "common.h":
 
 import struct
 from libc.stdint cimport uintptr_t
+import numpy as np
 
 # TODO: pxd files
 
@@ -155,13 +156,13 @@ cdef class BufferRegion:
         else:
             buffer.buf = <void *>&(self.buf.buf[0])
 
-        shape2[0] = self.shape[0]
+        shape2[0] = np.prod(self.shape)
 
         buffer.format = self.format
         buffer.internal = NULL
         buffer.itemsize = self.itemsize
-        buffer.len = self.shape[0] * self.itemsize
-        buffer.ndim = 1
+        buffer.len = np.prod(self.shape) * self.itemsize
+        buffer.ndim = len(self.shape)
         buffer.obj = self
         buffer.readonly = 0  # TODO
         buffer.shape = shape2


### PR DESCRIPTION
Previously we would only use the first dimension in a Message shape
in the __getbuffer__ method.  This would result in poorly formed memoryview
objects.

Fixes https://github.com/rapidsai/ucx-py/issues/119