### PR TITLE
Consistent separation of public vs private API 

### DIFF
--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -64,10 +64,10 @@ async def test_listener_close():
     async def server_node(ep):
         msg = np.empty(100, dtype=np.int64)
         await ep.recv(msg)
-        assert listener.closed is False
+        assert listener.closed() is False
         listener.close()
         await ep.recv(msg)
-        assert listener.closed is True
+        assert listener.closed() is True
 
     listener = ucp.create_listener(server_node)
     await client_node(listener.port)
@@ -85,6 +85,6 @@ async def test_listener_del():
     listener = ucp.create_listener(server_node)
     ep = await ucp.create_endpoint(ucp.get_address(), listener.port)
     await ep.send(np.arange(100, dtype=np.int64))
-    assert listener.closed is False
+    assert listener.closed() is False
     del listener
     await ep.send(np.arange(100, dtype=np.int64))

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -106,6 +106,7 @@ def asyncio_handle_exception(loop, context):
 
 
 async def listener_handler(ucp_endpoint, ucp_worker, config, func):
+    from ..public_api import Endpoint
     loop = asyncio.get_event_loop()
     # TODO: exceptions in this callback is never showed when no
     #       get_exception_handler() is set.
@@ -114,23 +115,15 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
     if loop.get_exception_handler() is None:
         loop.set_exception_handler(asyncio_handle_exception)
 
-    # Get the tags from the client and create a new Endpoint
+    # Get the tags from the client and create a new _Endpoint
     cdef Tags tags
     cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags)
     await stream_recv(ucp_endpoint, tags_mv, tags_mv.nbytes)
-    ep = Endpoint(ucp_endpoint, ucp_worker, config, tags.msg_tag, tags.ctrl_tag)
+    ep = _Endpoint(ucp_endpoint, ucp_worker, config, tags.msg_tag, tags.ctrl_tag)
 
     logging.debug("listener_handler() server: %s, msg-tag: %s, ctrl-tag: %s" %(
         hex(<size_t>ucp_endpoint), hex(ep._msg_tag), hex(ep._ctrl_tag))
     )
-
-    # Call `func` asynchronously (even if it isn't coroutine)
-    if asyncio.iscoroutinefunction(func):
-        func_fut = func(ep)
-    else:
-        async def _func(ep):  # coroutine wrapper
-            await func(ep)
-        func_fut = _func(ep)
 
     # Initiate the shutdown receive
     cdef uint64_t shutdown_msg
@@ -142,12 +135,22 @@ async def listener_handler(ucp_endpoint, ucp_worker, config, func):
                             shutdown_msg_mv.nbytes,
                             ep._ctrl_tag,
                             pending_msg=ep.pending_msg_list[-1])
+    ep = Endpoint(ep)
 
     def _close(future):
         logging.debug(log)
         if not ep.closed():
             ep.close()
     shutdown_fut.add_done_callback(_close)
+
+    # Call `func` asynchronously (even if it isn't coroutine)
+    if asyncio.iscoroutinefunction(func):
+        func_fut = func(ep)
+    else:
+        async def _func(ep):  # coroutine wrapper
+            func(ep)
+        func_fut = _func(ep)
+
     await func_fut
 
 
@@ -308,6 +311,7 @@ cdef class ApplicationContext:
         return ret
 
     async def create_endpoint(self, str ip_address, port):
+        from ..public_api import Endpoint
         self._bind_epoll_fd_to_event_loop()
 
         cdef ucp_ep_params_t params
@@ -324,34 +328,35 @@ cdef class ApplicationContext:
                           "ctrl_tag": hash(uuid.uuid4())}
         cdef Tags[::1] tags_mv = <Tags[:1:1]>(&tags)
 
