### PR TITLE
Rename package to ucxpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ ext_modules = [
 ]
 
 setup(
-    name="ucp",
+    name="ucxpy",
     packages=["ucp"],
     ext_modules=ext_modules,
     cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ucx-py/issues/299

This renames the package to `ucxpy` like the PyPI name that we claimed.