### PR TITLE
add test for cudf send receive

### DIFF
--- a/tests/multiple-listener-client-test.py
+++ b/tests/multiple-listener-client-test.py
@@ -3,8 +3,8 @@ import asyncio
 
 async def tmp():
     addr = ucp.get_address().encode('utf-8')
-    ep1 = ucp.get_endpoint(addr, 13337)
-    ep2 = ucp.get_endpoint(addr, 13338)
+    ep1 = await ucp.get_endpoint(addr, 13337)
+    ep2 = await ucp.get_endpoint(addr, 13338)
 
     await ep1.send_obj(b'hi')
     print("past send1")

--- a/tests/test_buffer_region.py
+++ b/tests/test_buffer_region.py
@@ -1,4 +1,5 @@
 import pytest
+import functools
 
 import ucp
 
@@ -47,3 +48,37 @@ def test_cupy(dtype):
 
     result = cupy.asarray(buffer_region)
     cupy.testing.assert_array_equal(result, arr)
+
+
+@pytest.mark.parametrize(
+    "g",
+    [
+        lambda cudf: cudf.Series([1, 2, 3]),
+        pytest.param(lambda cudf: cudf.Series([1, 2, 3], index=[4, 5, 6]),
+            marks=pytest.mark.xfail),
+        lambda cudf: cudf.Series([1, None, 3]),
+        lambda cudf: cudf.Dataframe({'A': [1, 2, 3]}),
+    ]
+)
+def test_cudf(g):
+    cudf = pytest.importorskip('cudf')
+    deserialize = pytest.importorskip("distributed.protocol").deserialize
+    serialize = pytest.importorskip("distributed.protocol").serialize
+    from dask.dataframe.utils import assert_eq
+
+    cuda_serialize = functools.partial(serialize, serializers=["cuda"])
+    cuda_deserialize = functools.partial(deserialize, deserializers=["cuda"])
+
+    cdf = g(cudf)
+    header, frames = cuda_serialize(cdf)
+
+    gpu_buffers = []
+    for f in frames:
+        if hasattr(f, '__cuda_array_interface__'):
+           buffer_region = ucp.BufferRegion()
+           buffer_region.populate_cuda_ptr(f)
+           gpu_buffers.append(buffer_region)
+        else:
+            gpu_buffers.append(f)
+    res = cuda_deserialize(header, gpu_buffers)
+    assert_eq(res, cdf)

--- a/tests/test_send_recv_obj.py
+++ b/tests/test_send_recv_obj.py
@@ -23,6 +23,7 @@ async def echo_pair(cuda_info=None):
         await t
         ucp.fin()
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("size", msg_sizes)
 async def test_send_recv_bytes(size):
@@ -120,7 +121,6 @@ async def test_send_recv_numba(size):
     arr = np.array(msg, dtype='u1')
     msg = numba.cuda.to_device(arr)
 
-    breakpoint()
     async with echo_pair(cuda_info) as (_, client):
         await client.send_obj(bytes(str(size), encoding='utf-8'))
         await client.send_obj(msg)

--- a/tests/test_send_recv_obj.py
+++ b/tests/test_send_recv_obj.py
@@ -59,20 +59,18 @@ async def test_send_recv_memoryview(size):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("size", msg_sizes)
-async def test_send_recv_numpy(size):
+@pytest.mark.parametrize("dtype", dtypes)
+async def test_send_recv_numpy(size, dtype):
     np = pytest.importorskip('numpy')
-    x = "a"
-    x = x * size
-    msg = bytes(x, encoding='utf-8')
-    msg = memoryview(msg)
-    msg = np.frombuffer(msg, dtype='u1')
+    msg = np.arange(size, dtype=dtype)
+    alloc_size = msg.nbytes
 
     async with echo_pair() as (_, client):
-        await client.send_obj(bytes(str(size), encoding='utf-8'))
+        await client.send_obj(bytes(str(alloc_size), encoding='utf-8'))
         await client.send_obj(msg)
-        resp = await client.recv_obj(len(msg))
+        resp = await client.recv_obj(alloc_size)
         result = ucp.get_obj_from_msg(resp)
-        result = np.frombuffer(result, 'u1')
+        result = np.frombuffer(result, dtype)
 
     np.testing.assert_array_equal(result, msg)
 

