### PR TITLE
Endpoint.ucx_info(): low-level UCX info

### DIFF
--- a/tests/test_multiple_nodes.py
+++ b/tests/test_multiple_nodes.py
@@ -12,15 +12,18 @@ async def hello(ep):
     await f1
     await f2
     np.testing.assert_array_equal(msg2send, msg2recv)
+    assert isinstance(ep.ucx_info(), str)
 
 
 async def server_node(ep):
     await hello(ep)
+    assert isinstance(ep.ucx_info(), str)
 
 
 async def client_node(port):
     ep = await ucp.create_endpoint(ucp.get_address(), port)
     await hello(ep)
+    assert isinstance(ep.ucx_info(), str)
 
 
 @pytest.mark.asyncio

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -532,11 +532,24 @@ class Endpoint:
             pending_msg=self.pending_msg_list[-1]
         )
 
-    def pprint_ep(self):
-        """Pretty print low-level UCX info about this endpoint"""
+    def ucx_info(self):
+        """Return low-level UCX info about this endpoint as a string"""
         if self._closed:
             raise UCXCloseError("pprint_ep() - Endpoint closed")
-        ucp_ep_print_info(<ucp_ep_h>PyLong_AsVoidPtr(self._ucp_ep), stdout)
+
+        # Calling `ucp_ep_print_info()` into a memstream, convert it to
+        # a Python string, clean up, and return string.
+        cdef char *text
+        cdef size_t text_len
+        cdef FILE *text_fd = open_memstream(&text, &text_len)
+        assert(text_fd != NULL)
+        cdef ucp_ep_h ep = <ucp_ep_h> PyLong_AsVoidPtr(self._ucp_endpoint)
+        ucp_ep_print_info(ep, text_fd)
+        fflush(text_fd)
+        cdef bytes py_text = <bytes> text
+        fclose(text_fd)
+        free(text)
+        return py_text.decode()
 
     def cuda_support(self):
         """Return whether UCX is configured with CUDA support or not"""

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -537,8 +537,8 @@ class Endpoint:
         if self._closed:
             raise UCXCloseError("pprint_ep() - Endpoint closed")
 
-        # Calling `ucp_ep_print_info()` into a memstream, convert it to
-        # a Python string, clean up, and return string.
+        # Making `ucp_ep_print_info()` write into a memstream,
+        # convert it to a Python string, clean up, and return string.
         cdef char *text
         cdef size_t text_len
         cdef FILE *text_fd = open_memstream(&text, &text_len)


### PR DESCRIPTION
Fixes #234 by implementing `Endpoint.ucx_info()`:
```python
def ucx_info(self):
        """Return low-level UCX info about this endpoint as a string"""
```

cc  @cjnolet 