### PR TITLE
Flushing before shutdown

### DIFF
--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -126,5 +126,21 @@ async def test_close_after_n_recv():
             await ep.recv(msg)
         assert ep.closed()
 
+        ep = await ucp.create_endpoint(ucp.get_address(), port)
+        for _ in range(10):
+            msg = np.empty(10)
+            await ep.recv(msg)
+
+        with pytest.raises(
+            ucp.exceptions.UCXError, match="`n` cannot be less than current recv_count"
+        ):
+            ep.close_after_n_recv(5, count_from_ep_creation=True)
+
+        ep.close_after_n_recv(1)
+        with pytest.raises(
+            ucp.exceptions.UCXError, match="close_after_n_recv has already been set to"
+        ):
+            ep.close_after_n_recv(1)
+
     listener = ucp.create_listener(server_node)
     await client_node(listener.port)

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -546,8 +546,9 @@ class _Endpoint:
         self._ctrl_tag_send = ctrl_tag_send
         self._ctrl_tag_recv = ctrl_tag_recv
         self._guarantee_msg_order = guarantee_msg_order
-        self._send_count = 0
-        self._recv_count = 0
+        self._send_count = 0  # Number of calls to self.send()
+        self._recv_count = 0  # Number of calls to self.recv()
+        self._finished_recv_count = 0 # Number of returned (finished) self.recv() calls
         self._closed = False
         self.pending_msg_list = []
         # UCX supports CUDA if "cuda" is part of the TLS or TLS is "all"
@@ -657,8 +658,9 @@ class _Endpoint:
             tag,
             pending_msg=self.pending_msg_list[-1]
         )
+        self._finished_recv_count += 1
         if self._close_after_n_recv is not None \
-                and self._recv_count >= self._close_after_n_recv:
+                and self._finished_recv_count >= self._close_after_n_recv:
             self.close()
         return ret
 

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -314,18 +314,18 @@ class Endpoint:
             from the creation of the endpoint.
         """
         if not count_from_ep_creation:
-            n += self._ep._recv_count  # Make `n` absolute
+            n += self._ep._finished_recv_count  # Make `n` absolute
         if self._ep._close_after_n_recv is not None:
             raise exceptions.UCXError(
                 "close_after_n_recv() is already set to: %d (abs)"
                 % self._ep._close_after_n_recv
             )
-        if n == self._ep._recv_count:
+        if n == self._ep._finished_recv_count:
             self._ep.close()
-        elif n > self._ep._recv_count:
+        elif n > self._ep._finished_recv_count:
             self._ep._close_after_n_recv = n
         else:
             raise exceptions.UCXError(
-                "n cannot be less than current recv_count: %d (abs) < %d (abs)"
-                % (n, self._ep._recv_count)
+                "`n` cannot be less than current recv_count: %d (abs) < %d (abs)"
+                % (n, self._ep._finished_recv_count)
             )

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -310,7 +310,8 @@ class Endpoint:
         n: int
             Number of messages to received before closing the endpoint.
         count_from_ep_creation: bool, optional
-            Whether to count `n` from this function call (default) or from the creation of the endpoint.
+            Whether to count `n` from this function call (default) or
+            from the creation of the endpoint.
         """
         if not count_from_ep_creation:
             n += self._ep._recv_count  # Make `n` absolute

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -317,7 +317,7 @@ class Endpoint:
             n += self._ep._finished_recv_count  # Make `n` absolute
         if self._ep._close_after_n_recv is not None:
             raise exceptions.UCXError(
-                "close_after_n_recv() is already set to: %d (abs)"
+                "close_after_n_recv has already been set to: %d (abs)"
                 % self._ep._close_after_n_recv
             )
         if n == self._ep._finished_recv_count:


### PR DESCRIPTION
This PR makes sure that when a Endpoint receive the shutdown signal it delays the shutdown to after all inflight messages has been received.

Also, this PR implements `Endpoint.close_after_n_recv()`:
```python
    def close_after_n_recv(self, n, count_from_ep_creation=False):
        """Close the endpoint after `n` received messages.

        Parameters
        ----------
        n: int
            Number of messages to received before closing the endpoint.
        count_from_ep_creation: bool, optional
            Whether to count `n` from this function call (default) or
            from the creation of the endpoint.
        """
        if not count_from_ep_creation:
            n += self._ep._finished_recv_count  # Make `n` absolute
        if self._ep._close_after_n_recv is not None:
            raise exceptions.UCXError(
                "close_after_n_recv() is already set to: %d (abs)"
                % self._ep._close_after_n_recv
            )
        if n == self._ep._finished_recv_count:
            self._ep.close()
        elif n > self._ep._finished_recv_count:
            self._ep._close_after_n_recv = n
        else:
            raise exceptions.UCXError(
                "`n` cannot be less than current recv_count: %d (abs) < %d (abs)"
                % (n, self._ep._finished_recv_count)
            )
```
With this PR, all the communication tests in [distributed](https://github.com/dask/distributed/tree/master/distributed/comm/tests) passes on my machine,