--- a/tests/test_send_recv_obj.py
+++ b/tests/test_send_recv_obj.py
@@ -217,11 +217,11 @@ async def test_send_recv_cudf(event_loop, g):
             print("Sending meta...")
             await self.ep.send_obj(meta)
             for idx, frame in enumerate(frames):
-                breakpoint()
                 print("Sending frame: ", idx)
                 await self.ep.send_obj(frame)
 
         async def read(self):
+            print("Receiving frames...")
             await asyncio.sleep(1)
             print("Receiving frames...")
             resp = await self.ep.recv_future()
@@ -271,7 +271,6 @@ async def test_send_recv_cudf(event_loop, g):
     uu.address = ucp.get_address()
     uu.client = await ucp.get_endpoint(uu.address.encode(), 13337)
     ucx = UCX(uu.client)
-    breakpoint()
     await ucx.write(cdf)
     await asyncio.sleep(1)
     frames = await uu.comm.read()
@@ -329,7 +328,6 @@ async def test_send_recv_rmm(size, dtype):
     assert isinstance(n_result, numba.cuda.devicearray.DeviceNDArray)
     nn_result = np.asarray(n_result, dtype=dtype)
     msg = np.asarray(msg, dtype=dtype)
-    breakpoint()
     np.testing.assert_array_equal(msg, nn_result)
 
 
@@ -354,9 +352,7 @@ async def test_send_recv_zero(dtype):
     async with echo_pair(cuda_info) as (_, client):
         await client.send_obj(bytes(str(gpu_alloc_size), encoding='utf-8'))
         await client.send_obj(msg)
-        breakpoint()
         resp = await client.recv_obj(gpu_alloc_size, cuda=True)
-        breakpoint()
         result = ucp.get_obj_from_msg(resp)
 
     assert hasattr(result, '__cuda_array_interface__')

--- a/tests/test_send_recv_obj.py
+++ b/tests/test_send_recv_obj.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import itertools
 import pytest
 from contextlib import asynccontextmanager
@@ -21,7 +22,6 @@ async def echo_pair(cuda_info=None):
         ucp.destroy_ep(client)
         await t
         ucp.fin()
-
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("size", msg_sizes)
@@ -172,3 +172,114 @@ async def test_send_recv_into_cuda(size):
     result = cupy.asarray(result)
     cupy.testing.assert_array_equal(result, msg)
     cupy.testing.assert_array_equal(sink, msg)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "g",
+    [
+        lambda cudf: cudf.Series([1, 2, 3]),
+        lambda cudf: cudf.Series([1, 2, 3], index=[4, 5, 6]),
+        lambda cudf: cudf.Series([1, None, 3]),
+    ]
+)
+async def test_send_recv_cudf(event_loop, g):
+    cudf = pytest.importorskip('cudf')
+    deserialize = pytest.importorskip("distributed.protocol").deserialize
+    serialize = pytest.importorskip("distributed.protocol").serialize
+    import struct
+    from distributed.utils import nbytes
+    import pickle
+
+    cuda_serialize = functools.partial(serialize, serializers=["cuda"])
+    cuda_deserialize = functools.partial(deserialize, deserializers=["cuda"])
+
+    cdf = g(cudf)
+
+    class UCX:
+        def __init__(self, ep):
+            self.ep = ep
+
+        async def write(self, cdf):
+            header, _frames = cuda_serialize(cdf)
+            frames = [pickle.dumps(header)] + _frames
+
+            is_gpus = b"".join([struct.pack("?", hasattr(frame, "__cuda_array_interface__")) for frame in frames])
+            nframes = struct.pack("Q", len(frames))
+            sizes = b"".join([struct.pack("Q", nbytes(frame)) for frame in frames])
+            meta = b"".join([nframes, is_gpus, sizes])
+
+            print("Sending meta...")
+            await self.ep.send_obj(meta)
+            for idx, frame in enumerate(frames):
+                print("Sending frame: ", idx)
+                await self.ep.send_obj(frame)
+
+        async def read(self):
+            await asyncio.sleep(1)
+            print("Receiving frames...")
+            resp = await self.ep.recv_future()
+            obj = ucp.get_obj_from_msg(resp)
+            nframes, = struct.unpack("Q", obj[:8])  # first eight bytes for number of frames
+            gpu_frame_msg = obj[
+                8 : 8 + nframes
+            ]  # next nframes bytes for if they're GPU frames
+            is_gpus = struct.unpack("{}?".format(nframes), gpu_frame_msg)
+
+            sized_frame_msg = obj[8 + nframes :]  # then the rest for frame sizes
+            sizes = struct.unpack("{}Q".format(nframes), sized_frame_msg)
+
+            frames = []
+
+            for i, (is_gpu, size) in enumerate(zip(is_gpus, sizes)):
+                if size > 0:
+                    resp = await self.ep.recv_obj(size, cuda=is_gpu)
+                else:
+                    resp = await self.ep.recv_future()
+                frame = ucp.get_obj_from_msg(resp)
+                frames.append(frame)
+
+            print(frames)
+            res = cudf.Series(frames[-2]).to_pandas()
+            print(res)
+            return frames
+
+    class UCXListener:
+        def __init__(self):
+           self.comm_handler = None
+
+        def start(self):
+            async def serve_forever(ep, li):
+                print("starting server...")
+                ucx = UCX(ep)
+                self.comm = ucx
+
+            ucp.init()
+            loop = asyncio.get_event_loop()
+
+            self.ucp_server = ucp.start_listener(serve_forever,
+                                          listener_port=13337,
+                                          is_coroutine=True)
+            t = loop.create_task(self.ucp_server.coroutine)
+            self._t = t
+
+    uu = UCXListener()
+    uu.start()
+    uu.address = ucp.get_address()
+    uu.client = await ucp.get_endpoint(uu.address.encode(), 13337)
+    ucx = UCX(uu.client)
+    await ucx.write(cdf)
+    await asyncio.sleep(1)
+    frames = await uu.comm.read()
+
+    ucx_header = pickle.loads(frames[0])
+    ucx_index = bytes(frames[1])
+    cudf_buffer = frames[2]
+    ucx_bytes_leftovers = bytes(frames[3])
+    ucx_received_frames = [ucx_index, cudf_buffer, ucx_bytes_leftovers]
+    # cuda_deserialize(header, ucx_received_frames).to_pandas() # fails with NoneType
+    assert cudf.Series(cudf_buffer).to_array() == cdf.to_array()
+
+
+    ucp.destroy_ep(uu.client)
+    ucp.fin()

