### PR TITLE
[MERGE] Fixes wrong shape and stack allocation in BufferRegion

### DIFF
--- a/tests/test_buffer_region.py
+++ b/tests/test_buffer_region.py
@@ -8,7 +8,7 @@ def test_set_read():
     buffer_region = ucp.BufferRegion()
     buffer_region.populate_ptr(obj)
     res = memoryview(buffer_region)
-    assert res == obj
+    assert bytes(res) == bytes(obj)
     assert res.tobytes() == obj.tobytes()
 
     # our properties

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -296,7 +296,7 @@ cdef class Endpoint:
         Receive into an existing block of memory.
         """
         buf_reg = BufferRegion()
-        buf_reg.shape[0] = nbytes
+        buf_reg.shape = (nbytes,)
         if hasattr(buffer, '__cuda_array_interface__'):
             buf_reg.populate_cuda_ptr(buffer)
         else:

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -192,7 +192,8 @@ cdef class BufferRegion:
         self._populate_ptr(obj)
 
     cpdef _populate_ptr(self, format_[:] pyobj):
-        self.shape = pyobj.shape
+        # Notice, `len(memoryview.shape)` might not equal `memoryview.ndim`
+        self.shape = [pyobj.shape[i] for i in range(pyobj.ndim)]
         self._is_cuda  = 0
         # TODO: We may not have a `.format` here. Not sure how to handle.
         if hasattr(pyobj.base, 'format'):

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -226,18 +226,18 @@ cdef class BufferRegion:
     # ------------------------------------------------------------------------
     # Manual memory management
 
-    def alloc_host(self, Py_ssize_t len):
-        self.buf = allocate_host_buffer(len)
+    def alloc_host(self, Py_ssize_t length):
+        self.buf = allocate_host_buffer(length)
         self._is_cuda = 0
         self._mem_allocated = 1
-        self.shape[0] = len
+        self.shape = (length,)
 
-    def alloc_cuda(self, len):
+    def alloc_cuda(self, length):
         cuda_check()
-        self.buf = allocate_cuda_buffer(len)
+        self.buf = allocate_cuda_buffer(length)
         self._is_cuda = 1
         self._mem_allocated = 1
-        self.shape[0] = len
+        self.shape = (length,)
 
     def free_host(self):
         free_host_buffer(self.buf)

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -166,7 +166,7 @@ cdef class BufferRegion:
         buffer.internal = NULL
         buffer.itemsize = self.itemsize
         buffer.len = shape2[0] * self.itemsize
-        buffer.ndim = len(self.shape)
+        buffer.ndim = len(shape2)
         buffer.obj = self
         buffer.readonly = 0  # TODO
         buffer.shape = shape2

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -156,7 +156,7 @@ cdef class BufferRegion:
         if self.shape[0] == 0:
             buffer.buf = <void *>empty
         else:
-            buffer.buf = <void *>&(self.buf.buf[0])
+            buffer.buf = <void *>(self.buf.buf)
 
         shape2[0] = self.shape[0]
         for s in self.shape[1:]:

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -147,7 +147,6 @@ cdef class BufferRegion:
         cdef:
             Py_ssize_t *strides = <Py_ssize_t*>PyMem_Malloc(sizeof(Py_ssize_t))
             Py_ssize_t *shape2 = <Py_ssize_t*>PyMem_Malloc(sizeof(Py_ssize_t))
-            empty = b''
 
         if not self.is_set:
             raise ValueError("This buffer region's memory has not been set.")
@@ -155,7 +154,7 @@ cdef class BufferRegion:
         strides[0] = <Py_ssize_t>self.itemsize
         assert len(self.shape)
         if self.shape[0] == 0:
-            buffer.buf = <void *>empty
+            buffer.buf = NULL
         else:
             buffer.buf = <void *>(self.buf.buf)
 

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -110,8 +110,7 @@ cdef class BufferRegion:
         self.itemsize = 1
         self._readonly = False  # True?
         self.buf = NULL
-        self.shape = [0]
-
+        self.shape = (0,)
     def __len__(self):
         if not self.is_set:
             return 0
@@ -193,7 +192,7 @@ cdef class BufferRegion:
 
     cpdef _populate_ptr(self, format_[:] pyobj):
         # Notice, `len(memoryview.shape)` might not equal `memoryview.ndim`
-        self.shape = [pyobj.shape[i] for i in range(pyobj.ndim)]
+        self.shape = tuple([pyobj.shape[i] for i in range(pyobj.ndim)])
         self._is_cuda  = 0
         # TODO: We may not have a `.format` here. Not sure how to handle.
         if hasattr(pyobj.base, 'format'):


### PR DESCRIPTION
`len(memoryview.shape)` might not equal `memoryview.ndim`

All tests in `tests/test_buffer_region.py ` now passes on my installation

**Update:** the returned shape and strides in `__buffer__` is now allocated on the heap.