### PR TITLE
[FEA] print unfinished messages 

### DIFF
--- a/tests/test_send_recv_obj.py
+++ b/tests/test_send_recv_obj.py
@@ -16,7 +16,7 @@ async def echo_pair(cuda_info=None):
     listener = ucp.start_listener(ucp.make_server(cuda_info), is_coroutine=True)
     t = loop.create_task(listener.coroutine)
     address = ucp.get_address()
-    client = await ucp.get_endpoint(address.encode(), listener.port)
+    client = await ucp.get_endpoint(address.encode(), listener.port, name="client to server")
     try:
         yield listener, client
     finally:

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -68,6 +68,22 @@ def unfinished_messages_info():
         ret += "  %s\n" % msg
     return ret
 
+class MsgHangError(Exception):
+    pass
+
+def unfinished_messages_exception_trigger():
+    """Sets exception on all current unfinished messages 
+       and trigger them"""
+    update_pending_messages()
+    msg_count = len(PENDING_MESSAGES)
+    for msg, fut in PENDING_MESSAGES.items():
+        try:
+            fut.set_exception(MsgHangError(str(msg)))
+            fut.get_loop().run_until_complete(fut)
+        except MsgHangError as e:
+            print("MsgHangError: %s" %e)
+
+
 def get_ucp_worker():
     return <size_t>get_worker()
 

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -699,7 +699,7 @@ def fin():
         raise RuntimeError("UCX-Py fin(): ucp_py_finalize() failed!")
 
 @ucp_logger
-async def get_endpoint(peer_ip, peer_port, timeout=None, name=None):
+async def get_endpoint(peer_ip, peer_port, timeout=None, name="client to server"):
     """Connect to a peer running at `peer_ip` and `peer_port`
 
     Parameters

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -62,10 +62,10 @@ def update_pending_messages():
 
 def unfinished_messages_info():
     """Returns info of all current unfinished messages"""
-    update_pending_messages()
     ret = "Unfinished messages:\n"
     for msg, fut in PENDING_MESSAGES.items():
-        ret += "  %s\n" % msg
+        if not fut.done():
+            ret += "  %s\n" % msg
     return ret
 
 class MsgHangError(Exception):

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -75,7 +75,6 @@ def unfinished_messages_exception_trigger():
     """Sets exception on all current unfinished messages 
        and trigger them"""
     update_pending_messages()
-    msg_count = len(PENDING_MESSAGES)
     for msg, fut in PENDING_MESSAGES.items():
         try:
             fut.set_exception(MsgHangError(str(msg)))

--- a/ucp/_libs/ucp_py.pyx
+++ b/ucp/_libs/ucp_py.pyx
@@ -407,6 +407,8 @@ cdef class Endpoint:
 cdef class Listener:
     cdef void* listener_ptr
 
+_message_count = 0
+
 cdef class Message:
     """A class that represents the message associated with a
     communication request
@@ -425,11 +427,15 @@ cdef class Message:
     cdef ssize_t _length
     cdef int is_blind
     cdef object endpoint
+    cdef int _id
 
     def __cinit__(self, BufferRegion buf_reg, name='', length=-1):
+        global _message_count
         self._name = name
         self._length = length
         self.endpoint = None
+        self._id = _message_count
+        _message_count += 1
 
         if buf_reg is None:
             self.buf_reg = BufferRegion()
@@ -445,7 +451,7 @@ cdef class Message:
         return
 
     def __repr__(self):
-        return f'<Message - name: "{self.name}", cuda: {bool(self.is_cuda)}, ' + \
+        return f'<Message #{self._id} - name: "{self.name}", cuda: {bool(self.is_cuda)}, ' + \
                f'comm_len: {self.comm_len}, alloc_len: {self.alloc_len}, endpoint: "{self.endpoint}">'
 
     @property


### PR DESCRIPTION
This PR adds `unfinished_messages_info()`, which returns info about all current unfinished messages.

The idea is that if the execution has deadlocked, you can _Control-C_ out to pdb and call `ucp.unfinished_messages_info()`.

Example, if I add an extra receive in `test_send_recv_bytes()`: 
```python
@pytest.mark.asyncio
@pytest.mark.parametrize("size", msg_sizes)
async def test_send_recv_bytes(size):
    x = "a"
    x = x * size
    msg = bytes(x, encoding="utf-8")

    async with echo_pair() as (_, client):
        await client.send_obj(bytes(str(size), encoding="utf-8"))
        await client.send_obj(msg)
        resp = await client.recv_obj(len(msg))
        result = ucp.get_obj_from_msg(resp)
        await client.recv_obj(42) # extra 42 bytes receive 
    assert result.tobytes() == msg
```
It will then hang; I can _Control-C_ out to pdb and see the hanging `recv_obj`:
```
(Pdb) import ucp; print(ucp.unfinished_messages_info())
Unfinished messages:
  <Message - name: "recv_obj", cuda: False, comm_len: 256, alloc_len: -1, endpoint: "<Endpoint "client to server" on 10.33.225.165 connected to 10.33.225.165:13337>">
```