### PR TITLE
Include license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+Copyright (c) 2014-2015      UT-Battelle, LLC. All rights reserved.
+Copyright (C) 2014-2015      Mellanox Technologies Ltd. All rights reserved.
+Copyright (C) 2014-2015      The University of Houston System. All rights reserved.
+Copyright (C) 2015           The University of Tennessee and The University 
+                             of Tennessee Research Foundation. All rights reserved.
+Copyright (C) 2016           ARM Ltd. All rights reserved.
+Copyright (c) 2016           Los Alamos National Security, LLC. All rights reserved.
+Copyright (C) 2016-2017      Advanced Micro Devices, Inc.  All rights reserved.
+Copyright (C) 2019           UChicago Argonne, LLC.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions 
+are met:
+
+1. Redistributions of source code must retain the above copyright 
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its 
+contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,3 @@
-Copyright (c) 2014-2015      UT-Battelle, LLC. All rights reserved.
-Copyright (C) 2014-2015      Mellanox Technologies Ltd. All rights reserved.
-Copyright (C) 2014-2015      The University of Houston System. All rights reserved.
-Copyright (C) 2015           The University of Tennessee and The University 
-                             of Tennessee Research Foundation. All rights reserved.
-Copyright (C) 2016           ARM Ltd. All rights reserved.
-Copyright (c) 2016           Los Alamos National Security, LLC. All rights reserved.
-Copyright (C) 2016-2017      Advanced Micro Devices, Inc.  All rights reserved.
-Copyright (C) 2019           UChicago Argonne, LLC.  All rights reserved.
 Copyright (c) 2019           NVIDIA CORPORATION. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 

--- a/LICENSE
+++ b/LICENSE
@@ -7,6 +7,7 @@ Copyright (C) 2016           ARM Ltd. All rights reserved.
 Copyright (c) 2016           Los Alamos National Security, LLC. All rights reserved.
 Copyright (C) 2016-2017      Advanced Micro Devices, Inc.  All rights reserved.
 Copyright (C) 2019           UChicago Argonne, LLC.  All rights reserved.
+Copyright (c) 2019           NVIDIA CORPORATION. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 
 modification, are permitted provided that the following conditions 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
Copies over the OpenUCX license file and ensures it is included in various Python packages that may be produced.

Fixes https://github.com/rapidsai/ucx-py/issues/123