### PR TITLE
WIP: Make shape a pointer and add ndim + strides

### DIFF
--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -176,7 +176,7 @@ cdef class BufferRegion:
         buffer.internal = NULL
         buffer.itemsize = self.itemsize
         buffer.len = self._shape[0] * self.itemsize
-        buffer.ndim = 1
+        buffer.ndim = self.ndim
         buffer.obj = self
         buffer.readonly = 0  # TODO
         buffer.shape = self._shape

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -112,13 +112,20 @@ cdef class BufferRegion:
         self.buf = NULL
         self.ndim = 1
         self._shape = <Py_ssize_t*>malloc(sizeof(Py_ssize_t) * self.ndim)
-        self._shape[0] = 0
+        for i in range(self.ndim):
+            self._shape[i] = 0
         self._strides = <Py_ssize_t*>malloc(sizeof(Py_ssize_t) * self.ndim)
-        self._strides[0] = 1
+        for i in range(self.ndim):
+            self._strides[i] = 1
 
     def __dealloc__(self):
+        self.ndim = 1
         free(self._shape)
+        self._shape = <Py_ssize_t*>malloc(sizeof(Py_ssize_t) * self.ndim)
+        self._shape[0] = 0
         free(self._strides)
+        self._strides = <Py_ssize_t*>malloc(sizeof(Py_ssize_t) * self.ndim)
+        self._strides[0] = 1
 
     def __len__(self):
         if not self.is_set:


### PR DESCRIPTION
Adds `_shape` and `_strides` as private pointers that contain the shape and strides of the data. Also adds `ndim` to aid tracking the dimensionality as a publicly visible value. Includes properties to view the `shape` and `strides`.

Note: Still need to handle some code that is assigning to `self.shape` as that is no longer valid with this approach.