### PR TITLE
Add ReadTheDocs badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![https://ucx-py.readthedocs.io/en/latest/](https://readthedocs.org/projects/ucx-py/badge/ "ReadTheDocs")]( https://ucx-py.readthedocs.io/en/latest/ )
+
 # Python Bindings for UCX
 
 ## Installing preliminary Conda packages


### PR DESCRIPTION
Makes sure we have an easy way to link people to the ReadTheDocs documentation page for ucx-py. Also makes the build status of ReadTheDocs more visible.