--- a/ucp/_libs/src/ucp_py_ucp_fxns.c
+++ b/ucp/_libs/src/ucp_py_ucp_fxns.c
@@ -177,15 +177,15 @@ static unsigned ucp_ipy_worker_progress(ucp_worker_h ucp_worker)
     char tmp_str[TAG_STR_MAX_LEN];
     struct ucx_context *request = 0;
     ucp_py_internal_ep_t *internal_ep;
-    
+
 #ifdef UCX_PY_PROF
     struct timeval s, e;
     double lat;
     gettimeofday(&s, NULL);
 #endif
-    
+
     status = ucp_worker_progress(ucp_worker);
-    
+
 #ifdef UCX_PY_PROF
     gettimeofday(&e, NULL);
     lat = (e.tv_usec - s.tv_usec) + (1E+6 * (e.tv_sec - s.tv_sec));
@@ -350,7 +350,7 @@ struct ucx_context *ucp_py_ep_send_nb(void *internal_ep, struct data_buf *send_b
     DEBUG_PRINT("EP send : %p\n", int_ep->ep_ptr);
 
     DEBUG_PRINT("sending %p\n", send_buf->buf);
-    
+
     tag = int_ep->send_tag;
     DEBUG_PRINT("send_nb tag = %d\n", tag);
     request = ucp_tag_send_nb(*((ucp_ep_h *) int_ep->ep_ptr), send_buf->buf, length,
@@ -367,11 +367,11 @@ struct ucx_context *ucp_py_ep_send_nb(void *internal_ep, struct data_buf *send_b
 	request->length = length;
 	request->type   = UCP_SEND;
 #endif
-    
+
     } else {
         /* request is complete so no need to wait on request */
     }
-    
+
     DEBUG_PRINT("returning request %p\n", request);
 
     return request;
@@ -410,7 +410,7 @@ int ucp_py_worker_progress_wait(void)
         printf("ucp_worker_arm error\n");
         goto err;
     }
-    
+
 #ifdef UCX_PY_PROF
     gettimeofday(&e, NULL);
     lat = (e.tv_usec - s.tv_usec) + (1E+6 * (e.tv_sec - s.tv_sec));
@@ -437,7 +437,7 @@ int ucp_py_worker_drain_fd()
         ret = epoll_wait(ucp_py_ctx_head->epoll_fd_local, &(ucp_py_ctx_head->ev), 1, -1);
     } while ((ret == -1) && (errno == EINTR));
 #endif