-        ret = Endpoint(
+        ep = _Endpoint(
             PyLong_FromVoidPtr(<void*> ucp_ep),
             PyLong_FromVoidPtr(<void*> self.worker),
             self.config,
             tags.msg_tag,
             tags.ctrl_tag,
         )
-        await stream_send(ret._ucp_endpoint, tags_mv, tags_mv.nbytes)
+        await stream_send(ep._ucp_endpoint, tags_mv, tags_mv.nbytes)
 
         # Initiate the shutdown receive
         cdef uint64_t shutdown_msg
         cdef uint64_t[::1] shutdown_msg_mv = <uint64_t[:1:1]>(&shutdown_msg)
-        log = "[Recv shutdown] ep: %s, tag: %s" % (hex(ret.uid), hex(ret._ctrl_tag))
-        ret.pending_msg_list.append({'log': log})
+        log = "[Recv shutdown] ep: %s, tag: %s" % (hex(ep.uid), hex(ep._ctrl_tag))
+        ep.pending_msg_list.append({'log': log})
         shutdown_fut = tag_recv(
             PyLong_FromVoidPtr(<void*>self.worker),
             shutdown_msg_mv,
             shutdown_msg_mv.nbytes,
-            ret._ctrl_tag,
-            pending_msg=ret.pending_msg_list[-1]
+            ep._ctrl_tag,
+            pending_msg=ep.pending_msg_list[-1]
         )
+        ep = Endpoint(ep)
 
         def _close(future):
             logging.debug(log)
-            if not ret.closed():
-                ret.close()
+            if not ep.closed():
+                ep.close()
         shutdown_fut.add_done_callback(_close)
-        return ret
+        return ep
 
     cdef _progress(self):
         while ucp_worker_progress(self.worker) != 0:
@@ -373,11 +378,11 @@ cdef class ApplicationContext:
         return self.config
 
 
-class Endpoint:
+class _Endpoint:
     """An endpoint represents a connection to a peer
 
     Please use `create_listener()` and `create_endpoint()`
-    to create an Endpoint.
+    to create an _Endpoint.
     """
 
     def __init__(self, ucp_endpoint, ucp_worker, config, msg_tag, ctrl_tag):
@@ -389,7 +394,7 @@ class Endpoint:
         self._send_count = 0
         self._recv_count = 0
         self._closed = False
-        self.pending_msg_list = [{}]
+        self.pending_msg_list = []
         # UCX supports CUDA if "cuda" is part of the TLS
         self._cuda_support = "cuda" in config['TLS']
 
@@ -405,7 +410,7 @@ class Endpoint:
         To do that, use `.close()` or del the object.
         """
         if self._closed:
-            raise UCXCloseError("signal_shutdown() - Endpoint closed")
+            raise UCXCloseError("signal_shutdown() - _Endpoint closed")
 
         # Send a shutdown message to the peer
         cdef uint64_t msg = 42
@@ -431,9 +436,9 @@ class Endpoint:
         To do that, use `.signal_shutdown()` or del the object.
         """
         if self._closed:
-            raise UCXCloseError("close() - Endpoint closed")
+            raise UCXCloseError("close() - _Endpoint closed")
         self._closed = True
-        logging.debug("Endpoint.close(): %s" % hex(self.uid))
+        logging.debug("_Endpoint.close(): %s" % hex(self.uid))
 
         cdef ucp_worker_h worker = <ucp_worker_h> PyLong_AsVoidPtr(self._ucp_worker)  # noqa
 
@@ -475,7 +480,7 @@ class Endpoint:
             Number of bytes to send. Default is the whole buffer.
         """
         if self._closed:
-            raise UCXCloseError("send() - Endpoint closed")
+            raise UCXCloseError("send() - _Endpoint closed")
         nbytes = get_buffer_nbytes(buffer, check_min_size=nbytes,
                                    cuda_support=self._cuda_support)
         log = "[Send #%03d] ep: %s, tag: %s, nbytes: %d" % (
@@ -504,7 +509,7 @@ class Endpoint:
             Number of bytes to receive. Default is the whole buffer.
         """
         if self._closed:
-            raise UCXCloseError("recv() - Endpoint closed")
+            raise UCXCloseError("recv() - _Endpoint closed")
         nbytes = get_buffer_nbytes(buffer, check_min_size=nbytes,
                                    cuda_support=self._cuda_support)
         log = "[Recv #%03d] ep: %s, tag: %s, nbytes: %d" % (
@@ -524,7 +529,7 @@ class Endpoint:
     def ucx_info(self):
         """Return low-level UCX info about this endpoint as a string"""
         if self._closed:
-            raise UCXCloseError("pprint_ep() - Endpoint closed")
+            raise UCXCloseError("pprint_ep() - _Endpoint closed")
 
         # Making `ucp_ep_print_info()` write into a memstream,
         # convert it to a Python string, clean up, and return string.

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -88,6 +88,12 @@ cdef struct _listener_callback_args:
     PyObject *py_func
 
 
+# The tags used when send/recv messages
+cdef struct Tags:
+    uint64_t msg_tag
+    uint64_t ctrl_tag
+
+
 def asyncio_handle_exception(loop, context):
     msg = context.get("exception", context["message"])
     if isinstance(msg, UCXCanceled):
@@ -365,12 +371,6 @@ cdef class ApplicationContext:
 
     def get_config(self):
         return self.config
-
-
-# The tags used when send/recv messages
-cdef struct Tags:
-    uint64_t msg_tag
-    uint64_t ctrl_tag
 
 
 class Endpoint:

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -498,3 +498,9 @@ class _Endpoint:
 
     def cuda_support(self):
         return self._cuda_support
+
+    def get_ucp_worker(self):
+        return self._ucp_worker
+
+    def get_ucp_endpoint(self):
+        return self._ucp_endpoint

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -379,10 +379,9 @@ cdef class ApplicationContext:
 
 
 class _Endpoint:
-    """An endpoint represents a connection to a peer
+    """This represents the private part of a Endpoint
 
-    Please use `create_listener()` and `create_endpoint()`
-    to create an _Endpoint.
+    See <..public_api.Endpoint> for documentation
     """
 
     def __init__(self, ucp_endpoint, ucp_worker, config, msg_tag, ctrl_tag):
@@ -400,15 +399,9 @@ class _Endpoint:
 
     @property
     def uid(self):
-        """The unique ID of the endpoint"""
         return self._ucp_endpoint
 
     async def signal_shutdown(self):
-        """Signal the connected peer to shutdown.
-
-        Notice, this functions doesn't close the endpoint.
-        To do that, use `.close()` or del the object.
-        """
         if self._closed:
             raise UCXCloseError("signal_shutdown() - _Endpoint closed")
 
@@ -426,15 +419,9 @@ class _Endpoint:
         )
 
     def closed(self):
-        """Is this endpoint closed?"""
         return self._closed
 
     def close(self):
-        """Close this endpoint.
-
-        Notice, this functions doesn't signal the connected peer to shutdown
-        To do that, use `.signal_shutdown()` or del the object.
-        """
         if self._closed:
             raise UCXCloseError("close() - _Endpoint closed")
         self._closed = True
@@ -469,16 +456,6 @@ class _Endpoint:
             self.close()
 
     async def send(self, buffer, nbytes=None):
-        """Send `buffer` to connected peer.
-
-        Parameters
-        ----------
-        buffer: exposing the buffer protocol or array/cuda interface
-            The buffer to send. Raise ValueError if buffer is smaller
-            than nbytes.
-        nbytes: int, optional
-            Number of bytes to send. Default is the whole buffer.
-        """
         if self._closed:
             raise UCXCloseError("send() - _Endpoint closed")
         nbytes = get_buffer_nbytes(buffer, check_min_size=nbytes,
@@ -498,16 +475,6 @@ class _Endpoint:
         )
 
     async def recv(self, buffer, nbytes=None):
-        """Receive from connected peer into `buffer`.
-
-        Parameters
-        ----------
-        buffer: exposing the buffer protocol or array/cuda interface
-            The buffer to receive into. Raise ValueError if buffer
-            is smaller than nbytes or read-only.
-        nbytes: int, optional
-            Number of bytes to receive. Default is the whole buffer.
-        """
         if self._closed:
             raise UCXCloseError("recv() - _Endpoint closed")
         nbytes = get_buffer_nbytes(buffer, check_min_size=nbytes,
@@ -527,7 +494,6 @@ class _Endpoint:
         )
 
     def ucx_info(self):
-        """Return low-level UCX info about this endpoint as a string"""
         if self._closed:
             raise UCXCloseError("pprint_ep() - _Endpoint closed")
 
@@ -546,5 +512,4 @@ class _Endpoint:
         return py_text.decode()
 
     def cuda_support(self):
-        """Return whether UCX is configured with CUDA support or not"""
         return self._cuda_support

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -4,7 +4,6 @@
 import os
 
 from ._libs import core
-from ._libs.core import Endpoint  # noqa TODO: define a public Endpoint
 
 # The module should only instantiate one instance of the application context
 # However, the init of CUDA must happen after all process forks thus we delay
@@ -26,8 +25,9 @@ def _get_ctx():
 
 
 def init(options={}, env_takes_precedence=False):
-    """
-    Initiate UCX. Usually this is done automatically at the first API call
+    """Initiate UCX.
+
+    Usually this is done automatically at the first API call
     but this function makes it possible to set UCX options programmable.
     Alternatively, UCX options can be specified through environment variables.
 
@@ -54,8 +54,7 @@ def init(options={}, env_takes_precedence=False):
 
 
 def create_listener(callback_func, port=None):
-    """
-    Create and start a listener to accept incoming connections
+    """Create and start a listener to accept incoming connections
 
     NB: the listening is continued until the returned Listener
         object goes out of scope thus remember to keep a reference
@@ -78,8 +77,7 @@ def create_listener(callback_func, port=None):
 
 
 async def create_endpoint(ip_address, port):
-    """
-    Create a new endpoint to a server specified by `ip_address` and `port`
+    """Create a new endpoint to a server
 
     Parameters
     ----------
@@ -90,15 +88,14 @@ async def create_endpoint(ip_address, port):
 
     Returns
     -------
-    Endpoint
+    _Endpoint
         The new endpoint
     """
     return await _get_ctx().create_endpoint(ip_address, port)
 
 
 def progress():
-    """
-    Try to progress the communication layer
+    """Try to progress the communication layer
 
     Returns
     -------
@@ -109,16 +106,15 @@ def progress():
 
 
 def get_ucp_worker():
-    """
-    Returns the underlying UCP worker handle (ucp_worker_h)
+    """Returns the underlying UCP worker handle (ucp_worker_h)
     as a Python integer.
     """
     return _get_ctx().get_ucp_worker()
 
 
 def get_config():
-    """
-    Returns all UCX configuration options as a dict.
+    """Returns all UCX configuration options as a dict.
+
     If UCX is initialized, the options returned are the
     options used if UCX were to be initialized now.
     Notice, this function doesn't initialize UCX.
@@ -136,9 +132,83 @@ def get_config():
 
 
 def reset():
-    """
-    Resets the UCX library by shutting down all of UCX.
+    """Resets the UCX library by shutting down all of UCX.
+
     The library is initiated at next API call.
     """
     global _ctx
     _ctx = None
+
+
+class Endpoint:
+    """An endpoint represents a connection to a peer
+
+    Please use `create_listener()` and `create_endpoint()`
+    to create an _Endpoint.
+    """
+
+    def __init__(self, ep):
+        self._ep = ep
+
+    def __del__(self):
+        if not self.closed():
+            self.close()
+
+    @property
+    def uid(self):
+        """The unique ID of the underlying UCX endpoint"""
+        return self._ep.uid
+
+    async def signal_shutdown(self):
+        """Signal the connected peer to shutdown.
+
+        Notice, this functions doesn't close the endpoint.
+        To do that, use `Endpoint.close()` or del the object.
+        """
+        await self._ep.signal_shutdown()
+
+    def closed(self):
+        """Is this endpoint closed?"""
+        return self._ep._closed
+
+    def close(self):
+        """Close this endpoint.
+
+        Notice, this functions doesn't signal the connected peer to shutdown
+        To do that, use `Endpoint.signal_shutdown()`
+        """
+        return self._ep.close()
+
+    async def send(self, buffer, nbytes=None):
+        """Send `buffer` to connected peer.
+
+        Parameters
+        ----------
+        buffer: exposing the buffer protocol or array/cuda interface
+            The buffer to send. Raise ValueError if buffer is smaller
+            than nbytes.
+        nbytes: int, optional
+            Number of bytes to send. Default is the whole buffer.
+        """
+        await self._ep.send(buffer, nbytes=nbytes)
+
+    async def recv(self, buffer, nbytes=None):
+        """Receive from connected peer into `buffer`.
+
+        Parameters
+        ----------
+        buffer: exposing the buffer protocol or array/cuda interface
+            The buffer to receive into. Raise ValueError if buffer
+            is smaller than nbytes or read-only.
+        nbytes: int, optional
+            Number of bytes to receive. Default is the whole buffer.
+        """
+        await self._ep.recv(buffer, nbytes=nbytes)
+
+    def ucx_info(self):
+        """Return low-level UCX info about this endpoint as a string"""
+        return self._ep.ucx_info()
+
+    def cuda_support(self):
+        """Return whether UCX is configured with CUDA support or not"""
+        return self._ep._cuda_support

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -243,3 +243,15 @@ class Endpoint:
     def cuda_support(self):
         """Return whether UCX is configured with CUDA support or not"""
         return self._ep._cuda_support
+
+    def get_ucp_worker(self):
+        """Returns the underlying UCP worker handle (ucp_worker_h)
+        as a Python integer.
+        """
+        return self._ucp_worker
+
+    def get_ucp_endpoint(self):
+        """Returns the underlying UCP endpoint handle (ucp_ep_h)
+        as a Python integer.
+        """
+        return self._ucp_endpoint

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -140,11 +140,42 @@ def reset():
     _ctx = None
 
 
+class Listener:
+    """A handle to the listening service started by `create_listener()`
+
+    The listening continues as long as this object exist or `.close()` is called.
+    Please use `create_listener()` to create an Listener.
+    """
+
+    def __init__(self, backend):
+        self._b = backend
+        self._closed = False
+
+    def __del__(self):
+        if not self.closed():
+            self.close()
+
+    def closed(self):
+        """Is the listener closed?"""
+        return self._closed
+
+    @property
+    def port(self):
+        """The network point listening on"""
+        return self._b.port()
+
+    def close(self):
+        """Closing the listener"""
+        if not self._closed:
+            self._b.destroy()
+            self._closed = True
+
+
 class Endpoint:
     """An endpoint represents a connection to a peer
 
     Please use `create_listener()` and `create_endpoint()`
-    to create an _Endpoint.
+    to create an Endpoint.
     """
 
     def __init__(self, ep):


### PR DESCRIPTION
This PR fixes https://github.com/rapidsai/ucx-py/issues/235 and fixes #219 by moving `Endpoint` and `Listener` to `public_api.py`