### PR TITLE
Implements BufferRegion Constructors

### DIFF
--- a/tests/test_buffer_region.py
+++ b/tests/test_buffer_region.py
@@ -4,9 +4,8 @@ import ucp
 
 
 def test_set_read():
-    obj = memoryview(b"hi")
-    buffer_region = ucp.BufferRegion()
-    buffer_region.populate_ptr(obj)
+    obj = memoryview(b'hi')
+    buffer_region = ucp.BufferRegion.fromBuffer(obj)
     res = memoryview(buffer_region)
     assert bytes(res) == bytes(obj)
     assert res.tobytes() == obj.tobytes()
@@ -22,13 +21,7 @@ def test_numpy(dtype, data):
     np = pytest.importorskip("numpy")
     arr = np.ones(10, dtype)
 
-    buffer_region = ucp.BufferRegion()
-
-    if data:
-        buffer_region.populate_ptr(arr.data)
-    else:
-        buffer_region.populate_ptr(arr.data)
-
+    buffer_region = ucp.BufferRegion.fromBuffer(arr)
     result = np.asarray(buffer_region)
     np.testing.assert_array_equal(result, arr)
 
@@ -38,8 +31,7 @@ def test_cupy(dtype):
     cupy = pytest.importorskip("cupy")
     arr = cupy.ones(10, dtype)
 
-    buffer_region = ucp.BufferRegion()
-    buffer_region.populate_cuda_ptr(arr)
+    buffer_region = ucp.BufferRegion.fromBuffer(arr)
 
     result = cupy.asarray(buffer_region)
     cupy.testing.assert_array_equal(result, arr)
@@ -50,8 +42,7 @@ def test_numba_empty():
     import numba.cuda  # noqa
 
     arr = numba.cuda.device_array(0)
-    br = ucp.BufferRegion()
-    br.populate_cuda_ptr(arr)
+    br = ucp.BufferRegion.fromBuffer(arr)
 
     assert len(br) == 0
     assert br.__cuda_array_interface__["data"][0] == 0

--- a/tests/test_buffer_region.py
+++ b/tests/test_buffer_region.py
@@ -5,7 +5,7 @@ import ucp
 
 def test_set_read():
     obj = memoryview(b'hi')
-    buffer_region = ucp.BufferRegion.fromBuffer(obj)
+    buffer_region = ucp.BufferRegion.from_buffer(obj)
     res = memoryview(buffer_region)
     assert bytes(res) == bytes(obj)
     assert res.tobytes() == obj.tobytes()
@@ -21,7 +21,7 @@ def test_numpy(dtype, data):
     np = pytest.importorskip("numpy")
     arr = np.ones(10, dtype)
 
-    buffer_region = ucp.BufferRegion.fromBuffer(arr)
+    buffer_region = ucp.BufferRegion.from_buffer(arr)
     result = np.asarray(buffer_region)
     np.testing.assert_array_equal(result, arr)
 
@@ -31,7 +31,7 @@ def test_cupy(dtype):
     cupy = pytest.importorskip("cupy")
     arr = cupy.ones(10, dtype)
 
-    buffer_region = ucp.BufferRegion.fromBuffer(arr)
+    buffer_region = ucp.BufferRegion.from_buffer(arr)
 
     result = cupy.asarray(buffer_region)
     cupy.testing.assert_array_equal(result, arr)
@@ -42,7 +42,7 @@ def test_numba_empty():
     import numba.cuda  # noqa
 
     arr = numba.cuda.device_array(0)
