### PR TITLE
Fixing UCX leaks and safe UCX shutdown

### DIFF
--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -1,0 +1,65 @@
+import pytest
+import ucp
+
+
+class ResetAfterN:
+    """Calls ucp.reset() after n calls"""
+
+    def __init__(self, n):
+        self.n = n
+        self.count = 0
+
+    def __call__(self):
+        self.count += 1
+        if self.count == self.n:
+            ucp.reset()
+
+
+@pytest.mark.asyncio
+async def test_reset():
+    reset = ResetAfterN(2)
+
+    def server(ep):
+        ep.close()
+        reset()
+
+    lt = ucp.create_listener(server)
+    ep = await ucp.create_endpoint(ucp.get_address(), lt.port)
+    del lt
+    del ep
+    reset()
+
+
+@pytest.mark.asyncio
+async def test_lt_still_in_scope_error():
+    reset = ResetAfterN(2)
+
+    def server(ep):
+        ep.close()
+        reset()
+
+    lt = ucp.create_listener(server)
+    ep = await ucp.create_endpoint(ucp.get_address(), lt.port)
+    del ep
+    with pytest.raises(ucp.exceptions.UCXError, match="ucp._libs.core._Listener"):
+        ucp.reset()
+
+    lt.close()
+    ucp.reset()
+
+
+@pytest.mark.asyncio
+async def test_ep_still_in_scope_error():
+    reset = ResetAfterN(2)
+
+    def server(ep):
+        ep.close()
+        reset()
+
+    lt = ucp.create_listener(server)
+    ep = await ucp.create_endpoint(ucp.get_address(), lt.port)
+    del lt
+    with pytest.raises(ucp.exceptions.UCXError, match="_ucp_endpoint"):
+        ucp.reset()
+    ep.close()
+    ucp.reset()

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -88,5 +88,3 @@ async def test_listener_del():
     assert listener.closed() is False
     del listener
     await ep.recv(msg)
-    ucp.reset()
-

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -88,3 +88,5 @@ async def test_listener_del():
     assert listener.closed() is False
     del listener
     await ep.recv(msg)
+    ucp.reset()
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,7 +6,7 @@ def test_get_ucx_version():
     version = ucp.get_ucx_version()
     assert isinstance(version, tuple)
     assert len(version) == 3
-    # Check UCX isn't initizated
+    # Check UCX isn't initialized
     assert ucp.public_api._ctx is None
 
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -303,6 +303,7 @@ cdef class ApplicationContext:
         assert_ucs_status(status)
 
         self.epoll_fd = epoll_create(1)
+        assert(self.epoll_fd != -1)
         cdef epoll_event ev
         ev.data.fd = ucp_epoll_fd
         ev.events = EPOLLIN
@@ -323,6 +324,7 @@ cdef class ApplicationContext:
         if self.initiated:
             ucp_worker_destroy(self.worker)
             ucp_cleanup(self.context)
+            close(self.epoll_fd)
 
     def create_listener(self, callback_func, port=None):
         from ..public_api import Listener

--- a/ucp/_libs/core_dep.pxd
+++ b/ucp/_libs/core_dep.pxd
@@ -7,6 +7,7 @@ from libc.stdint cimport *
 from libc.stdlib cimport malloc, free
 from libc.stdio cimport FILE, stdin, stdout, stderr, printf, fflush, fclose
 from posix.stdio cimport open_memstream
+from posix.unistd cimport close
 from cpython.long cimport PyLong_AsVoidPtr, PyLong_FromVoidPtr
 from cpython.ref cimport PyObject, Py_INCREF, Py_DECREF
 

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -182,6 +182,7 @@ class Listener:
         if not self._closed:
             self._b.destroy()
             self._closed = True
+            self._b = None
 
 
 class Endpoint:

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
-import os
 import gc
+import os
 import weakref
 
-from ._libs import core
 from . import exceptions
+from ._libs import core
 
 # The module should only instantiate one instance of the application context
 # However, the init of CUDA must happen after all process forks thus we delay


### PR DESCRIPTION
This PR fixes many resource leaks and makes `ucp.reset()` raise an exception if the `ApplicationContext` is still referenced by `Endpoint` and `Listener` objects. If that is the case, we cannot safely shutdown UCX.