### PR TITLE
Use struct tags

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -103,8 +103,8 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
         loop.set_exception_handler(asyncio_handle_exception)
 
     # Get the tags from the client and create a new Endpoint
-    cdef Tags[1] tags
-    cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags[0])
+    cdef Tags tags
+    cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags)
     await stream_recv(ucp_endpoint, tags_mv, tags_mv.nbytes)
     ep = Endpoint(ucp_endpoint, ucp_worker, config,
                   tags.recv_tag, tags.send_tag,
@@ -307,8 +307,8 @@ cdef class ApplicationContext:
         assert_ucs_status(status)
 
         # Create a new Endpoint and send the tags to the peer
-        cdef Tags[1] tags
-        cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags[0])
+        cdef Tags tags
+        cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags)
         tags.recv_tag = hash(uuid.uuid4())
         tags.send_tag = hash(uuid.uuid4())
         tags.ctrl_recv_tag = hash(uuid.uuid4())

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -107,13 +107,13 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
     cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags[0])
     await stream_recv(ucp_endpoint, tags_mv, tags_mv.nbytes)
     ep = Endpoint(ucp_endpoint, ucp_worker, config,
-                  tags_mv[0].recv_tag, tags_mv[0].send_tag,
-                  tags_mv[0].ctrl_recv_tag, tags_mv[0].ctrl_send_tag)
+                  tags.recv_tag, tags.send_tag,
+                  tags.ctrl_recv_tag, tags.ctrl_send_tag)
 
     logging.debug("listener_handler() server: %s client: %s "
                   "server-control-tag: %s client-control-tag: %s"
-                  %(hex(tags_mv[0].send_tag), hex(tags_mv[0].recv_tag),
-                    hex(tags_mv[0].ctrl_send_tag), hex(tags_mv[0].ctrl_recv_tag)))
+                  %(hex(tags.send_tag), hex(tags.recv_tag),
+                    hex(tags.ctrl_send_tag), hex(tags.ctrl_recv_tag)))
 
     # Call `func` asynchronously (even if it isn't coroutine)
     if asyncio.iscoroutinefunction(func):
@@ -309,19 +309,19 @@ cdef class ApplicationContext:
         # Create a new Endpoint and send the tags to the peer
         cdef Tags[1] tags
         cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags[0])
-        tags_mv[0].recv_tag = hash(uuid.uuid4())
-        tags_mv[0].send_tag = hash(uuid.uuid4())
-        tags_mv[0].ctrl_recv_tag = hash(uuid.uuid4())
-        tags_mv[0].ctrl_send_tag = hash(uuid.uuid4())
+        tags.recv_tag = hash(uuid.uuid4())
+        tags.send_tag = hash(uuid.uuid4())
+        tags.ctrl_recv_tag = hash(uuid.uuid4())
+        tags.ctrl_send_tag = hash(uuid.uuid4())
 
         ret = Endpoint(
             PyLong_FromVoidPtr(<void*> ucp_ep),
             PyLong_FromVoidPtr(<void*> self.worker),
             self.config,
-            tags_mv[0].send_tag,
-            tags_mv[0].recv_tag,
-            tags_mv[0].ctrl_send_tag,
-            tags_mv[0].ctrl_recv_tag
+            tags.send_tag,
+            tags.recv_tag,
+            tags.ctrl_send_tag,
+            tags.ctrl_recv_tag
         )
         await stream_send(ret._ucp_endpoint, tags_mv, tags_mv.nbytes)
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -106,11 +106,14 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
     cdef uint64_t[4] tags
     cdef uint64_t[::1] tags_mv = <uint64_t[:4:1]>(&tags[0])
     await stream_recv(ucp_endpoint, tags_mv, tags_mv.nbytes)
-    ep = Endpoint(ucp_endpoint, ucp_worker, config, tags_mv[0], tags_mv[1], tags_mv[2], tags_mv[3])
+    ep = Endpoint(ucp_endpoint, ucp_worker, config,
+                  tags_mv[0], tags_mv[1],
+                  tags_mv[2], tags_mv[3])
 
     logging.debug("listener_handler() server: %s client: %s "
                   "server-control-tag: %s client-control-tag: %s"
-                  %(hex(tags_mv[1]), hex(tags_mv[0]), hex(tags_mv[3]), hex(tags_mv[2])))
+                  %(hex(tags_mv[1]), hex(tags_mv[0]),
+                    hex(tags_mv[3]), hex(tags_mv[2])))
 
     # Call `func` asynchronously (even if it isn't coroutine)
     if asyncio.iscoroutinefunction(func):

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -307,12 +307,11 @@ cdef class ApplicationContext:
         assert_ucs_status(status)
 
         # Create a new Endpoint and send the tags to the peer
-        cdef Tags tags
+        cdef Tags tags = {"recv_tag": hash(uuid.uuid4()),
+                          "send_tag": hash(uuid.uuid4()),
+                          "ctrl_recv_tag": hash(uuid.uuid4()),
+                          "ctrl_send_tag": hash(uuid.uuid4())}
         cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags)
-        tags.recv_tag = hash(uuid.uuid4())
-        tags.send_tag = hash(uuid.uuid4())
-        tags.ctrl_recv_tag = hash(uuid.uuid4())
-        tags.ctrl_send_tag = hash(uuid.uuid4())
 
         ret = Endpoint(
             PyLong_FromVoidPtr(<void*> ucp_ep),

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -365,6 +365,13 @@ cdef class ApplicationContext:
         return self.config
 
 
+cdef struct Tags:
+    uint64_t recv_tag
+    uint64_t send_tag
+    uint64_t ctrl_recv_tag
+    uint64_t ctrl_send_tag
+
+
 class Endpoint:
     """An endpoint represents a connection to a peer
 


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ucx-py/issues/210
Fixes https://github.com/rapidsai/ucx-py/issues/223
Merges https://github.com/rapidsai/ucx-py/pull/228
Merges https://github.com/rapidsai/ucx-py/pull/230

Creates a `struct` called `Tags` to hold the different tag values when sending or receiving them. Should make it easier to follow which tag is being used where.