### PR TITLE
Set UCX_CUDA_IPC_CACHE=n upon ucp import

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -20,6 +20,13 @@ if os.environ.get("UCX_MEMTYPE_CACHE", "") != "n":
     logger.debug("Setting env UCX_MEMTYPE_CACHE=n, which is required by UCX")
     os.environ["UCX_MEMTYPE_CACHE"] = "n"
 
+if os.environ.get("UCX_CUDA_IPC_CACHE", "") != "n":
+    # See <https://github.com/openucx/ucx/issues/4410>
+    logger.debug(
+        "Setting env UCX_CUDA_IPC_CACHE=n, which is required to avoid NVLink memory leaks"
+    )
+    os.environ["UCX_CUDA_IPC_CACHE"] = "n"
+
 # Set the root logger before importing modules that use it
 _level_enum = logging.getLevelName(os.getenv("UCXPY_LOG_LEVEL", "WARNING"))
 logging.basicConfig(level=_level_enum, format="%(levelname)s %(message)s")

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -15,12 +15,12 @@ logger = logging.getLogger("ucx")
 
 # Notice, if we have to update environment variables
 # we need to do it before importing UCX
-if os.environ.get("UCX_MEMTYPE_CACHE", "") != "n":
+if "UCX_MEMTYPE_CACHE" not in os.environ:
     # See <https://github.com/openucx/ucx/wiki/NVIDIA-GPU-Support#known-issues>
     logger.debug("Setting env UCX_MEMTYPE_CACHE=n, which is required by UCX")
     os.environ["UCX_MEMTYPE_CACHE"] = "n"
 
-if os.environ.get("UCX_CUDA_IPC_CACHE", "") != "n":
+if "UCX_CUDA_IPC_CACHE" not in os.environ:
     # See <https://github.com/openucx/ucx/issues/4410>
     logger.debug(
         "Setting env UCX_CUDA_IPC_CACHE=n, which is required to avoid NVLink memory "

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -23,7 +23,8 @@ if os.environ.get("UCX_MEMTYPE_CACHE", "") != "n":
 if os.environ.get("UCX_CUDA_IPC_CACHE", "") != "n":
     # See <https://github.com/openucx/ucx/issues/4410>
     logger.debug(
-        "Setting env UCX_CUDA_IPC_CACHE=n, which is required to avoid NVLink memory leaks"
+        "Setting env UCX_CUDA_IPC_CACHE=n, which is required to avoid NVLink memory "
+        "leaks"
     )
     os.environ["UCX_CUDA_IPC_CACHE"] = "n"
 


### PR DESCRIPTION
Set `UCX_CUDA_IPC_CACHE=n` upon ucp import to prevent memory leaks when NVLink is enabled (see https://github.com/openucx/ucx/issues/4410).

Using `ucp.init` to do this is currently not possible as it only supports UCP configurations and `UCX_CUDA_IPC_CACHE` is part of UCT, which is considerably more complex to query/set, as it requires traversing all MDs and interfaces.