-    
+
 #ifdef UCX_PY_PROF
     gettimeofday(&e, NULL);
     lat = (e.tv_usec - s.tv_usec) + (1E+6 * (e.tv_sec - s.tv_sec));
@@ -546,7 +546,7 @@ static int start_listener(ucp_worker_h ucp_worker, ucx_listener_ctx_t *context,
     int retry = 0;
 
     while (retry < MAX_LISTEN_RETRIES) {
-	
+
         set_listen_addr(&listen_addr, *port);
 
 	context->port             = *port;
@@ -556,7 +556,7 @@ static int start_listener(ucp_worker_h ucp_worker, ucx_listener_ctx_t *context,
 	params.sockaddr.addrlen   = sizeof(listen_addr);
 	params.accept_handler.cb  = listener_accept_cb;
 	params.accept_handler.arg = context;
-	
+
 	DEBUG_PRINT("listener port assigned = %d\n", context->port);
 
         status = ucp_listener_create(ucp_worker, &params, listener);
@@ -565,12 +565,12 @@ static int start_listener(ucp_worker_h ucp_worker, ucx_listener_ctx_t *context,
         } else {
             goto done;
         }
-        
+
         retry++;
 	*port = *port + 1;
 	DEBUG_PRINT("retrying with port %d\n", *port);
     }
-    
+
  done:
 
     return status;
@@ -597,7 +597,7 @@ void *ucp_py_get_ep(char *ip, int listener_port)
 
     ep_err_hanlder.cb = ep_err_handler_cb;
     ep_err_hanlder.arg = &connection_status;
-    
+
     internal_ep = (ucp_py_internal_ep_t *) malloc(sizeof(ucp_py_internal_ep_t));
     ep_ptr = (ucp_ep_h *) malloc(sizeof(ucp_ep_h));
     set_connect_addr(ip, &connect_addr, (uint16_t) listener_port);
@@ -796,7 +796,7 @@ void *ucp_py_listen(listener_accept_cb_func pyx_cb, void *py_cb, int *port)
     int listener_idx;
 
     if (ucp_py_ctx_head->num_listeners >= MAX_LISTENERS) return NULL;
-    
+
     listener_idx = ucp_py_ctx_head->num_listeners;
     ucp_py_ctx_head->listener_context[listener_idx].pyx_cb = pyx_cb;
     ucp_py_ctx_head->listener_context[listener_idx].py_cb = py_cb;

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -73,7 +73,7 @@ def ucp_logger(fxn):
     else:
         return fxn
     LOGGER.debug('done with ucxpy init')
-    
+
 
     return wrapper
 
@@ -97,8 +97,8 @@ def handle_msg(msg):
         The ``.result`` will be the original `msg`.
     """
     global reader_added
-    assert UCX_FILE_DESCRIPTOR > 0
-    assert reader_added > 0
+    assert UCX_FILE_DESCRIPTOR > 0, ("UCX_FILE_DESCRIPTOR", UCX_FILE_DESCRIPTOR)
+    assert reader_added > 0, ("reader_added", reader_added)
 
     fut = asyncio.Future()
     PENDING_MESSAGES[msg] = fut

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -211,7 +211,7 @@ cdef class BufferRegion:
         self._readonly = is_readonly
 
         if len(info.get('strides', ())) <= 1:
-            self.buf = populate_buffer_region_with_ptr(ptr_int)
+            self.buf = populate_buffer_region_with_ptr(ptr_int or 0)
         else:
             raise NotImplementedError("non-contiguous data not supported.")
 

--- a/ucp/_utils.py
+++ b/ucp/_utils.py
@@ -59,6 +59,11 @@ def make_server(cuda_info=None):
 
         if cuda_info:
             import cupy
+            if 'shape' in cuda_info:
+                 # this is critical -- incoming shape is often
+                 # the size of the buffer which is not the same
+                # as shape
+                obj.shape = cuda_info['shape']
             if 'typestr' in cuda_info:
                 obj.typestr = cuda_info['typestr']
             obj = cupy.asarray(obj)


### PR DESCRIPTION
PR adds a test for cudf send/receive and mimics the scheme dask uses for sending cuda objects through UCX.  

This test is currently failing and should serve as a minimal example of distributed/cudf working with UCX

cc @mrocklin @Akshay-Venkatesh @TomAugspurger @rjzamora 