### PR TITLE
Get UCX version

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,18 @@
+import ucp
+
+
+def test_get_ucx_version():
+    ucp.reset()
+    version = ucp.get_ucx_version()
+    assert isinstance(version, tuple)
+    assert len(version) == 3
+    # Check UCX isn't initizated
+    assert ucp.public_api._ctx is None
+
+
+def test_version_constant():
+    assert isinstance(ucp.__version__, str)
+
+
+def test_ucx_version_constant():
+    assert isinstance(ucp.__ucx_version__, str)

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -7,7 +7,7 @@ import logging
 import os
 import warnings
 
-from ._version import get_versions
+from ._version import get_versions as _get_versions
 from .exceptions import UCXWarning
 from .public_api import *  # noqa
 from .utils import get_address  # noqa
@@ -26,5 +26,5 @@ _level_enum = logging.getLevelName(os.getenv("UCXPY_LOG_LEVEL", "WARNING"))
 logging.basicConfig(level=_level_enum, format="%(levelname)s %(message)s")
 
 
-__version__ = get_versions()["version"]
-del get_versions
+__version__ = _get_versions()["version"]
+__ucx_version__ = "%d.%d.%d" % get_ucx_version()

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -9,6 +9,7 @@ import warnings
 
 from ._version import get_versions as _get_versions
 from .exceptions import UCXWarning
+from .public_api import get_ucx_version
 from .public_api import *  # noqa
 from .utils import get_address  # noqa
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -82,6 +82,12 @@ def get_config():
     return ret
 
 
+def get_ucx_version():
+    cdef unsigned int a, b, c
+    ucp_get_version(&a, &b, &c)
+    return (a, b, c)
+
+
 cdef struct _listener_callback_args:
     ucp_worker_h ucp_worker
     PyObject *py_config
@@ -247,9 +253,7 @@ cdef class ApplicationContext:
         self.config = {}
         self.initiated = False
 
-        cdef unsigned int a, b, c
-        ucp_get_version(&a, &b, &c)
-        self.config['VERSION'] = (a, b, c)
+        self.config['VERSION'] = get_ucx_version()
 
         memset(&ucp_params, 0, sizeof(ucp_params))
         ucp_params.field_mask = (UCP_PARAM_FIELD_FEATURES |  # noqa

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -24,6 +24,19 @@ def _get_ctx():
 # the functions here.
 
 
+def get_ucx_version():
+    """Return the version of the underlaying UCX installation
+
+    Notice, this function doesn't initialize UCX.
+
+    Returns
+    -------
+    tuple
+        The version as a tuple e.g. (1, 7, 0)
+    """
+    return core.get_ucx_version()
+
+
 def init(options={}, env_takes_precedence=False):
     """Initiate UCX.
 

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -25,7 +25,7 @@ def _get_ctx():
 
 
 def get_ucx_version():
-    """Return the version of the underlaying UCX installation
+    """Return the version of the underlying UCX installation
 
     Notice, this function doesn't initialize UCX.
 
@@ -47,7 +47,7 @@ def init(options={}, env_takes_precedence=False):
     Parameters
     ----------
     options: dict, optional
-        UCX options send to the underlaying UCX library
+        UCX options send to the underlying UCX library
     env_takes_precedence: bool, optional
         Whether environment variables takes precedence over the `options`
         specified here.


### PR DESCRIPTION
This PR implements  `ucp.get_ucx_version()` and `ucp.__ucx_version__`.