### PR TITLE
Relax NumPy requirement

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -42,6 +42,7 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
 
     # Get the tags from the client and create a new Endpoint
     cdef uint64_t[4] tags
+    cdef uint64_t[::1] tags_mv = <uint64_t[:4:1]>(&tags[0])
     await stream_recv(ucp_endpoint, tags, sizeof(tags))
     ep = Endpoint(ucp_endpoint, ucp_worker, config, tags[0], tags[1], tags[2], tags[3])
 
@@ -59,6 +60,7 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
 
     # Initiate the shutdown receive
     cdef uint64_t[1] shutdown_msg
+    cdef uint64_t[::1] shutdown_msg_mv = <uint64_t[:1:1]>(&shutdown_msg[0])
     log = "[UCX Comm] %s <=Shutdown== %s" % (hex(ep._recv_tag), hex(ep._send_tag))
     ep.pending_msg_list.append({'log': log})
     shutdown_fut = tag_recv(ucp_worker, shutdown_msg, sizeof(shutdown_msg),
@@ -232,6 +234,7 @@ cdef class ApplicationContext:
         # Create a new Endpoint and send the tags to the peer
         cdef Py_ssize_t i
         cdef uint64_t[4] tags
+        cdef uint64_t[::1] tags_mv = <uint64_t[:4:1]>(&tags[0])
         for i in range(len(tags)):
             tags[i] = hash(uuid.uuid4())
 
@@ -248,6 +251,7 @@ cdef class ApplicationContext:
 
         # Initiate the shutdown receive
         cdef uint64_t[1] shutdown_msg
+        cdef uint64_t[::1] shutdown_msg_mv = <uint64_t[:1:1]>(&shutdown_msg[0])
         log = "[UCX Comm] %s <=Shutdown== %s" % (hex(ret._recv_tag), hex(ret._send_tag))
         ret.pending_msg_list.append({'log': log})
         shutdown_fut = tag_recv(
@@ -324,6 +328,7 @@ class Endpoint:
 
         # Send a shutdown message to the peer
         cdef uint64_t[1] msg
+        cdef uint64_t[::1] msg_mv = <uint64_t[:1:1]>(&msg[0])
         msg[0] = 42
         log = "[UCX Comm] %s ==Shutdown=> %s" % (hex(self._recv_tag),
                                                  hex(self._send_tag))

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -43,12 +43,12 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
     # Get the tags from the client and create a new Endpoint
     cdef uint64_t[4] tags
     cdef uint64_t[::1] tags_mv = <uint64_t[:4:1]>(&tags[0])
-    await stream_recv(ucp_endpoint, tags, sizeof(tags))
-    ep = Endpoint(ucp_endpoint, ucp_worker, config, tags[0], tags[1], tags[2], tags[3])
+    await stream_recv(ucp_endpoint, tags_mv, tags_mv.nbytes)
+    ep = Endpoint(ucp_endpoint, ucp_worker, config, tags_mv[0], tags_mv[1], tags_mv[2], tags_mv[3])
 
     logging.debug("listener_handler() server: %s client: %s "
                   "server-control-tag: %s client-control-tag: %s"
-                  %(hex(tags[1]), hex(tags[0]), hex(tags[3]), hex(tags[2])))
+                  %(hex(tags_mv[1]), hex(tags_mv[0]), hex(tags_mv[3]), hex(tags_mv[2])))
 
     # Call `func` asynchronously (even if it isn't coroutine)
     if asyncio.iscoroutinefunction(func):
@@ -63,7 +63,7 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
     cdef uint64_t[::1] shutdown_msg_mv = <uint64_t[:1:1]>(&shutdown_msg[0])
     log = "[UCX Comm] %s <=Shutdown== %s" % (hex(ep._recv_tag), hex(ep._send_tag))
     ep.pending_msg_list.append({'log': log})
-    shutdown_fut = tag_recv(ucp_worker, shutdown_msg, sizeof(shutdown_msg),
+    shutdown_fut = tag_recv(ucp_worker, shutdown_msg_mv, shutdown_msg_mv.nbytes,
                             ep._ctrl_recv_tag, pending_msg=ep.pending_msg_list[-1])
 
     def _close(future):
@@ -235,19 +235,19 @@ cdef class ApplicationContext:
         cdef Py_ssize_t i
         cdef uint64_t[4] tags
         cdef uint64_t[::1] tags_mv = <uint64_t[:4:1]>(&tags[0])
-        for i in range(len(tags)):
-            tags[i] = hash(uuid.uuid4())
+        for i in range(len(tags_mv)):
+            tags_mv[i] = hash(uuid.uuid4())
 
         ret = Endpoint(
             PyLong_FromVoidPtr(<void*> ucp_ep),
             PyLong_FromVoidPtr(<void*> self.worker),
             self.config,
-            tags[1],
-            tags[0],
-            tags[3],
-            tags[2]
+            tags_mv[1],
+            tags_mv[0],
+            tags_mv[3],
+            tags_mv[2]
         )
-        await stream_send(ret._ucp_endpoint, tags, sizeof(tags))
+        await stream_send(ret._ucp_endpoint, tags_mv, tags_mv.nbytes)
 
         # Initiate the shutdown receive
         cdef uint64_t[1] shutdown_msg
@@ -256,8 +256,8 @@ cdef class ApplicationContext:
         ret.pending_msg_list.append({'log': log})
         shutdown_fut = tag_recv(
             PyLong_FromVoidPtr(<void*>self.worker),
-            shutdown_msg,
-            sizeof(shutdown_msg),
+            shutdown_msg_mv,
+            shutdown_msg_mv.nbytes,
             ret._ctrl_recv_tag,
             pending_msg=ret.pending_msg_list[-1]
         )
@@ -329,14 +329,14 @@ class Endpoint:
         # Send a shutdown message to the peer
         cdef uint64_t[1] msg
         cdef uint64_t[::1] msg_mv = <uint64_t[:1:1]>(&msg[0])
-        msg[0] = 42
+        msg_mv[0] = 42
         log = "[UCX Comm] %s ==Shutdown=> %s" % (hex(self._recv_tag),
                                                  hex(self._send_tag))
         logging.debug(log)
         self.pending_msg_list.append({'log': log})
         await tag_send(
             self._ucp_endpoint,
-            msg, sizeof(msg),
+            msg_mv, msg_mv.nbytes,
             self._ctrl_send_tag,
             pending_msg=self.pending_msg_list[-1]
         )

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -230,18 +230,23 @@ cdef class ApplicationContext:
         assert_ucs_status(status)
 
         # Create a new Endpoint and send the tags to the peer
+        tags = np.array(
+            [
+                np.uint64(hash(uuid.uuid4())),
+                np.uint64(hash(uuid.uuid4())),
+                np.uint64(hash(uuid.uuid4())),
+                np.uint64(hash(uuid.uuid4()))
+            ],
+            dtype="uint64"
+        )
         ret = Endpoint(
             PyLong_FromVoidPtr(<void*> ucp_ep),
             PyLong_FromVoidPtr(<void*> self.worker),
             self.config,
-            np.uint64(hash(uuid.uuid4())),
-            np.uint64(hash(uuid.uuid4())),
-            np.uint64(hash(uuid.uuid4())),
-            np.uint64(hash(uuid.uuid4()))
-        )
-        tags = np.array(
-            [ret._recv_tag, ret._send_tag, ret._ctrl_recv_tag, ret._ctrl_send_tag],
-            dtype="uint64"
+            tags[1],
+            tags[0],
+            tags[3],
+            tags[2]
         )
         await stream_send(ret._ucp_endpoint, tags, tags.nbytes)
 

--- a/ucp/_libs/send_recv.pyx
+++ b/ucp/_libs/send_recv.pyx
@@ -5,7 +5,6 @@
 import asyncio
 import logging
 import uuid
-import numpy as np
 from core_dep cimport *
 from .utils import get_buffer_data
 from ..exceptions import UCXError, UCXCanceled

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -6,7 +6,6 @@ import asyncio
 import uuid
 from functools import reduce
 import operator
-import numpy as np
 from core_dep cimport *
 from ..exceptions import UCXError, UCXCloseError
 
@@ -68,6 +67,7 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         array_interface = buffer.__array_interface__
 
     if array_interface is not None:
+        import numpy as np
         # TODO: check that data is contiguous
         itemsize = int(np.dtype(array_interface['typestr']).itemsize)
         # Making sure that the elements in shape is integers


### PR DESCRIPTION
Relaxes the requirement on NumPy where possible. Leverages fixed size C arrays when it makes sense. Drops an unneeded NumPy import. Also rescopes a NumPy import to the section of code where it is needed.