### PR TITLE
Combining communication tags

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -23,7 +23,7 @@ if os.environ.get("UCX_MEMTYPE_CACHE", "") != "n":
 
 # Set the root logger before importing modules that use it
 _level_enum = logging.getLevelName(os.getenv("UCXPY_LOG_LEVEL", "WARNING"))
-logging.basicConfig(level=_level_enum, format="[UCX/%(levelname)s] %(message)s")
+logging.basicConfig(level=_level_enum, format="%(levelname)s %(message)s")
 
 
 __version__ = get_versions()["version"]


### PR DESCRIPTION
This PR combines the communication tags into `msg_tag` and `ctrl_tag`, which fixes a problem when a Endpoint connects to itself: https://github.com/rapidsai/ucx-py/pull/215#discussion_r333047909

Also, the logging now uses the address of the underlying `ucp_ep_h` as the Endpoint ID, which is the same as UCX uses thus making it easier to follow the interplay between UCX and UCX-Py