### PR TITLE
Cleanup the closing of endpoint

### DIFF
--- a/benchmarks/recv-into-client.py
+++ b/benchmarks/recv-into-client.py
@@ -118,8 +118,7 @@ def serve(port, n_bytes, n_iter, recv, np, verbose, increment):
                 print("\n")
                 print(df)
 
-            await ep.signal_shutdown()
-            ep.close()
+            await ep.close()
             lf.close()
 
         lf = ucp.create_listener(inc, port)
@@ -169,8 +168,7 @@ async def connect(host, port, n_bytes, n_iter, recv, np, verbose, increment):
     print(format_bytes(2 * n_iter * msg.nbytes / took), "/ s")
     print("===================")
 
-    # await ep.signal_shutdown()
-    # ep.close()
+    # await ep.close()
 
 
 def main(args=None):

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -37,8 +37,7 @@ Process 1
         print("Sending incremented CuPy array")
         await ep.send(arr)
 
-        await ep.signal_shutdown()
-        ep.close()
+        await ep.close()
         lf.close()
 
     lf = ucp.create_listener(send, port)

--- a/tests/test_custom_send_recv.py
+++ b/tests/test_custom_send_recv.py
@@ -123,10 +123,8 @@ async def test_send_recv_cudf(event_loop, g):
     from dask.dataframe.utils import assert_eq
 
     assert_eq(res, msg)
-    await uu.comm.ep.signal_shutdown()
-    uu.comm.ep.close()
-    await uu.client.signal_shutdown()
-    uu.client.close()
+    await uu.comm.ep.close()
+    await uu.client.close()
 
     assert uu.client.closed()
     assert uu.comm.ep.closed()

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -20,7 +20,7 @@ async def test_reset():
     reset = ResetAfterN(2)
 
     def server(ep):
-        ep.close()
+        ep.abort()
         reset()
 
     lt = ucp.create_listener(server)
@@ -35,7 +35,7 @@ async def test_lt_still_in_scope_error():
     reset = ResetAfterN(2)
 
     def server(ep):
-        ep.close()
+        ep.abort()
         reset()
 
     lt = ucp.create_listener(server)
@@ -53,7 +53,7 @@ async def test_ep_still_in_scope_error():
     reset = ResetAfterN(2)
 
     def server(ep):
-        ep.close()
+        ep.abort()
         reset()
 
     lt = ucp.create_listener(server)
@@ -61,5 +61,5 @@ async def test_ep_still_in_scope_error():
     del lt
     with pytest.raises(ucp.exceptions.UCXError, match="_ucp_endpoint"):
         ucp.reset()
-    ep.close()
+    ep.abort()
     ucp.reset()

--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 
 import pytest
 import ucp
@@ -37,7 +36,6 @@ def make_echo_server(create_empty_data):
 def handle_exception(loop, context):
     msg = context.get("exception", context["message"])
     print(msg)
-    sys.exit(-1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -7,8 +7,7 @@ import ucp
 
 
 async def shutdown(ep):
-    await ep.signal_shutdown()
-    ep.close()
+    await ep.close()
 
 
 @pytest.mark.asyncio

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -630,6 +630,9 @@ class _Endpoint:
                 self._ctrl_tag_send,
                 pending_msg=self.pending_msg_list[-1]
             )
+            # Give all current outstanding send() calls a chance to return
+            self._ctx.progress()
+            await asyncio.sleep(0)
         finally:
             self.abort()
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -569,7 +569,6 @@ class _Endpoint:
         self._recv_count = 0  # Number of calls to self.recv()
         self._finished_recv_count = 0  # Number of returned (finished) self.recv() calls
         self._closed = False
-        self._signaled_shutdown = False
         self.pending_msg_list = []
         # UCX supports CUDA if "cuda" is part of the TLS or TLS is "all"
         self._cuda_support = "cuda" in ctx.config['TLS'] or ctx.config['TLS'] == "all"
@@ -579,44 +578,16 @@ class _Endpoint:
     def uid(self):
         return self._ucp_endpoint
 
-    async def signal_shutdown(self):
+    def abort(self):
         if self._closed:
