### PR TITLE
Guarantee Message Order

### DIFF
--- a/tests/test_guarantee_msg_order.py
+++ b/tests/test_guarantee_msg_order.py
@@ -1,0 +1,20 @@
+import pytest
+import ucp
+
+
+@pytest.mark.asyncio
+async def test_mismatch():
+    def server(ep):
+        pass
+
+    lt = ucp.create_listener(server, guarantee_msg_order=True)
+    with pytest.raises(
+        ValueError, match="Both peers must set guarantee_msg_order identically"
+    ):
+        await ucp.create_endpoint(ucp.get_address(), lt.port, guarantee_msg_order=False)
+
+    lt = ucp.create_listener(server, guarantee_msg_order=False)
+    with pytest.raises(
+        ValueError, match="Both peers must set guarantee_msg_order identically"
+    ):
+        await ucp.create_endpoint(ucp.get_address(), lt.port, guarantee_msg_order=True)

--- a/ucp/_libs/send_recv.pyx
+++ b/ucp/_libs/send_recv.pyx
@@ -11,7 +11,7 @@ from ..exceptions import UCXError, UCXCanceled
 
 
 cdef create_future_from_comm_status(ucs_status_ptr_t status,
-                                    size_t expected_receive,
+                                    int64_t expected_receive,
                                     pending_msg):
     if pending_msg is not None:
         log_str = pending_msg.get('log', None)

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -89,7 +89,6 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
             raise NotImplementedError("mask attribute not supported")
     else:
         mview = memoryview(buffer)
-        data = _data_from_memoryview(mview)
         nbytes = mview.nbytes
         if not mview.contiguous:
             raise ValueError("buffer must be contiguous")

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -69,7 +69,7 @@ def init(options={}, env_takes_precedence=False):
     _ctx = core.ApplicationContext(options)
 
 
-def create_listener(callback_func, port=None):
+def create_listener(callback_func, port=None, guarantee_msg_order=True):
     """Create and start a listener to accept incoming connections
 
     callback_func is the function or coroutine that takes one
@@ -94,10 +94,10 @@ def create_listener(callback_func, port=None):
     Listener
         The new listener. When this object is deleted, the listening stops
     """
-    return _get_ctx().create_listener(callback_func, port)
+    return _get_ctx().create_listener(callback_func, port, guarantee_msg_order)
 
 
-async def create_endpoint(ip_address, port):
+async def create_endpoint(ip_address, port, guarantee_msg_order=True):
     """Create a new endpoint to a server
 
     Parameters
@@ -112,7 +112,7 @@ async def create_endpoint(ip_address, port):
     _Endpoint
         The new endpoint
     """
-    return await _get_ctx().create_endpoint(ip_address, port)
+    return await _get_ctx().create_endpoint(ip_address, port, guarantee_msg_order)
 
 
 def progress():

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -84,10 +84,13 @@ def create_listener(callback_func, port=None, guarantee_msg_order=True):
     Parameters
     ----------
     callback_func: function or coroutine
-        a callback function that gets invoked when an incoming
+        A callback function that gets invoked when an incoming
         connection is accepted
     port: int, optional
-        an unused port number for listening
+        An unused port number for listening
+    guarantee_msg_order: boolean, optional
+        Whether to guarantee message order or not. Remember, both peers
+        of the endpoint must set guarantee_msg_order to the same value.
 
     Returns
     -------
@@ -106,7 +109,9 @@ async def create_endpoint(ip_address, port, guarantee_msg_order=True):
         IP address of the server the endpoint should connect to
     port: int
         IP address of the server the endpoint should connect to
-
+    guarantee_msg_order: boolean, optional
+        Whether to guarantee message order or not. Remember, both peers
+        of the endpoint must set guarantee_msg_order to the same value.
     Returns
     -------
     _Endpoint


### PR DESCRIPTION
This PR implements a `guarantee_msg_order` argument when creating Endpoints, which UCX tag messaging [doesn't guarantees](https://github.com/dask/distributed/pull/3135#issuecomment-545480041).



