### PR TITLE
UCX Options Programmable 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ extra_compile_args = ["-std=c99"]
 
 import versioneer
 
+
 class build_ext(_build_ext):
     user_options = [
         ("with-cuda", None, "build the Cuda extension"),
@@ -69,22 +70,22 @@ setup(
     cmdclass={"build_ext": build_ext, **versioneer.get_cmdclass()},
     version=versioneer.get_version(),
     python_requires=">=3.6",
-    description='Python Bindings for the Unified Communication X library (UCX)',
-    long_description=open('README.md').read(),
+    description="Python Bindings for the Unified Communication X library (UCX)",
+    long_description=open("README.md").read(),
     author="NVIDIA Corporation",
-    license='BSD-3-Clause',
+    license="BSD-3-Clause",
     classifiers=[
-          'Intended Audience :: Developers',
-          'Intended Audience :: System Administrators',
-          'License :: OSI Approved :: BSD License',
-          'Operating System :: POSIX :: Linux',
-          'Programming Language :: Python',
-          'Topic :: Software Development :: Libraries :: Python Modules',
-          'Topic :: System :: Hardware',
-          'Topic :: System :: Systems Administration',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: System :: Hardware",
+        "Topic :: System :: Systems Administration",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-    url='https://github.com/rapidsai/ucx-py',
+    url="https://github.com/rapidsai/ucx-py",
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,49 @@
 import os
+import pytest
 import ucp
 
 
-def test_config():
+def test_get_config():
     ucp.reset()
     config = ucp.get_config()
     assert isinstance(config, dict)
-    assert config["UCX_MEMTYPE_CACHE"] == "n"
+    assert config["MEMTYPE_CACHE"] == "n"
 
 
-def test_set_config():
+def test_set_env():
     ucp.reset()
     os.environ["UCX_SEG_SIZE"] = "2M"
     config = ucp.get_config()
-    assert config["UCX_SEG_SIZE"] == os.environ["UCX_SEG_SIZE"]
+    assert config["SEG_SIZE"] == os.environ["UCX_SEG_SIZE"]
+
+
+def test_init_options():
+    ucp.reset()
+    os.environ["UCX_SEG_SIZE"] = "2M"  # Should be ignored
+    options = {"SEG_SIZE": "3M"}
+    ucp.init(options)
+    config = ucp.get_config()
+    assert config["SEG_SIZE"] == options["SEG_SIZE"]
+
+
+def test_init_options_and_env():
+    ucp.reset()
+    os.environ["UCX_SEG_SIZE"] = "4M"
+    options = {"SEG_SIZE": "3M"}  # Should be ignored
+    ucp.init(options, env_takes_preceding=True)
+    config = ucp.get_config()
+    assert config["SEG_SIZE"] == options["SEG_SIZE"]
+
+
+def test_init_unknown_option():
+    ucp.reset()
+    options = {"UNKNOWN_OPTION": "3M"}
+    with pytest.raises(ucp.exceptions.UCXConfigError):
+        ucp.init(options)
+
+
+def test_init_invalid_option():
+    ucp.reset()
+    options = {"SEG_SIZE": "invalid-size"}
+    with pytest.raises(ucp.exceptions.UCXConfigError):
+        ucp.init(options)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,7 @@ def test_init_options_and_env():
     ucp.reset()
     os.environ["UCX_SEG_SIZE"] = "4M"
     options = {"SEG_SIZE": "3M"}  # Should be ignored
-    ucp.init(options, env_takes_preceding=True)
+    ucp.init(options, env_takes_precedence=True)
     config = ucp.get_config()
     assert config["SEG_SIZE"] == options["SEG_SIZE"]
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -65,6 +65,17 @@ cdef get_ucx_config_options(ucp_config_t *config):
     return ret
 
 
+def get_config():
+    """
+    Returns the current UCX options
+    if UCX were to be initialized now.
+    """
+    cdef ucp_config_t *config = read_ucx_config({})
+    ret = get_ucx_config_options(config)
+    ucp_config_release(config)
+    return ret
+
+
 cdef struct _listener_callback_args:
     ucp_worker_h ucp_worker
     PyObject *py_config
@@ -155,7 +166,7 @@ cdef class Listener:
 
     def __cinit__(self):
         # In order to prevent calling ucp_listener_destroy() on a
-        # uninitiated Listener, we flag the instance as closed
+        # initialized Listener, we flag the instance as closed
         # initially.
         self._closed = True
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -140,6 +140,7 @@ cdef class ApplicationContext:
         int epoll_fd
         object all_epoll_binded_to_event_loop
         object config
+        bint initiated
 
 
     def __cinit__(self):
@@ -149,6 +150,7 @@ cdef class ApplicationContext:
         cdef ucs_status_t status
         self.all_epoll_binded_to_event_loop = set()
         self.config = {}
+        self.initiated = False
 
         cdef unsigned int a, b, c
         ucp_get_version(&a, &b, &c)
@@ -205,10 +207,13 @@ cdef class ApplicationContext:
         for k, v in self.config.items():
             logging.info("  %s: %s" % (k, v))
 
+        self.initiated = True
+
 
     def __dealloc__(self):
-        ucp_worker_destroy(self.worker)
-        ucp_cleanup(self.context)
+        if self.initiated:
+            ucp_worker_destroy(self.worker)
+            ucp_cleanup(self.context)
 
 
     def create_listener(self, callback_func, port=None):

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -195,6 +195,7 @@ cdef class ApplicationContext:
         cdef bytes py_text = <bytes> text
         for line in py_text.decode().splitlines():
             k, v = line.split("=")
+            k = k[len("UCX_"):]
             self.config[k] = v
         fclose(text_fd)
         free(text)

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -340,8 +340,8 @@ class Endpoint:
         self._recv_count = 0
         self._closed = False
         self.pending_msg_list = [{}]
-        # UCX supports CUDA if "cuda" is part of the UCX_TLS
-        self._cuda_support = "cuda" in config['UCX_TLS']
+        # UCX supports CUDA if "cuda" is part of the TLS
+        self._cuda_support = "cuda" in config['TLS']
 
     @property
     def uid(self):

--- a/ucp/_libs/core_dep.pxd
+++ b/ucp/_libs/core_dep.pxd
@@ -64,6 +64,7 @@ cdef extern from "ucp/api/ucp.h":
     ucs_status_t UCS_OK
     ucs_status_t UCS_ERR_CANCELED
     ucs_status_t UCS_INPROGRESS
+    ucs_status_t UCS_ERR_NO_ELEM
 
     void ucp_get_version(unsigned * major_version, unsigned *minor_version, unsigned *release_number)
 
@@ -167,6 +168,9 @@ cdef extern from "ucp/api/ucp.h":
                           FILE *stream,
                           const char *title,
                           ucs_config_print_flags_t print_flags)
+
+    ucs_status_t ucp_config_modify(ucp_config_t *config, const char *name,
+                                   const char *value)
 
 cdef extern from "sys/epoll.h":
 

--- a/ucp/exceptions.py
+++ b/ucp/exceptions.py
@@ -10,6 +10,10 @@ class UCXError(UCXBaseException):
     pass
 
 
+class UCXConfigError(UCXError):
+    pass
+
+
 class UCXWarning(UserWarning):
     pass
 

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
+import os
 from ._libs import core
 from ._libs.core import Endpoint  # TODO: define a public Endpoint
 
@@ -22,6 +23,33 @@ def _get_ctx():
 # We could programmable extract the function definitions but
 # since the API is small, it might be worth to explicit define
 # the functions here.
+
+
+def init(options={}, env_takes_preceding=False):
+    """
+    Initiate UCX. Usually this is done automatically at the first API call
+    but this function makes it possible to set UCX options programmable.
+    Alternatively, UCX options can be specified through environment variables.
+
+    Parameters
+    ----------
+    options: dict, optional
+        UCX options send to the underlaying UCX library
+    env_takes_preceding: bool, optional
+        Environment variables takes preceding over the `options` specified here.
+    """
+    global _ctx
+    if _ctx is not None:
+        raise RuntimeError(
+            "UCX is already initiated. Call reset() and init() "
+            "in order to re-initate UCX with new options."
+        )
+    if env_takes_preceding:
+        for k in os.environ.keys():
+            if k in options:
+                del options[k]
+
+    _ctx = core.ApplicationContext(options)
 
 
 def create_listener(callback_func, port=None):

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -25,7 +25,7 @@ def _get_ctx():
 # the functions here.
 
 
-def init(options={}, env_takes_preceding=False):
+def init(options={}, env_takes_precedence=False):
     """
     Initiate UCX. Usually this is done automatically at the first API call
     but this function makes it possible to set UCX options programmable.
@@ -35,8 +35,9 @@ def init(options={}, env_takes_preceding=False):
     ----------
     options: dict, optional
         UCX options send to the underlaying UCX library
-    env_takes_preceding: bool, optional
-        Environment variables takes preceding over the `options` specified here.
+    env_takes_precedence: bool, optional
+        Whether environment variables takes precedence over the `options`
+        specified here.
     """
     global _ctx
     if _ctx is not None:
@@ -44,7 +45,7 @@ def init(options={}, env_takes_preceding=False):
             "UCX is already initiated. Call reset() and init() "
             "in order to re-initate UCX with new options."
         )
-    if env_takes_preceding:
+    if env_takes_precedence:
         for k in os.environ.keys():
             if k in options:
                 del options[k]

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -117,8 +117,22 @@ def get_ucp_worker():
 
 
 def get_config():
-    """Returns the configuration as a dict"""
-    return _get_ctx().get_config()
+    """
+    Returns all UCX configuration options as a dict.
+    If UCX is initialized, the options returned are the
+    options used if UCX were to be initialized now.
+    Notice, this function doesn't initialize UCX.
+
+    Returns
+    -------
+    dict
+        The current UCX configuration options
+    """
+
+    if _ctx is None:
+        return core.get_config()
+    else:
+        return _get_ctx().get_config()
 
 
 def reset():

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -117,7 +117,7 @@ def get_ucp_worker():
 
 
 def get_config():
-    """Returns the configuraion as a dict"""
+    """Returns the configuration as a dict"""
     return _get_ctx().get_config()
 
 

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -84,9 +84,9 @@ async def create_endpoint(ip_address, port):
     Parameters
     ----------
     ip_address: str
-        IP address of the server the endpoit should connect to
+        IP address of the server the endpoint should connect to
     port: int
-        IP address of the server the endpoit should connect to
+        IP address of the server the endpoint should connect to
 
     Returns
     -------


### PR DESCRIPTION
Fixes #83.

This makes it possible to specify UCX options programmable using `ucp.init()`:
```python
def init(options={}, env_takes_precedence=False):
    """
    Initiate UCX. Usually this is done automatically at the first API call
    but this function makes it possible to set UCX options programmable.
    Alternatively, UCX options can be specified through environment variables.

    Parameters
    ----------
    options: dict, optional
        UCX options send to the underlaying UCX library
    env_takes_precedence: bool, optional
        Whether environment variables takes precedence over the `options`
        specified here.
    """
```

cc @pentschev, @mrocklin