### PR TITLE
Fix a test that hangs and segfaults due to port mismatch

### DIFF
--- a/tests/test_custom_ep_send_recv.py
+++ b/tests/test_custom_ep_send_recv.py
@@ -127,6 +127,7 @@ async def test_send_recv_cudf(event_loop, g):
     # let UCP shutdown
     time.sleep(1)
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("size", [2 ** N for N in [5, 8, 13, 26, 28]])
 async def test_send_recv_cupy(event_loop, size):


### PR DESCRIPTION
UCP will automatically find the next available port when `start_listener` is called. `test_send_recv_cupy` (and others) uses a pre-assigned port # and hangs instead of failing immediately when the expected port is not available.

1. This PR modifies `start_listener` to pass the port by reference so that `test_send_recv_cupy` and others can use the rolling port number.

2. This PR also raises an exception when the port found by `start_listener` doesn't match the port number that was expected.

These methods are somewhat contradictory so I'm reviewing the changes here in the PR and considering how to go forward.

Fixes #168 