-    br = ucp.BufferRegion.fromBuffer(arr)
+    br = ucp.BufferRegion.from_buffer(arr)
 
     assert len(br) == 0
     assert br.__cuda_array_interface__["data"][0] == 0

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -310,13 +310,7 @@ cdef class Endpoint:
         >>> result
         <ucp_py._libs.ucp_py.BufferRegion at 0x...>
         """
-        buf_reg = BufferRegion()
-        if cuda:
-            buf_reg.alloc_cuda(nbytes)
-            buf_reg._is_cuda = 1
-        else:
-            buf_reg.alloc_host(nbytes)
-
+        buf_reg = BufferRegion.newBuffer(nbytes, cuda=cuda)
         return self._recv(buf_reg, nbytes, name)
 
     def _send_obj_cuda(self, obj):
@@ -421,15 +415,15 @@ cdef class Message:
     def is_cuda(self):
         return self.buf_reg.is_cuda
 
-    def alloc_host(self, len):
-        self.buf_reg.alloc_host(len)
+    def alloc_host(self, length):
+        self.buf_reg = BufferRegion.newBuffer(length, cuda=False)
         self.buf = self.buf_reg.buf
-        self.alloc_len = len
+        self.alloc_len = length
 
-    def alloc_cuda(self, len):
-        self.buf_reg.alloc_cuda(len)
+    def alloc_cuda(self, length):
+        self.buf_reg = BufferRegion.newBuffer(length, cuda=True)
         self.buf = self.buf_reg.buf
-        self.alloc_len = len
+        self.alloc_len = length
 
     def free_host(self):
         self.buf_reg.free_host()

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -269,12 +269,7 @@ cdef class Endpoint:
         """
         Receive into an existing block of memory.
         """
-        buf_reg = BufferRegion()
-        buf_reg.shape = (nbytes,)
-        if hasattr(buffer, '__cuda_array_interface__'):
-            buf_reg.populate_cuda_ptr(buffer)
-        else:
-            buf_reg.populate_ptr(buffer)
+        buf_reg = BufferRegion.fromBuffer(buffer)
         return self._recv(buf_reg, nbytes, name)
 
     @ucp_logger
@@ -325,14 +320,10 @@ cdef class Endpoint:
         return self._recv(buf_reg, nbytes, name)
 
     def _send_obj_cuda(self, obj):
-        buf_reg = BufferRegion()
-        buf_reg.populate_cuda_ptr(obj)
-        return buf_reg
+        return BufferRegion.fromBuffer(obj)
 
     def _send_obj_host(self, format_[:] obj):
-        buf_reg = BufferRegion()
-        buf_reg.populate_ptr(obj)
-        return buf_reg
+        return BufferRegion.fromBuffer(obj)
 
     @ucp_logger
     def send_obj(self, msg, nbytes=None, name='send_obj'):

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -269,7 +269,7 @@ cdef class Endpoint:
         """
         Receive into an existing block of memory.
         """
-        buf_reg = BufferRegion.fromBuffer(buffer)
+        buf_reg = BufferRegion.from_buffer(buffer)
         return self._recv(buf_reg, nbytes, name)
 
     @ucp_logger
@@ -310,14 +310,14 @@ cdef class Endpoint:
         >>> result
         <ucp_py._libs.ucp_py.BufferRegion at 0x...>
         """
-        buf_reg = BufferRegion.newBuffer(nbytes, cuda=cuda)
+        buf_reg = BufferRegion.new_buffer(nbytes, cuda=cuda)
         return self._recv(buf_reg, nbytes, name)
 
     def _send_obj_cuda(self, obj):
-        return BufferRegion.fromBuffer(obj)
+        return BufferRegion.from_buffer(obj)
 
     def _send_obj_host(self, format_[:] obj):
-        return BufferRegion.fromBuffer(obj)
+        return BufferRegion.from_buffer(obj)
 
     @ucp_logger
     def send_obj(self, msg, nbytes=None, name='send_obj'):
@@ -416,12 +416,12 @@ cdef class Message:
         return self.buf_reg.is_cuda
 
     def alloc_host(self, length):
-        self.buf_reg = BufferRegion.newBuffer(length, cuda=False)
+        self.buf_reg = BufferRegion.new_buffer(length, cuda=False)
         self.buf = self.buf_reg.buf
         self.alloc_len = length
 
     def alloc_cuda(self, length):
-        self.buf_reg = BufferRegion.newBuffer(length, cuda=True)
+        self.buf_reg = BufferRegion.new_buffer(length, cuda=True)
         self.buf = self.buf_reg.buf
         self.alloc_len = length
 

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -104,6 +104,7 @@ cdef class BufferRegion:
     @classmethod
     def fromBuffer(cls, obj):
         if hasattr(obj, "__cuda_array_interface__"):
+            cuda_check()
             ret = BufferRegion()
             ret._populate_cuda_ptr(obj)
             return ret
@@ -111,6 +112,24 @@ cdef class BufferRegion:
             ret = BufferRegion()
             ret._populate_ptr(obj)
             return ret            
+
+    @classmethod
+    def newBuffer(cls, nbytes, cuda=False):
+        ret = BufferRegion()
+        if cuda:
+            cuda_check()
+            ret.buf = malloc_cuda(nbytes)
+            ret._is_cuda = 1
+        else:
+            ret.buf = malloc_host(nbytes)
+            ret._is_cuda = 0
+        ret._mem_allocated = 1
+        ret.shape = (nbytes,)
+        ret.typestr = "B"
+        ret.format = b"B"
+        ret.itemsize = 1
+        ret._is_set = 1
+        return ret
 
     def __len__(self):
         if not self.is_set:

--- a/ucp/_libs/ucp_py_buffer_helper.pyx
+++ b/ucp/_libs/ucp_py_buffer_helper.pyx
@@ -102,7 +102,7 @@ cdef class BufferRegion:
         self._is_set = 0
 
     @classmethod
-    def fromBuffer(cls, obj):
+    def from_buffer(cls, obj):
         if hasattr(obj, "__cuda_array_interface__"):
             cuda_check()
             ret = BufferRegion()
@@ -114,7 +114,7 @@ cdef class BufferRegion:
             return ret            
 
     @classmethod
-    def newBuffer(cls, nbytes, cuda=False):
+    def new_buffer(cls, nbytes, cuda=False):
         ret = BufferRegion()
         if cuda:
             cuda_check()


### PR DESCRIPTION
This PR simply adds some constructors to the `BufferRegion` class. 
The is a step on the way to make `BufferRegion` only constructable through constructors. 