### PR TITLE
Drops outdated build flags from `build_ext`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,23 +5,12 @@
 
 from __future__ import absolute_import, print_function
 
-import os
-from distutils.util import strtobool
-
 import versioneer
 from setuptools import setup
-from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.extension import Extension
 
 libraries = ["ucp", "uct", "ucm", "ucs"]
 extra_compile_args = ["-std=c99"]
-
-
-class build_ext(_build_ext):
-    user_options = [] + _build_ext.user_options
-
-    def run(self):
-        _build_ext.run(self)
 
 
 ext_modules = [
@@ -52,7 +41,7 @@ setup(
     name="ucp",
     packages=["ucp"],
     ext_modules=ext_modules,
-    cmdclass={"build_ext": build_ext, **versioneer.get_cmdclass()},
+    cmdclass=versioneer.get_cmdclass(),
     version=versioneer.get_version(),
     python_requires=">=3.6",
     description="Python Bindings for the Unified Communication X library (UCX)",


### PR DESCRIPTION
Merges https://github.com/rapidsai/ucx-py/pull/260
Merges https://github.com/rapidsai/ucx-py/pull/261
Fixes https://github.com/rapidsai/ucx-py/issues/258
Fixes https://github.com/rapidsai/ucx-py/issues/259

Consolidates the changes to remove `--with-prof` and `--with-cuda` flags from the custom `build_ext`. Also goes ahead and removes the custom `build_ext` class entirely. After all it doesn't appear to have a use after removing both of these.