### PR TITLE
Drop hard numpy requirement

### DIFF
--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -9,7 +9,6 @@ cdef extern from "common.h":
 
 import struct
 from libc.stdint cimport uintptr_t
-import numpy as np
 
 # TODO: pxd files
 
@@ -158,7 +157,9 @@ cdef class BufferRegion:
         else:
             buffer.buf = <void *>&(self.buf.buf[0])
 
-        shape2[0] = np.prod(self.shape)
+        shape2[0] = self.shape[0]
+        for s in self.shape:
+            shape2[0] *= s
 
         buffer.format = self.format
         buffer.internal = NULL

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -163,7 +163,7 @@ cdef class BufferRegion:
         buffer.format = self.format
         buffer.internal = NULL
         buffer.itemsize = self.itemsize
-        buffer.len = np.prod(self.shape) * self.itemsize
+        buffer.len = shape2[0] * self.itemsize
         buffer.ndim = len(self.shape)
         buffer.obj = self
         buffer.readonly = 0  # TODO

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -158,7 +158,7 @@ cdef class BufferRegion:
             buffer.buf = <void *>&(self.buf.buf[0])
 
         shape2[0] = self.shape[0]
-        for s in self.shape:
+        for s in self.shape[1:]:
             shape2[0] *= s
 
         buffer.format = self.format


### PR DESCRIPTION
This reworks PR ( https://github.com/rapidsai/ucx-py/pull/120 )'s changes slightly to drop the hard NumPy requirement added by it. Fixing an issue encountered when building the ucx-py packages.