-            raise UCXCloseError("signal_shutdown() - _Endpoint closed")
-        self._signaled_shutdown = True
-        # Send a shutdown message to the peer
-        cdef CtrlMsg msg = CtrlMsg()
-        msg.data = {
-            'op': 1,  # "1" is shutdown, currently the only opcode.
-            'close_after_n_recv': self._send_count,
-        }
-        cdef CtrlMsgData[::1] ctrl_msg_mv = <CtrlMsgData[:1:1]>(&msg.data)
-        log = "[Send shutdown] ep: %s, tag: %s, close_after_n_recv: %d" % (
-            hex(self.uid), hex(self._ctrl_tag_send), self._send_count
-        )
-        logging.debug(log)
-        self.pending_msg_list.append({'log': log})
-        await tag_send(
-            self._ucp_endpoint,
-            ctrl_msg_mv, ctrl_msg_mv.nbytes,
-            self._ctrl_tag_send,
-            pending_msg=self.pending_msg_list[-1]
-        )
-
-    def closed(self):
-        return self._closed
-
-    def close(self):
-        if self._closed:
-            raise UCXCloseError("close() - _Endpoint closed")
+            return
         self._closed = True
-        logging.debug("_Endpoint.close(): %s" % hex(self.uid))
+        logging.debug("Endpoint.abort(): %s" % hex(self.uid))
 
         cdef ucp_worker_h worker = <ucp_worker_h> PyLong_AsVoidPtr(self._ucp_worker)  # noqa
 
         for msg in self.pending_msg_list:
             if 'future' in msg and not msg['future'].done():
-                # TODO: make sure that a potential shutdown
-                # message isn't cancelled
                 logging.debug("Future cancelling: %s" % msg['log'])
                 ucp_request_cancel(
                     worker,
@@ -635,15 +606,42 @@ class _Endpoint:
             ucp_request_free(status)
         self._ctx = None
 
+    async def close(self):
+        if self._closed:
+            return
+        cdef CtrlMsg msg
+        cdef CtrlMsgData[::1] ctrl_msg_mv
+        try:
+            # Send a shutdown message to the peer
+            msg = CtrlMsg()
+            msg.data = {
+                'op': 1,  # "1" is shutdown, currently the only opcode.
+                'close_after_n_recv': self._send_count,
+            }
+            ctrl_msg_mv = <CtrlMsgData[:1:1]>(&msg.data)
+            log = "[Send shutdown] ep: %s, tag: %s, close_after_n_recv: %d" % (
+                hex(self.uid), hex(self._ctrl_tag_send), self._send_count
+            )
+            logging.debug(log)
+            self.pending_msg_list.append({'log': log})
+            await tag_send(
+                self._ucp_endpoint,
+                ctrl_msg_mv, ctrl_msg_mv.nbytes,
+                self._ctrl_tag_send,
+                pending_msg=self.pending_msg_list[-1]
+            )
+        finally:
+            self.abort()
+
+    def closed(self):
+        return self._closed
+
     def __del__(self):
-        if not self._closed:
-            self.close()
+        self.abort()
 
     async def send(self, buffer, nbytes=None):
         if self._closed:
             raise UCXCloseError("Endpoint closed")
-        if self._signaled_shutdown:
-            raise UCXError("Cannot send on an Endpoint after signaling shutdown")
         nbytes = get_buffer_nbytes(buffer, check_min_size=nbytes,
                                    cuda_support=self._cuda_support)
         log = "[Send #%03d] ep: %s, tag: %s, nbytes: %d" % (
@@ -687,7 +685,7 @@ class _Endpoint:
         self._finished_recv_count += 1
         if self._close_after_n_recv is not None \
                 and self._finished_recv_count >= self._close_after_n_recv:
-            self.close()
+            self.abort()
         return ret
 
     def ucx_info(self):


### PR DESCRIPTION
Instead of `close()` and `async signal_shutdown()`, we now have:

```python
    def abort(self):
        """Close the communication immediately and abruptly.
        Useful in destructors or generators' ``finally`` blocks.

        Notice, this functions doesn't signal the connected peer to close.
        To do that, use `Endpoint.close()`
        """

    async def close(self):
        """Close the endpoint cleanly.
        This will attempt to flush outgoing buffers before actually
        closing the underlying UCX endpoint.
        """
```