### PR TITLE
Cleanup tests

### DIFF
--- a/ucp/_utils.py
+++ b/ucp/_utils.py
@@ -42,9 +42,7 @@ def make_server(cuda_info=None):
     async def echo_server(ep, lf):
         """
         Basic echo server for sized messages.
-
         We expect the other endpoint to follow the pattern::
-
         >>> await ep.send_obj(msg_size)  # size of the real message
         >>> await ep.send_obj(obj)       # send the real message
         >>> await ep.recv_obj(msg_size)  # receive the echo
@@ -53,17 +51,24 @@ def make_server(cuda_info=None):
 
         size_msg = await ep.recv_future()
         size = int(size_msg.get_obj())
-
         msg = await ep.recv_obj(size, cuda=bool(cuda_info))
         obj = msg.get_obj()
+        nbytes = None
 
         if cuda_info:
             import cupy
+            import numpy as np
+            if 'shape' in cuda_info:
+                 # this is critical -- incoming shape is often
+                 # the size of the buffer which is not the same
+                 # as shape
+                obj.shape = cuda_info['shape']
             if 'typestr' in cuda_info:
                 obj.typestr = cuda_info['typestr']
-            obj = cupy.asarray(obj)
+		        # get the true value of the size of the buffer
+                nbytes = np.dtype(obj.__cuda_array_interface__['typestr']).itemsize * len(obj)
 
-        await ep.send_obj(obj)
+        await ep.send_obj(obj, nbytes=nbytes)
         destroy_ep(ep)
         stop_listener(lf)
 


### PR DESCRIPTION
PR cleans up tests
- no longer send all objects as cupy arrays in make_server
- adds dtype tests
- adds large data test