### PR TITLE
Drop the now irrelevant `--with-cuda` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,10 @@ CFLAGS  = "-I$(UCX_PATH)/include -I$(CUDA_PATH)/include"
 LDFLAGS = "-L$(UCX_PATH)/lib -L$(CUDA_PATH)/lib64"
 
 install:
-	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) $(PYTHON) setup.py build_ext -i --with-cuda
-	$(PYTHON) -m pip install -e .
-
-install-cpu:
 	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) $(PYTHON) setup.py build_ext -i
 	$(PYTHON) -m pip install -e .
 
 conda-install:
-	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) $(PYTHON) setup.py build_ext -i --with-cuda install
-
-conda-install-cpu:
 	LDFLAGS=$(LDFLAGS) CFLAGS=$(CFLAGS) $(PYTHON) setup.py build_ext -i install
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,19 +19,12 @@ extra_compile_args = ["-std=c99"]
 
 class build_ext(_build_ext):
     user_options = [
-        ("with-cuda", None, "build the Cuda extension"),
-        ("with-prof", None, "build with profiling"),
+        ("with-prof", None, "build with profiling")
     ] + _build_ext.user_options
-
-    with_cuda = strtobool(os.environ.get("UCX_PY_WITH_CUDA", "0"))
 
     with_prof = strtobool(os.environ.get("UCX_PY_WITH_PROF", "0"))
 
     def run(self):
-        if self.with_cuda:
-            module = ext_modules[0]
-            module.libraries.extend(["cuda", "cudart"])
-            module.extra_compile_args.append("-DUCX_PY_CUDA")
         if self.with_prof:
             module = ext_modules[0]
             module.extra_compile_args.append("-DUCX_PY_PROF")


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ucx-py/issues/259

This flag no longer has any effect on the compilation process of ucx-py after the rewrite. So go ahead and drop this flag.