### PR TITLE
Send-recv benchmark for a local machine

### DIFF
--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -187,9 +187,9 @@ def main():
     print(f"reuse alloc | {args.reuse_alloc}")
     print("==========================")
     if args.object_type == "cupy":
-        print(f"Device      | {args.server_dev}, {args.client_dev}")
+        print(f"Device(s)   | {args.server_dev}, {args.client_dev}")
     else:
-        print(f"Device      | CPU")
+        print(f"Device(s)    | Single CPU")
     print(
         f"Average     | {format_bytes(2 * args.n_iter * args.n_bytes / sum(times))}/s"
     )

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -4,7 +4,7 @@ Benchmark send receive on one machine
 import argparse
 import asyncio
 import multiprocessing as mp
-from time import perf_counter as clock, sleep
+from time import perf_counter as clock
 
 from distributed.utils import format_bytes, parse_bytes
 
@@ -12,8 +12,6 @@ import numpy
 import ucp
 
 mp = mp.get_context("spawn")
-
-port = 4300
 
 
 def server(queue, args):
@@ -40,19 +38,14 @@ def server(queue, args):
 
             assert msg_recv_list[0].nbytes == args.n_bytes
 
-            start = clock()
             for i in range(args.n_iter):
                 await ep.recv(msg_recv_list[i], args.n_bytes)
                 await ep.send(msg_recv_list[i], args.n_bytes)
-            stop = clock()
-
-            took = stop - start
-            queue.put(took)
             await ep.close()
             lf.close()
 
-        lf = ucp.create_listener(server_handler, port)
-        host = ucp.get_address()
+        lf = ucp.create_listener(server_handler)
+        queue.put(lf.port)
 
         while not lf.closed():
             await asyncio.sleep(0.5)
@@ -62,7 +55,7 @@ def server(queue, args):
     loop.close()
 
 
-def client(queue, args):
+def client(queue, port, args):
     import ucp
 
     ucp.init()
@@ -92,14 +85,14 @@ def client(queue, args):
         assert msg_send_list[0].nbytes == args.n_bytes
         assert msg_recv_list[0].nbytes == args.n_bytes
 
-        start = clock()
+        times = []
         for i in range(args.n_iter):
+            start = clock()
             await ep.send(msg_send_list[i], args.n_bytes)
             await ep.recv(msg_recv_list[i], args.n_bytes)
-        stop = clock()
-
-        took = stop - start
-        queue.put(took)
+            stop = clock()
+            times.append(stop - start)
+        queue.put(times)
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run())
@@ -175,36 +168,38 @@ def main():
     q1 = mp.Queue()
     p1 = mp.Process(target=server, args=(q1, args))
     p1.start()
-    sleep(1)
+    port = q1.get()
     q2 = mp.Queue()
-    p2 = mp.Process(target=client, args=(q2, args))
+    p2 = mp.Process(target=client, args=(q2, port, args))
     p2.start()
-    t1 = q1.get()
-    t2 = q2.get()
+    times = q2.get()
     p1.join()
     p2.join()
     assert not p1.exitcode
     assert not p2.exitcode
+    assert len(times) == args.n_iter
 
-    if args.object_type == "cupy":
-        gpu_dev = ["(GPU %d)" % args.server_dev, "(GPU %d)" % args.client_dev]
-    else:
-        gpu_dev = ["", ""]
-
+    print("Roundtrip benchmark")
     print("--------------------------")
-    print(f"n_iter   | {args.n_iter}")
-    print(f"n_bytes  | {format_bytes(args.n_bytes)}")
-    print(f"object   | {args.object_type}")
-    print("\n==========================")
-    print(
-        "Server%s: %s/s"
-        % (gpu_dev[0], format_bytes(2 * args.n_iter * args.n_bytes / t1))
-    )
-    print(
-        "Client%s: %s/s"
-        % (gpu_dev[1], format_bytes(2 * args.n_iter * args.n_bytes / t2))
-    )
+    print(f"n_iter      | {args.n_iter}")
+    print(f"n_bytes     | {format_bytes(args.n_bytes)}")
+    print(f"object      | {args.object_type}")
+    print(f"reuse alloc | {args.reuse_alloc}")
     print("==========================")
