### PR TITLE
Python getters to the underlying UCP objects

### DIFF
--- a/tests/test_ucx_getters.py
+++ b/tests/test_ucx_getters.py
@@ -1,0 +1,29 @@
+import pytest
+import ucp
+
+
+@pytest.mark.asyncio
+async def test_get_ucp_worker():
+    worker = ucp.get_ucp_worker()
+    assert isinstance(worker, int)
+
+    def server(ep):
+        assert ep.get_ucp_worker() == worker
+
+    lt = ucp.create_listener(server)
+    ep = await ucp.create_endpoint(ucp.get_address(), lt.port)
+    assert ep.get_ucp_worker() == worker
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint():
+    def server(ep):
+        ucp_ep = ep.get_ucp_endpoint()
+        assert isinstance(ucp_ep, int)
+        assert ucp_ep > 0
+
+    lt = ucp.create_listener(server)
+    ep = await ucp.create_endpoint(ucp.get_address(), lt.port)
+    ucp_ep = ep.get_ucp_endpoint()
+    assert isinstance(ucp_ep, int)
+    assert ucp_ep > 0

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -248,10 +248,10 @@ class Endpoint:
         """Returns the underlying UCP worker handle (ucp_worker_h)
         as a Python integer.
         """
-        return self._ucp_worker
+        return self._ep.get_ucp_worker()
 
     def get_ucp_endpoint(self):
         """Returns the underlying UCP endpoint handle (ucp_ep_h)
         as a Python integer.
         """
-        return self._ucp_endpoint
+        return self._ep.get_ucp_endpoint()


### PR DESCRIPTION
Fix #117 and fix #130, including tests