### PR TITLE
Drop the now irrelevant `--with-prof` flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,22 +19,16 @@ extra_compile_args = ["-std=c99"]
 
 class build_ext(_build_ext):
     user_options = [
-        ("with-cuda", None, "build the Cuda extension"),
-        ("with-prof", None, "build with profiling"),
+        ("with-cuda", None, "build the Cuda extension")
     ] + _build_ext.user_options
 
     with_cuda = strtobool(os.environ.get("UCX_PY_WITH_CUDA", "0"))
-
-    with_prof = strtobool(os.environ.get("UCX_PY_WITH_PROF", "0"))
 
     def run(self):
         if self.with_cuda:
             module = ext_modules[0]
             module.libraries.extend(["cuda", "cudart"])
             module.extra_compile_args.append("-DUCX_PY_CUDA")
-        if self.with_prof:
-            module = ext_modules[0]
-            module.extra_compile_args.append("-DUCX_PY_PROF")
         _build_ext.run(self)
 
 


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ucx-py/issues/258

This flag no longer has any effect on the compilation process of ucx-py after the rewrite. So go ahead and drop this flag.