+    if args.object_type == "cupy":
+        print(f"Device      | {args.server_dev}, {args.client_dev}")
+    else:
+        print(f"Device      | CPU")
+    print(
+        f"Average     | {format_bytes(2 * args.n_iter * args.n_bytes / sum(times))}/s"
+    )
+    print("--------------------------")
+    print("Iterations")
+    print("--------------------------")
+    for i, t in enumerate(times):
+        ts = format_bytes(2 * args.n_bytes / t)
+        ts = (" " * (9 - len(ts))) + ts
+        print("%03d         |%s/s" % (i, ts))
 
 
 if __name__ == "__main__":

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -1,0 +1,209 @@
+"""
+Benchmark send receive on one machine
+"""
+import argparse
+import asyncio
+from time import sleep, perf_counter as clock
+import multiprocessing as mp
+import numpy
+import ucp
+from distributed.utils import format_bytes, parse_bytes
+
+mp = mp.get_context("spawn")
+
+port = 4300
+
+
+def server(queue, args):
+    ucp.init()
+    if args.object_type == "numpy":
+        import numpy as np
+    else:
+        import cupy as np
+
+        np.cuda.runtime.setDevice(args.server_dev)
+
+    async def run():
+        async def server_handler(ep):
+            times = []
+
+            msg_recv_list = []
+            if not args.reuse_alloc:
+                for _ in range(args.n_iter):
+                    msg_recv_list.append(np.zeros(args.n_bytes, dtype="u1"))
+            else:
+                t = np.zeros(args.n_bytes, dtype="u1")
+                for _ in range(args.n_iter):
+                    msg_recv_list.append(t)
+
+            assert msg_recv_list[0].nbytes == args.n_bytes
+
+            start = clock()
+            for i in range(args.n_iter):
+                await ep.recv(msg_recv_list[i], args.n_bytes)
+                await ep.send(msg_recv_list[i], args.n_bytes)
+            stop = clock()
+
+            took = stop - start
+            queue.put(took)
+            await ep.close()
+            lf.close()
+
+        lf = ucp.create_listener(server_handler, port)
+        host = ucp.get_address()
+
+        while not lf.closed():
+            await asyncio.sleep(0.5)
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run())
+    loop.close()
+
+
+def client(queue, args):
+    import ucp
+
+    ucp.init()
+
+    if args.object_type == "numpy":
+        import numpy as np
+    else:
+        import cupy as np
+
+        np.cuda.runtime.setDevice(args.client_dev)
+
+    async def run():
+        ep = await ucp.create_endpoint(args.server_address, port)
+
+        msg_send_list = []
+        msg_recv_list = []
+        if not args.reuse_alloc:
+            for i in range(args.n_iter):
+                msg_send_list.append(np.arange(args.n_bytes, dtype="u1"))
+                msg_recv_list.append(np.zeros(args.n_bytes, dtype="u1"))
+        else:
+            t1 = np.arange(args.n_bytes, dtype="u1")
+            t2 = np.zeros(args.n_bytes, dtype="u1")
+            for i in range(args.n_iter):
+                msg_send_list.append(t1)
+                msg_recv_list.append(t2)
+        assert msg_send_list[0].nbytes == args.n_bytes
+        assert msg_recv_list[0].nbytes == args.n_bytes
+
+        start = clock()
+        for i in range(args.n_iter):
+            await ep.send(msg_send_list[i], args.n_bytes)
+            await ep.recv(msg_recv_list[i], args.n_bytes)
+        stop = clock()
+
+        took = stop - start
+        queue.put(took)
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run())
+    loop.close()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-n",
+        "--n-bytes",
+        metavar="BYTES",
+        default="10 Mb",
+        type=parse_bytes,
+        help="Message size. Default '10 Mb'.",
+    )
+    parser.add_argument(
+        "--n-iter",
+        metavar="N",
+        default=10,
+        type=int,
+        help="Numer of send / recv iterations (default 10).",
+    )
+    parser.add_argument(
+        "-o",
+        "--object_type",
+        default="numpy",
+        choices=["numpy", "cupy"],
+        help="In-memory array type.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        default=False,
+        action="store_true",
+        help="Whether to print timings per iteration.",
+    )
+    parser.add_argument(
+        "-s",
+        "--server-address",
+        metavar="ip",
+        default=ucp.get_address(),
+        type=str,
+        help="Server address (default `ucp.get_address()`).",
+    )
+    parser.add_argument(
+        "-d",
+        "--server-dev",
+        metavar="N",
+        default=0,
+        type=int,
+        help="GPU device on server (default 0).",
+    )
+    parser.add_argument(
+        "-e",
+        "--client-dev",
+        metavar="N",
+        default=0,
+        type=int,
+        help="GPU device on client (default 0).",
+    )
+    parser.add_argument(
+        "--reuse-alloc",
+        default=False,
+        action="store_true",
+        help="Reuse memory allocations between communication.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    q1 = mp.Queue()
+    p1 = mp.Process(target=server, args=(q1, args))
+    p1.start()
+    sleep(1)
+    q2 = mp.Queue()
+    p2 = mp.Process(target=client, args=(q2, args))
+    p2.start()
+    t1 = q1.get()
+    t2 = q2.get()
+    p1.join()
+    p2.join()
+    assert not p1.exitcode
+    assert not p2.exitcode
+
+    if args.object_type == "cupy":
+        gpu_dev = ["(GPU %d)" % args.server_dev, "(GPU %d)" % args.client_dev]
+    else:
+        gpu_dev = ["", ""]
+
+    print("--------------------------")
+    print(f"n_iter   | {args.n_iter}")
+    print(f"n_bytes  | {format_bytes(args.n_bytes)}")
+    print(f"object   | {args.object_type}")
+    print("\n==========================")
+    print(
+        "Server%s: %s/s"
+        % (gpu_dev[0], format_bytes(2 * args.n_iter * args.n_bytes / t1))
+    )
+    print(
+        "Client%s: %s/s"
+        % (gpu_dev[1], format_bytes(2 * args.n_iter * args.n_bytes / t2))
+    )
+    print("==========================")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -166,7 +166,7 @@ def parse_args():
         "--cuda-profile",
         default=False,
         action="store_true",
-        help="Setting profiler.start()/stop() around send/recv "
+        help="Setting CUDA profiler.start()/stop() around send/recv "
         "typically used with `nvprof --profile-from-start off "
         "--profile-child-processes`",
     )

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -3,11 +3,13 @@ Benchmark send receive on one machine
 """
 import argparse
 import asyncio
-from time import sleep, perf_counter as clock
 import multiprocessing as mp
+from time import perf_counter as clock, sleep
+
+from distributed.utils import format_bytes, parse_bytes
+
 import numpy
 import ucp
-from distributed.utils import format_bytes, parse_bytes
 
 mp = mp.get_context("spawn")
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -128,5 +128,8 @@ else
     logger "TEST WITH TCP ONLY..."
     UCXPY_IFNAME=eth0 UCX_MEMTYPE_CACHE=n UCX_TLS=tcp,cuda_copy,sockcm UCX_SOCKADDR_TLS_PRIORITY=sockcm py.test --cache-clear --junitxml=${WORKSPACE}/junit-ucx-py.xml -v --cov-config=.coveragerc --cov=cudf --cov-report=xml:${WORKSPACE}/ucp-coverage.xml --cov-report term tests/
 
+    logger "Run local benchmark..."
+    UCXPY_IFNAME=eth0 UCX_MEMTYPE_CACHE=n UCX_TLS=tcp,cuda_copy,sockcm UCX_SOCKADDR_TLS_PRIORITY=sockcm python benchmarks/local-send-recv.py -o cupy --server-dev 0 --client-dev 0 --reuse-alloc
+
 fi
 


### PR DESCRIPTION
This PR implements a send-recv benchmark targeting a single machine with multiple GPUs.

```
$ local-send-recv.py --help
usage: local-send-recv.py [-h] [-n BYTES] [--n-iter N] [-o {numpy,cupy}] [-v]
                          [-s ip] [-d N] [-e N] [--reuse-alloc]
                          [--cuda-profile]

Roundtrip benchmark

optional arguments:
  -h, --help            show this help message and exit
  -n BYTES, --n-bytes BYTES
                        Message size. Default '10 Mb'.
  --n-iter N            Numer of send / recv iterations (default 10).
  -o {numpy,cupy}, --object_type {numpy,cupy}
                        In-memory array type.
  -v, --verbose         Whether to print timings per iteration.
  -s ip, --server-address ip
                        Server address (default `ucp.get_address()`).
  -d N, --server-dev N  GPU device on server (default 0).
  -e N, --client-dev N  GPU device on client (default 0).
  --reuse-alloc         Reuse memory allocations between communication.
  --cuda-profile        Setting CUDA profiler.start()/stop() around send/recv
                        typically used with `nvprof --profile-from-start off
                        --profile-child-processes`
```

Example:
```
$ local-send-recv.py -o cupy  -n "100MB" --server-dev 1 --client-dev 2 --reuse-alloc
Roundtrip benchmark
--------------------------
n_iter      | 10
n_bytes     | 100.00 MB
object      | cupy
reuse alloc | True
==========================
Device      | 1, 2
Average     | 30.08 GB/s
--------------------------
Iterations
--------------------------
000         |  9.59 GB/s
001         | 40.96 GB/s
002         | 42.80 GB/s
003         | 41.56 GB/s
004         | 42.42 GB/s
005         | 42.63 GB/s
006         | 26.09 GB/s
007         | 42.33 GB/s
008         | 42.59 GB/s
009         | 41.89 GB/s
```

cc @quasiben @pentschev 
