### PR TITLE
Split installation documentation to CPU/GPU sections

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -45,19 +45,18 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install "cudf>=0.10" "dask-cudf>=0.10" "cudatoolkit=$CUDA_REL" \
-              "dask>=2.3.0" "distributed>=2.3.2" "numpy>=1.16" "pyarrow=0.15.0" \
-              "arrow-cpp=0.15.0" -c rapidsai-nightly
+conda install "cudatoolkit=$CUDA_REL" \
+              "cupy>=6.5.0" "numpy>=1.16" \
+              "cudf>=0.10" "dask-cudf>=0.10" \
+              "dask>=2.3.0" "distributed>=2.3.2" \
+              "pyarrow=0.15.0" "arrow-cpp=0.15.0" \
+              -c rapidsai-nightly
 
 # needed for asynccontextmanager in py36
 conda install -c conda-forge "async_generator" "automake" "libtool" \
                               "cmake" "automake" "autoconf" "cython" \
                               "pytest" "pkg-config" "pytest-asyncio" \
                               "pynvml"
-
-
-# install cupy
-conda install -c rapidsai -c nvidia "cupy>=6.2.0"
 
 # install ucx from conda-forge rc channel
 # conda install -c conda-forge/label/rc_ucx "ucx-proc=*=gpu" "ucx"
@@ -81,6 +80,7 @@ conda list
 logger "Build ucx"
 git clone https://github.com/openucx/ucx
 cd ucx
+git checkout v1.7.x
 ls
 ./autogen.sh
 mkdir build

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,12 +4,19 @@ Install
 Conda
 -----
 
+With GPU support:
+
 ::
 
     conda create -n ucx -c conda-forge -c conda-forge/label/rc_ucx \
-    cudatoolkit=<CUDA version> ucx-proc=*=<processor type> ucx ucx-py python=3.7
+      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.7
 
-Where ``<processor type>`` can be ``gpu`` or ``cpu``.
+Without GPU support:
+
+::
+
+    conda create -n ucx -c conda-forge -c conda-forge/label/rc_ucx \
+      ucx-proc=*=cpu ucx ucx-py python=3.7
 
 Source
 ------


### PR DESCRIPTION
It's complex regardless, but this way we stop people from
installing cudatoolkit, and give them a copy-pasteable solution in
the CPU-only case.