### PR TITLE
Relax CuPy requirement to 6.2.0

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -55,7 +55,7 @@ conda install -c conda-forge "async_generator" "automake" "libtool" \
 
 
 # install cupy
-conda install -c rapidsai -c nvidia "cupy>=6.3.0"
+conda install -c rapidsai -c nvidia "cupy>=6.2.0"
 
 # install ucx from john's channel
 # conda install -c jakirkham/label/ucx "ucx-proc=*=gpu" "ucx"


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ucx-py/issues/231

Relaxes the CuPy minimum version requirement from 6.3.0 to 6.2.0 based on discussion in this thread ( https://github.com/rapidsai/ucx-py/pull/214#pullrequestreview-299711936 ).