### PR TITLE
add join benchmark

### DIFF
--- a/benchmarks/dask-join.py
+++ b/benchmarks/dask-join.py
@@ -1,0 +1,91 @@
+import asyncio
+import time
+from time import perf_counter as clock
+
+import dask.array as da
+import dask.dataframe as dd
+from dask_cuda import DGX
+from dask_cuda.initialize import initialize
+from distributed import Client
+from distributed.utils import format_bytes
+from distributed.utils_test import captured_logger
+
+import cudf
+import dask_cudf
+import pytest
+
+enable_tcp_over_ucx = True
+enable_infiniband = False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enable_nvlink", [True, False])
+async def test_join(enable_nvlink):
+    initialize(
+        create_cuda_context=True,
+        enable_tcp_over_ucx=enable_tcp_over_ucx,
+        enable_infiniband=enable_infiniband,
+        enable_nvlink=enable_nvlink,
+    )
+
+    async with DGX(
+        interface="enp1s0f0",
+        protocol="ucx",
+        enable_tcp_over_ucx=enable_tcp_over_ucx,
+        enable_infiniband=enable_infiniband,
+        enable_nvlink=enable_nvlink,
+        asynchronous=True,
+    ) as dgx:
+        async with Client(dgx, asynchronous=True) as client:
+
+            n_rows = 1_000_000_000
+            n_keys = 5_000_000
+
+            left = dd.concat(
+                [
+                    da.random.random(n_rows).to_dask_dataframe(columns="x"),
+                    da.random.randint(0, n_keys, size=n_rows).to_dask_dataframe(
+                        columns="id"
+                    ),
+                ],
+                axis=1,
+            ).persist()
+            n_rows = 10_000_000
+
+            right = dd.concat(
+                [
+                    da.random.random(n_rows).to_dask_dataframe(columns="y"),
+                    da.random.randint(0, n_keys, size=n_rows).to_dask_dataframe(
+                        columns="id"
+                    ),
+                ],
+                axis=1,
+            ).persist()
+
+            gleft = left.map_partitions(cudf.from_pandas)
+            gright = right.map_partitions(cudf.from_pandas)
+            gleft = await gleft.persist()
+            gright = await gright.persist()  # persist data in device memory
+
+            start = clock()
+            out = gleft.merge(gright, on=["id"])  # this is lazy
+            out = await out.persist()
+            stop = clock()
+
+            took = stop - start
+
+            async def f(dask_scheduler):
+                return dask_scheduler.bandwidth_workers
+
+            data = await client.run_on_scheduler(f)
+            total = sum([d for w, d in data.items()])
+            total_str = format_bytes(total)
+
+            with open("benchmarks.txt", "a+") as f:
+                f.write("Join benchmark\n")
+                f.write(f"NVLINK: {enable_nvlink}\n")
+                f.write("-------------------\n")
+                f.write(f"n_bytes  | {format_bytes(total)}\n")
+                f.write("\n===================\n")
+                f.write(f"{format_bytes(total / took)} / s\n")
+                f.write("===================\n\n\n")

--- a/benchmarks/dask-join.py
+++ b/benchmarks/dask-join.py
@@ -1,6 +1,50 @@
-import asyncio
-import time
+"""
+Conda Environment
+-----------------
 
+# environment.yml
+name: ucx-benchmark
+channels:
+  - conda-forge
+  - conda-forge/label/rc_ucx
+  - rapidsai-nightly
+  - nvidia
+dependencies:
+  - cudatoolkit
+  - ucx-proc=*=gpu
+  - ucx
+  - ucx-py
+  - dask-cudf=0.11
+  - dask-cuda=0.11
+  - pytest
+  - pytest-asyncio
+  - python=3.7
+  - numba=0.46
+  - pip
+  - pip:
+    - git+https://github.com/dask/distributed@0b68318112b13d70a9cdd741e5db00da2ec6a8f5
+
+$ conda env create -n ucx-benchmark -f myfile.yaml
+$ conda activate ucx-benchmark
+$ py.test benchmarks/dask-join.py
+
+
+Config
+------
+
+distributed:
+  worker:
+    multiprocessing-method: spawn
+  comm:
+    offload: False
+"""
+import os
+import time
+os.environ["UCX_CUDA_IPC_CACHE"] = "n"
+
+import cudf
+import cupy
+import pytest
 import dask
 import dask.dataframe as dd
 from dask_cuda import DGX
@@ -8,9 +52,6 @@ from dask_cuda.initialize import initialize
 from distributed import Client
 from distributed.utils import format_bytes
 
-import cudf
-import cupy
-import pytest
 
 enable_tcp_over_ucx = True
 enable_infiniband = False
@@ -80,5 +121,3 @@ async def test_join(enable_nvlink):
             print("NVLink:", enable_nvlink, "Rows:", n_rows, "Bandwidth:", format_bytes(bandwidth))
 
             _ = await client.profile(server=True, filename="join-communication.html")
-
-

--- a/benchmarks/dask-join.py
+++ b/benchmarks/dask-join.py
@@ -40,6 +40,7 @@ distributed:
 """
 import os
 import time
+
 os.environ["UCX_CUDA_IPC_CACHE"] = "n"
 
 import cudf
@@ -118,6 +119,13 @@ async def test_join(enable_nvlink):
             duration = stop - start
 
             bandwidth = dgx.scheduler.bandwidth
-            print("NVLink:", enable_nvlink, "Rows:", n_rows, "Bandwidth:", format_bytes(bandwidth))
+            print(
+                "NVLink:",
+                enable_nvlink,
+                "Rows:",
+                n_rows,
+                "Bandwidth:",
+                format_bytes(bandwidth),
+            )
 
             _ = await client.profile(server=True, filename="join-communication.html")

--- a/benchmarks/dask-join.py
+++ b/benchmarks/dask-join.py
@@ -50,6 +50,7 @@ async def test_join(enable_nvlink):
                 ],
                 axis=1,
             ).persist()
+
             n_rows = 10_000_000
 
             right = dd.concat(
@@ -74,18 +75,15 @@ async def test_join(enable_nvlink):
 
             took = stop - start
 
-            async def f(dask_scheduler):
-                return dask_scheduler.bandwidth_workers
-
-            data = await client.run_on_scheduler(f)
-            total = sum([d for w, d in data.items()])
-            total_str = format_bytes(total)
+            # bandwidth_workers = dgx.scheduler.bandwidth_workers
+            # bandwidth_workers_total = sum([d for w, d in bandwidth_workers.items()])
+            bandwidth = dgx.scheduler.bandwidth
 
             with open("benchmarks.txt", "a+") as f:
                 f.write("Join benchmark\n")
                 f.write(f"NVLINK: {enable_nvlink}\n")
                 f.write("-------------------\n")
-                f.write(f"n_bytes  | {format_bytes(total)}\n")
+                f.write(f"Aggregate Bandwidth  | {format_bytes(bandwidth)}\n")
                 f.write("\n===================\n")
                 f.write(f"{format_bytes(total / took)} / s\n")
                 f.write("===================\n\n\n")


### PR DESCRIPTION
This PR adds a benchmark tests designed to be executed with pytest on a DGX1

> py.test -v "benchmarks/dask-join.py::test_join"

Sample output

```
Join benchmark
NVLINK: True
-------------------
n_bytes  | 713.89 MB

===================
91.74 MB / s
===================


Join benchmark
NVLINK: False
-------------------
n_bytes  | 262.96 MB

===================
26.29 MB / s
===================
```

cc @mrocklin 