### PR TITLE
Restore the conda package install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ conda create -n ucx -c conda-forge -c jakirkham/label/ucx cudatoolkit=<CUDA vers
 
 The ucx recipe can be found here: https://github.com/conda-forge/ucx-split-feedstock/tree/f13e882cc0566e795ff12f2a039f490ce1653698/recipe
 
-# Detailed Build Instructions
+# Build from source
 
 The following instructions assume you'll be using `ucx-py` on a CUDA enabled system. The instructions assume you're using CUDA 9.2 for unspecific reasons. Change the `CUDA_HOME` environment variable, and the environment created and used by `conda` to `cudf_dev_10.0.yml` in order to support CUDA 10.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ version>` with either `9.2` or `10.0`.
 conda create -n ucx -c conda-forge -c jakirkham/label/ucx cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.7
 ```
 
-All of the recipes used can be found here: https://github.com/jakirkham/staged-recipes/tree/ad6f8c51e9b08f34b800b19e9e15dd80cee6f7ea/recipes
+The ucx recipe can be found here: https://github.com/conda-forge/ucx-split-feedstock/tree/f13e882cc0566e795ff12f2a039f490ce1653698/recipe
 
 # Detailed Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # Python Bindings for UCX
 
+# Installing preliminary Conda packages.
+
+Some preliminary Conda packages can be installed as so. Replace `<CUDA
+version>` with either `9.2` or `10.0`.
+
+```
+conda create -n ucx -c conda-forge -c jakirkham/label/ucx cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.7
+```
+
+All of the recipes used can be found here: https://github.com/jakirkham/staged-recipes/tree/ad6f8c51e9b08f34b800b19e9e15dd80cee6f7ea/recipes
+
 # Detailed Build and instructions
 
 The following instructions assume you'll be using `ucx-py` on a CUDA enabled system. The instructions assume you're using CUDA 9.2 for unspecific reasons. Change the `CUDA_HOME` environment variable, and the environment created and used by `conda` to `cudf_dev_10.0.yml` in order to support CUDA 10.
-
-All of the recipes used can be found here: https://github.com/jakirkham/staged-recipes/tree/ad6f8c51e9b08f34b800b19e9e15dd80cee6f7ea/recipes
 
 ## Using Dask, Cudf, and UCX together ##
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python Bindings for UCX
 
-# Installing preliminary Conda packages.
+# Installing preliminary Conda packages
 
 Some preliminary Conda packages can be installed as so. Replace `<CUDA
 version>` with either `9.2` or `10.0`.
@@ -11,7 +11,7 @@ conda create -n ucx -c conda-forge -c jakirkham/label/ucx cudatoolkit=<CUDA vers
 
 All of the recipes used can be found here: https://github.com/jakirkham/staged-recipes/tree/ad6f8c51e9b08f34b800b19e9e15dd80cee6f7ea/recipes
 
-# Detailed Build and instructions
+# Detailed Build Instructions
 
 The following instructions assume you'll be using `ucx-py` on a CUDA enabled system. The instructions assume you're using CUDA 9.2 for unspecific reasons. Change the `CUDA_HOME` environment variable, and the environment created and used by `conda` to `cudf_dev_10.0.yml` in order to support CUDA 10.
 


### PR DESCRIPTION
Appears these conda package install instructions got lost in some recent restructuring of the README. This readds them. Though please recheck to make sure this still keeps everything added from the recent restructuring.