### PR TITLE
UCX context and worker cleanup

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -174,7 +174,7 @@ cdef class ApplicationContext:
         free(text)
         ucp_config_release(config)
 
-        logging.info("UCP initiated using condig: ")
+        logging.info("UCP initiated using config: ")
         for k, v in self.config.items():
             logging.info("  %s: %s" % (k, v))
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -179,6 +179,11 @@ cdef class ApplicationContext:
             logging.info("  %s: %s" % (k, v))
 
 
+    def __dealloc__(self):
+        ucp_worker_destroy(self.worker)
+        ucp_cleanup(self.context)
+
+
     def create_listener(self, callback_func, port=None):
         self._bind_epoll_fd_to_event_loop()
         if port in (None, 0):

--- a/ucp/_libs/core_dep.pxd
+++ b/ucp/_libs/core_dep.pxd
@@ -77,6 +77,7 @@ cdef extern from "ucp/api/ucp.h":
     int UCP_FEATURE_WAKEUP
     int UCP_FEATURE_STREAM
     ucs_status_t ucp_init(const ucp_params_t *params, const ucp_config_t *config, ucp_context_h *context_p)
+    void ucp_cleanup(ucp_context_h context_p)
 
     ctypedef enum ucs_thread_mode_t:
         pass
@@ -92,6 +93,7 @@ cdef extern from "ucp/api/ucp.h":
 
     int UCP_WORKER_PARAM_FIELD_THREAD_MODE
     ucs_status_t ucp_worker_create(ucp_context_h context, const ucp_worker_params_t *params, ucp_worker_h *worker_p)
+    void ucp_worker_destroy(ucp_worker_h worker)
 
     ctypedef struct ucp_listener_h:
         pass


### PR DESCRIPTION
Now cleaning up UCX context and worker in `ApplicationContext.__dealloc__()`