### PR TITLE
Add TopologicalDistance class to identify closest devices to a GPU

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -56,7 +56,7 @@ conda install "cudatoolkit=$CUDA_REL" \
 conda install -c conda-forge "async_generator" "automake" "libtool" \
                               "cmake" "automake" "autoconf" "cython" \
                               "pytest" "pkg-config" "pytest-asyncio" \
-                              "pynvml"
+                              "pynvml" "libhwloc"
 
 # install ucx from conda-forge rc channel
 # conda install -c conda-forge/label/rc_ucx "ucx-proc=*=gpu" "ucx"

--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -15,6 +15,7 @@ dependencies:
 - recommonmark
 - pandoc=<2.0.0
 - pip
+- libhwloc
 - ucx
 - ucx-py
 - pip:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools.extension import Extension
 
 include_dirs = [os.path.dirname(get_python_inc())]
 library_dirs = [get_config_var("LIBDIR")]
-libraries = ["ucp", "uct", "ucm", "ucs", "hwloc", "cuda"]
+libraries = ["ucp", "uct", "ucm", "ucs", "hwloc"]
 extra_compile_args = ["-std=c99"]
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools.extension import Extension
 
 include_dirs = [os.path.dirname(get_python_inc())]
 library_dirs = [get_config_var("LIBDIR")]
-libraries = ["ucp", "uct", "ucm", "ucs"]
+libraries = ["ucp", "uct", "ucm", "ucs", "hwloc", "cuda"]
 extra_compile_args = ["-std=c99"]
 
 
@@ -39,8 +39,29 @@ ext_modules = [
     ),
     Extension(
         "ucp._libs.core",
-        sources=["ucp/_libs/core.pyx", "ucp/_libs/src/c_util.c"],
-        depends=["ucp/_libs/src/c_util.h", "ucp/_libs/core_dep.pxd"],
+        sources=[
+            "ucp/_libs/core.pyx",
+            "ucp/_libs/src/c_util.c",
+        ],
+        depends=[
+            "ucp/_libs/src/c_util.h",
+            "ucp/_libs/core_dep.pxd",
+        ],
+        include_dirs=include_dirs,
+        library_dirs=library_dirs,
+        libraries=libraries,
+        extra_compile_args=extra_compile_args,
+    ),
+    Extension(
+        "ucp._libs.topological_distance",
+        sources=[
+            "ucp/_libs/topological_distance.pyx",
+            "ucp/_libs/src/topological_distance.c",
+        ],
+        depends=[
+            "ucp/_libs/src/topological_distance.h",
+            "ucp/_libs/topological_distance_dep.pxd",
+        ],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
         libraries=libraries,

--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,8 @@ ext_modules = [
     ),
     Extension(
         "ucp._libs.core",
-        sources=[
-            "ucp/_libs/core.pyx",
-            "ucp/_libs/src/c_util.c",
-        ],
-        depends=[
-            "ucp/_libs/src/c_util.h",
-            "ucp/_libs/core_dep.pxd",
-        ],
+        sources=["ucp/_libs/core.pyx", "ucp/_libs/src/c_util.c",],
+        depends=["ucp/_libs/src/c_util.h", "ucp/_libs/core_dep.pxd",],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
         libraries=libraries,

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ ext_modules = [
     ),
     Extension(
         "ucp._libs.core",
-        sources=["ucp/_libs/core.pyx", "ucp/_libs/src/c_util.c",],
-        depends=["ucp/_libs/src/c_util.h", "ucp/_libs/core_dep.pxd",],
+        sources=["ucp/_libs/core.pyx", "ucp/_libs/src/c_util.c"],
+        depends=["ucp/_libs/src/c_util.h", "ucp/_libs/core_dep.pxd"],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
         libraries=libraries,

--- a/tests/test_topological_distance.py
+++ b/tests/test_topological_distance.py
@@ -1,0 +1,43 @@
+import pytest
+import os
+import pynvml
+
+from ucp._libs.topological_distance import TopologicalDistance
+
+
+def test_topological_distance_dgx():
+    if not os.path.isfile("/etc/dgx-release"):
+        pytest.skip("This test can only be executed on an NVIDIA DGX Server")
+
+    dgx_server = None
+    for line in open("/etc/dgx-release"):
+        if line.startswith("DGX_PLATFORM"):
+            if "DGX Server for DGX-1" in line:
+                dgx_server = 1
+            elif "DGX Server for DGX-2" in line:
+                dgx_server = 2
+            break
+
+    pynvml.nvmlInit()
+    dev_count = pynvml.nvmlDeviceGetCount()
+
+    dgx_network = ["ib" + str(i // 2) for i in range(dev_count)]
+    if dgx_server == 1:
+        dgx_openfabrics = ["mlx5_0", "mlx5_0", "mlx5_1", "mlx5_1",
+                           "mlx5_2", "mlx5_2", "mlx5_3", "mlx5_3"]
+    elif dgx_server == 2:
+        dgx_openfabrics = ["mlx5_0", "mlx5_0", "mlx5_1", "mlx5_1",
+                           "mlx5_2", "mlx5_2", "mlx5_3", "mlx5_3",
+                           "mlx5_6", "mlx5_6", "mlx5_7", "mlx5_7",
+                           "mlx5_8", "mlx5_8", "mlx5_9", "mlx5_9"]
+    else:
+        pytest.skip("DGX Server not recognized or not supported")
+
+    td = TopologicalDistance()
+
+    for i in range(dev_count):
+        closest_network = td.get_cuda_distances_from_device_index(i, "network")[0]["name"]
+        closest_openfabrics = td.get_cuda_distances_from_device_index(i, "openfabrics")[0]["name"]
+
+        assert dgx_network[i] == closest_network.decode("utf-8")
+        assert dgx_openfabrics[i] == closest_openfabrics.decode("utf-8")

--- a/tests/test_topological_distance.py
+++ b/tests/test_topological_distance.py
@@ -1,7 +1,7 @@
-import pytest
 import os
-import pynvml
 
+import pynvml
+import pytest
 from ucp._libs.topological_distance import TopologicalDistance
 
 

--- a/tests/test_topological_distance.py
+++ b/tests/test_topological_distance.py
@@ -23,21 +23,47 @@ def test_topological_distance_dgx():
 
     dgx_network = ["ib" + str(i // 2) for i in range(dev_count)]
     if dgx_server == 1:
-        dgx_openfabrics = ["mlx5_0", "mlx5_0", "mlx5_1", "mlx5_1",
-                           "mlx5_2", "mlx5_2", "mlx5_3", "mlx5_3"]
+        dgx_openfabrics = [
+            "mlx5_0",
+            "mlx5_0",
+            "mlx5_1",
+            "mlx5_1",
+            "mlx5_2",
+            "mlx5_2",
+            "mlx5_3",
+            "mlx5_3",
+        ]
     elif dgx_server == 2:
-        dgx_openfabrics = ["mlx5_0", "mlx5_0", "mlx5_1", "mlx5_1",
-                           "mlx5_2", "mlx5_2", "mlx5_3", "mlx5_3",
-                           "mlx5_6", "mlx5_6", "mlx5_7", "mlx5_7",
-                           "mlx5_8", "mlx5_8", "mlx5_9", "mlx5_9"]
+        dgx_openfabrics = [
+            "mlx5_0",
+            "mlx5_0",
+            "mlx5_1",
+            "mlx5_1",
+            "mlx5_2",
+            "mlx5_2",
+            "mlx5_3",
+            "mlx5_3",
+            "mlx5_6",
+            "mlx5_6",
+            "mlx5_7",
+            "mlx5_7",
+            "mlx5_8",
+            "mlx5_8",
+            "mlx5_9",
+            "mlx5_9",
+        ]
     else:
         pytest.skip("DGX Server not recognized or not supported")
 
     td = TopologicalDistance()
 
     for i in range(dev_count):
-        closest_network = td.get_cuda_distances_from_device_index(i, "network")[0]["name"]
-        closest_openfabrics = td.get_cuda_distances_from_device_index(i, "openfabrics")[0]["name"]
+        closest_network = td.get_cuda_distances_from_device_index(i, "network")[0][
+            "name"
+        ]
+        closest_openfabrics = td.get_cuda_distances_from_device_index(i, "openfabrics")[
+            0
+        ]["name"]
 
         assert dgx_network[i] == closest_network.decode("utf-8")
         assert dgx_openfabrics[i] == closest_openfabrics.decode("utf-8")

--- a/tests/test_topological_distance.py
+++ b/tests/test_topological_distance.py
@@ -58,12 +58,8 @@ def test_topological_distance_dgx():
     td = TopologicalDistance()
 
     for i in range(dev_count):
-        closest_network = td.get_cuda_distances_from_device_index(i, "network")[0][
-            "name"
-        ]
-        closest_openfabrics = td.get_cuda_distances_from_device_index(i, "openfabrics")[
-            0
-        ]["name"]
+        closest_network = td.get_cuda_distances_from_device_index(i, "network")
+        closest_openfabrics = td.get_cuda_distances_from_device_index(i, "openfabrics")
 
-        assert dgx_network[i] == closest_network.decode("utf-8")
-        assert dgx_openfabrics[i] == closest_openfabrics.decode("utf-8")
+        assert dgx_network[i] == closest_network[0]["name"]
+        assert dgx_openfabrics[i] == closest_openfabrics[0]["name"]

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -10,7 +10,6 @@ from libc.stdint cimport uint64_t
 import uuid
 import socket
 import logging
-import pynvml
 from core_dep cimport *
 from ..exceptions import (
     UCXError,

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -10,6 +10,7 @@ from libc.stdint cimport uint64_t
 import uuid
 import socket
 import logging
+import pynvml
 from core_dep cimport *
 from ..exceptions import (
     UCXError,

--- a/ucp/_libs/src/topological_distance.c
+++ b/ucp/_libs/src/topological_distance.c
@@ -1,0 +1,188 @@
+#include "topological_distance.h"
+
+int compare_topological_distance_objs(const void *obj1, const void *obj2)
+{
+    topological_distance_objs_t *o1 = (topological_distance_objs_t *)obj1;
+    topological_distance_objs_t *o2 = (topological_distance_objs_t *)obj2;
+    return o1->distance - o2->distance;
+}
+
+hwloc_topology_t initialize_topology(void)
+{
+    hwloc_topology_t topo;
+
+    hwloc_topology_init(&topo);
+
+    hwloc_topology_set_io_types_filter(topo, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
+    hwloc_topology_load(topo);
+
+    return topo;
+}
+
+hwloc_obj_t
+hwloc_get_common_pcidev_ancestor_obj(hwloc_topology_t topology,
+                                     hwloc_obj_t obj1,
+                                     hwloc_obj_t obj2)
+{
+    while(obj1 != obj2) {
+        while(obj1->depth < obj2->depth)
+            obj1 = obj1->parent;
+        while(obj2->depth < obj1->depth)
+            obj2 = obj2->parent;
+        if(obj1 != obj2 && obj1->depth == obj2->depth) {
+            obj1 = obj1->parent;
+            obj2 = obj2->parent;
+        }
+    }
+    return obj1;
+}
+
+void print_obj(hwloc_obj_t obj)
+{
+    char upstream_bridge[65536], downstream_bridge[65536];
+    hwloc_obj_type_snprintf(upstream_bridge, 65536, obj, 1);
+    hwloc_obj_type_snprintf(downstream_bridge, 65536, obj, 1);
+
+    printf("  Name:                %s\n", obj->name);
+    printf("  Depth:               %d\n", obj->depth);
+    printf("  Bridge:\n");
+    printf("    Depth:             %d\n", obj->attr->bridge.depth);
+    printf("    Upstream PCI:\n");
+    printf("      Bus:Dev:         %x:%x\n",
+           obj->attr->bridge.upstream.pci.bus,
+           obj->attr->bridge.upstream.pci.dev);
+    printf("      Vendor ID:       %x\n",
+           obj->attr->bridge.upstream.pci.vendor_id);
+    printf("      Device ID:       %x\n",
+           obj->attr->bridge.upstream.pci.device_id);
+    printf("      Subvendor ID:    %x\n",
+           obj->attr->bridge.upstream.pci.vendor_id);
+    printf("      Subdevice ID:    %x\n",
+           obj->attr->bridge.upstream.pci.device_id);
+    printf("      Subdevice ID:    %x\n",
+           obj->attr->bridge.upstream.pci.device_id);
+    printf("    Upstream Type: %s\n", upstream_bridge);
+    printf("    Downstream PCI:\n");
+    printf("      Domain:          %x\n",
+           obj->attr->bridge.downstream.pci.domain);
+    printf("      Secondary bus:   %x\n",
+           obj->attr->bridge.downstream.pci.secondary_bus);
+    printf("      Subordinate bus: %x\n",
+           obj->attr->bridge.downstream.pci.subordinate_bus);
+    printf("    Downstream Type:   %s\n", downstream_bridge);
+    printf("  PCI:\n");
+    printf("    Bus:Dev:           %x:%x\n",
+           obj->attr->pcidev.bus, obj->attr->pcidev.dev);
+    printf("    Vendor ID:         %x\n", obj->attr->pcidev.vendor_id);
+    printf("    Device ID:         %x\n", obj->attr->pcidev.device_id);
+    printf("    Subvendor ID:      %x\n", obj->attr->pcidev.vendor_id);
+    printf("    Subdevice ID:      %x\n", obj->attr->pcidev.device_id);
+    printf("----------------------------------\n");
+}
+
+void print_topological_distance_objs(const topological_distance_objs_t *objs_dist,
+                                    int n)
+{
+    for(int i = 0; i < n; ++i)
+    {
+        printf("Name: %s\n", objs_dist[i].dst->name);
+        printf("Depth distance: %d\n", objs_dist[i].distance);
+    }
+}
+
+topological_distance_and_name_t *
+get_topological_distance_and_name(const topological_distance_objs_t *objs_dist, int n)
+{
+    topological_distance_and_name_t *ret =
+        malloc(sizeof(topological_distance_and_name_t) * n);
+
+    for(int i = 0; i < n; ++i)
+    {
+        ret[i].distance = objs_dist[i].distance;
+        ret[i].name = objs_dist[i].dst->name;
+    }
+
+    return ret;
+}
+
+hwloc_obj_t get_cuda_pcidev_from_pci_info(hwloc_topology_t topo,
+                                          int domain, int bus, int dev)
+{
+    hwloc_obj_t pcidev = hwloc_get_pcidev_by_busid(topo, domain, bus, dev, 0);
+
+    return pcidev;
+}
+
+#ifdef HAS_CUDA
+hwloc_obj_t get_cuda_pcidev_from_cudevice(hwloc_topology_t topo,
+                                          CUdevice cudev)
+{
+    int domain, bus, dev;
+
+    CHECK_CU_RESULT(cuDeviceGetAttribute(&domain, CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID, cudev));
+    CHECK_CU_RESULT(cuDeviceGetAttribute(&bus, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, cudev));
+    CHECK_CU_RESULT(cuDeviceGetAttribute(&dev, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, cudev));
+
+    return get_cuda_pcidev_by_busid(topo, domain, bus, dev);
+}
+
+hwloc_obj_t get_cuda_pcidev_from_device_index(hwloc_topology_t topo,
+                                              int device_index)
+{
+    CUdevice cudev;
+
+    cuInit(0);
+    CHECK_CU_RESULT(cuDeviceGet(&cudev, device_index));
+
+    return get_cuda_pcidev_from_cudevice(topo, cudev);
+}
+#endif
+
+int count_osdev_objects(hwloc_topology_t topo, hwloc_obj_osdev_type_t type)
+{
+    int count = 0;
+    hwloc_obj_t obj;
+
+    for(obj = hwloc_get_next_osdev(topo, NULL); obj; obj = hwloc_get_next_osdev(topo, obj))
+    {
+        if(obj->attr->osdev.type == type)
+            ++count;
+    }
+
+    return count;
+}
+
+void get_osdev_distance_to_pcidev(topological_distance_objs_t **objs_dist,
+                                  int *objs_dist_count,
+                                  hwloc_topology_t topo, hwloc_obj_t pcidev,
+                                  hwloc_obj_osdev_type_t type)
+{
+    *objs_dist_count = count_osdev_objects(topo, type);
+    *objs_dist = malloc(sizeof(topological_distance_objs_t) * *objs_dist_count);
+
+    hwloc_obj_t obj;
+    int i;
+
+    for(i = 0, obj = hwloc_get_next_osdev(topo, NULL);
+            obj;
+            obj = hwloc_get_next_osdev(topo, obj))
+    {
+        if(obj->attr->osdev.type != type)
+            continue;
+
+        hwloc_obj_t ancestor =
+            hwloc_get_common_pcidev_ancestor_obj(topo, pcidev, obj);
+
+        int distance = (ancestor->attr->bridge.depth - pcidev->attr->bridge.depth);
+        distance = (distance < 0) ? -distance : distance;
+
+        (*objs_dist)[i].distance = distance;
+        (*objs_dist)[i].src = pcidev;
+        (*objs_dist)[i].dst = obj;
+        ++i;
+    }
+
+    qsort(*objs_dist, *objs_dist_count,
+          sizeof(topological_distance_objs_t),
+          compare_topological_distance_objs);
+}

--- a/ucp/_libs/src/topological_distance.c
+++ b/ucp/_libs/src/topological_distance.c
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
 #include "topological_distance.h"
 
 int compare_topological_distance_objs(const void *obj1, const void *obj2)

--- a/ucp/_libs/src/topological_distance.h
+++ b/ucp/_libs/src/topological_distance.h
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
 #include <hwloc.h>
 
 #ifdef HAS_CUDA

--- a/ucp/_libs/src/topological_distance.h
+++ b/ucp/_libs/src/topological_distance.h
@@ -1,0 +1,63 @@
+#include <hwloc.h>
+
+#ifdef HAS_CUDA
+#include <cuda.h>
+
+#define CHECK_CU_RESULT(call) do {                                  \
+    CUresult res = call;                                            \
+    const char *error = NULL;                                       \
+    if (res != CUDA_SUCCESS) {                                      \
+        printf("CUDA failed with error \"%s\" in %s:%d\n",          \
+               cuGetErrorName(res, &error), __FILE__, __LINE__);    \
+        exit(EXIT_FAILURE);                                         \
+    }                                                               \
+} while(0)
+
+#endif
+
+
+typedef struct topological_distance_objs {
+    int distance;
+    hwloc_obj_t src;
+    hwloc_obj_t dst;
+} topological_distance_objs_t;
+
+typedef struct topological_distance_and_name_t {
+    int distance;
+    char *name;
+} topological_distance_and_name_t;
+
+int compare_topological_distance_objs(const void *obj1, const void *obj2);
+
+hwloc_topology_t initialize_topology(void);
+
+hwloc_obj_t
+hwloc_get_common_pcidev_ancestor_obj(hwloc_topology_t topology,
+                                     hwloc_obj_t obj1,
+                                     hwloc_obj_t obj2);
+
+void print_obj(hwloc_obj_t obj);
+
+void print_topological_distance_objs(const topological_distance_objs_t *objs_dist,
+                                    int n);
+
+topological_distance_and_name_t *
+get_topological_distance_and_name(const topological_distance_objs_t *objs_dist, int n);
+
+hwloc_obj_t get_cuda_pcidev_from_pci_info(hwloc_topology_t topo,
+                                          int domain, int bus, int dev);
+
+#ifdef HAS_CUDA
+hwloc_obj_t get_cuda_pcidev_from_cudevice(hwloc_topology_t topo,
+                                          CUdevice cudev);
+
+hwloc_obj_t get_cuda_pcidev_from_device_index(hwloc_topology_t topo,
+                                              int device_index);
+#endif
+
+int count_osdev_objects(hwloc_topology_t topo, hwloc_obj_osdev_type_t type);
+
+void get_osdev_distance_to_pcidev(topological_distance_objs_t **objs_dist,
+                                  int *objs_dist_count,
+                                  hwloc_topology_t topo, hwloc_obj_t pcidev,
+                                  hwloc_obj_osdev_type_t type);

--- a/ucp/_libs/src/topological_distance_sample.c
+++ b/ucp/_libs/src/topological_distance_sample.c
@@ -1,0 +1,26 @@
+#include "topological_distance.h"
+
+int main()
+{
+    hwloc_topology_t topo = initialize_topology();
+
+    hwloc_obj_t cuda_pcidev = get_cuda_pcidev_from_device_index(topo, 0);
+    print_obj(cuda_pcidev);
+
+    topological_distance_objs_t_t *network_dist, *openfabrics_dist;
+    int network_dist_count, openfabrics_dist_count;
+    get_osdev_distance_to_pcidev(&network_dist, &network_dist_count, topo, cuda_pcidev,
+                                 HWLOC_OBJ_OSDEV_NETWORK);
+    get_osdev_distance_to_pcidev(&openfabrics_dist, &openfabrics_dist_count, topo, cuda_pcidev,
+                                 HWLOC_OBJ_OSDEV_OPENFABRICS);
+
+    print_topological_distance_objs_t(network_dist, network_dist_count);
+    print_topological_distance_objs_t(openfabrics_dist, openfabrics_dist_count);
+
+    free(network_dist);
+    free(openfabrics_dist);
+
+    hwloc_topology_destroy(topo);
+
+    return 0;
+}

--- a/ucp/_libs/src/topological_distance_sample.c
+++ b/ucp/_libs/src/topological_distance_sample.c
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * See file LICENSE for terms.
+ */
+
 #include "topological_distance.h"
 
 int main()

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -30,7 +30,7 @@ cdef class TopologicalDistance:
         hwloc_topology_destroy(topo)
 
     def get_cuda_distances_from_pci_info(self, domain, bus, device,
-            device_type="openfabrics"):
+                                         device_type="openfabrics"):
         """ Find network or openfabrics devices closest to CUDA device at
         domain:bus:device address.
 
@@ -77,28 +77,29 @@ cdef class TopologicalDistance:
 
         cdef hwloc_obj_t cuda_pcidev
         cuda_pcidev = <hwloc_obj_t> get_cuda_pcidev_from_pci_info(
-                <hwloc_topology_t> self.topo, domain, bus, device
-            )
+            <hwloc_topology_t> self.topo, domain, bus, device
+        )
 
         cdef topological_distance_objs_t *dev_dist
         cdef int dev_count
         get_osdev_distance_to_pcidev(&dev_dist, &dev_count, self.topo, cuda_pcidev,
                                      hwloc_osdev_type)
 
-        cdef topological_distance_and_name_t *dist_name;
+        cdef topological_distance_and_name_t *dist_name
         dist_name = <topological_distance_and_name_t *> (
-                get_topological_distance_and_name(dev_dist, dev_count)
-            )
+            get_topological_distance_and_name(dev_dist, dev_count)
+        )
 
         ret = [{"distance": <int>(&dist_name[i]).distance,
                "name": <char *>(&dist_name[i]).name} for i in range(dev_count)]
 
-        free(dev_dist);
-        free(dist_name);
+        free(dev_dist)
+        free(dist_name)
 
         return ret
 
-    def get_cuda_distances_from_device_index(self, cuda_device_index, device_type="openfabrics"):
+    def get_cuda_distances_from_device_index(self, cuda_device_index,
+                                             device_type="openfabrics"):
         """ Find network or openfabrics devices closest to CUDA device of given index.
 
         Parameters
@@ -132,5 +133,5 @@ cdef class TopologicalDistance:
         pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
 
         return self.get_cuda_distances_from_pci_info(
-                pci_info.domain, pci_info.bus, pci_info.device, device_type
-            )
+            pci_info.domain, pci_info.bus, pci_info.device, device_type
+        )

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -11,13 +11,65 @@ cdef class TopologicalDistance:
         hwloc_topology_t topo
 
     def __init__(self):
+        """ Find topological distance between devices
+
+        To ensure best communication performance, it's important to identify devices
+        close to each other, allowing less communication overhead. Consider a system
+        with multiple InfiniBand interfaces, to maximize performance, each GPU should
+        choose the interface physically closer, thus allowing data to run through a
+        shortest path.
+
+        Currently, this class only supports finding the PCI network and openfabrics
+        (e.g., InfiniBand, aka. 'mlx5' or 'ib') interfaces closest to a NVIDIA GPU.
+
+        """
         self.topo = <hwloc_topology_t> initialize_topology()
 
     def __del__(self):
         cdef hwloc_topology_t topo = <hwloc_topology_t> self.topo
         hwloc_topology_destroy(topo)
 
-    def get_cuda_distances_from_pci_info(self, domain, bus, device, device_type="openfabrics"):
+    def get_cuda_distances_from_pci_info(self, domain, bus, device,
+            device_type="openfabrics"):
+        """ Find network or openfabrics devices closest to CUDA device at
+        domain:bus:device address.
+
+        Parameters
+        ----------
+        domain: int
+            PCI domain index of CUDA device
+        bus: int
+            PCI bus index of CUDA device
+        device: int
+            PCI device index of CUDA device
+        device_type: string
+            Type of device to find distance, currently supported types are "network"
+            and "openfabrics"
+
+        Returns
+        -------
+        List of distances and names to the CUDA device, sorted in ascending order of
+        distances (closest first). Note that there may be multiple devices with equal
+        distance, in such cases there's no particular ordering.
+
+        Example
+        -------
+        >>> import pynvml
+        >>> from ucp._libs.topological_distance import TopologicalDistance
+        >>> pynvml.nvmlInit()
+        >>> handle = pynvmlDeviceGetHandleByIndex(0)
+        >>> handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        >>> pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
+        >>> domain, bus, device = pci_info.domain, pci_info.bus, pci_info.device
+        >>> td = TopologicalDistance()
+        >>> td.get_cuda_distances_from_device_index(domain, bus, device, "network")
+        [{'distance': 2, 'name': b'ib0'}, {'distance': 4, 'name': b'enp1s0f0'},
+         {'distance': 4, 'name': b'enp1s0f1'}, {'distance': 4, 'name': b'ib1'},
+         {'distance': 4, 'name': b'ib2'}, {'distance': 4, 'name': b'ib3'}]
+        >>> td.get_cuda_distances_from_device_index(domain, bus, device, "openfabrics")
+        [{'distance': 2, 'name': b'mlx5_0'}, {'distance': 4, 'name': b'mlx5_1'},
+         {'distance': 4, 'name': b'mlx5_2'}, {'distance': 4, 'name': b'mlx5_3'}]
+        """
         if device_type == "openfabrics":
             hwloc_osdev_type = HWLOC_OBJ_OSDEV_OPENFABRICS
         if device_type == "network":
@@ -47,6 +99,34 @@ cdef class TopologicalDistance:
         return ret
 
     def get_cuda_distances_from_device_index(self, cuda_device_index, device_type="openfabrics"):
+        """ Find network or openfabrics devices closest to CUDA device of given index.
+
+        Parameters
+        ----------
+        cuda_device_index: int
+            Index of the CUDA device
+        device_type: string
+            Type of device to find distance, currently supported types are "network"
+            and "openfabrics"
+
+        Returns
+        -------
+        List of distances and names to the CUDA device, sorted in ascending order of
+        distances (closest first). Note that there may be multiple devices with equal
+        distance, in such cases there's no particular ordering.
+
+        Example
+        -------
+        >>> from ucp._libs.topological_distance import TopologicalDistance
+        >>> td = TopologicalDistance()
+        >>> td.get_cuda_distances_from_device_index(0, "network")
+        [{'distance': 2, 'name': b'ib0'}, {'distance': 4, 'name': b'enp1s0f0'},
+         {'distance': 4, 'name': b'enp1s0f1'}, {'distance': 4, 'name': b'ib1'},
+         {'distance': 4, 'name': b'ib2'}, {'distance': 4, 'name': b'ib3'}]
+        >>> td.get_cuda_distances_from_device_index(0, "openfabrics")
+        [{'distance': 2, 'name': b'mlx5_0'}, {'distance': 4, 'name': b'mlx5_1'},
+         {'distance': 4, 'name': b'mlx5_2'}, {'distance': 4, 'name': b'mlx5_3'}]
+        """
         pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(cuda_device_index)
         pci_info = pynvml.nvmlDeviceGetPciInfo(handle)

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -63,14 +63,14 @@ cdef class TopologicalDistance:
         >>> domain, bus, device = pci_info.domain, pci_info.bus, pci_info.device
         >>> td = TopologicalDistance()
         >>> td.get_cuda_distances_from_device_index(domain, bus, device, "network")
-        [{'distance': 2, 'name': b'ib0'}, {'distance': 4, 'name': b'enp1s0f0'},
-         {'distance': 4, 'name': b'enp1s0f1'}, {'distance': 4, 'name': b'ib1'},
-         {'distance': 4, 'name': b'ib2'}, {'distance': 4, 'name': b'ib3'}]
+        [{'distance': 2, 'name': 'ib0'}, {'distance': 4, 'name': 'enp1s0f0'},
+         {'distance': 4, 'name': 'enp1s0f1'}, {'distance': 4, 'name': 'ib1'},
+         {'distance': 4, 'name': 'ib2'}, {'distance': 4, 'name': 'ib3'}]
         >>> td.get_cuda_distances_from_device_index(domain, bus, device, "openfabrics")
-        [{'distance': 2, 'name': b'mlx5_0'}, {'distance': 4, 'name': b'mlx5_1'},
-         {'distance': 4, 'name': b'mlx5_2'}, {'distance': 4, 'name': b'mlx5_3'}]
+        [{'distance': 2, 'name': 'mlx5_0'}, {'distance': 4, 'name': 'mlx5_1'},
+         {'distance': 4, 'name': 'mlx5_2'}, {'distance': 4, 'name': 'mlx5_3'}]
         >>> td.get_cuda_distances_from_device_index(domain, bus, device, "block")
-        [{'distance': 4, 'name': b'sdb'}, {'distance': 4, 'name': b'sda'}]
+        [{'distance': 4, 'name': 'sdb'}, {'distance': 4, 'name': 'sda'}]
         """
         if device_type == "openfabrics":
             hwloc_osdev_type = HWLOC_OBJ_OSDEV_OPENFABRICS
@@ -95,7 +95,8 @@ cdef class TopologicalDistance:
         )
 
         ret = [{"distance": <int>(&dist_name[i]).distance,
-               "name": <char *>(&dist_name[i]).name} for i in range(dev_count)]
+               "name": (<char *>(&dist_name[i]).name).decode("utf-8")}
+               for i in range(dev_count)]
 
         free(dev_dist)
         free(dist_name)
@@ -125,14 +126,14 @@ cdef class TopologicalDistance:
         >>> from ucp._libs.topological_distance import TopologicalDistance
         >>> td = TopologicalDistance()
         >>> td.get_cuda_distances_from_device_index(0, "network")
-        [{'distance': 2, 'name': b'ib0'}, {'distance': 4, 'name': b'enp1s0f0'},
-         {'distance': 4, 'name': b'enp1s0f1'}, {'distance': 4, 'name': b'ib1'},
-         {'distance': 4, 'name': b'ib2'}, {'distance': 4, 'name': b'ib3'}]
+        [{'distance': 2, 'name': 'ib0'}, {'distance': 4, 'name': 'enp1s0f0'},
+         {'distance': 4, 'name': 'enp1s0f1'}, {'distance': 4, 'name': 'ib1'},
+         {'distance': 4, 'name': 'ib2'}, {'distance': 4, 'name': 'ib3'}]
         >>> td.get_cuda_distances_from_device_index(0, "openfabrics")
-        [{'distance': 2, 'name': b'mlx5_0'}, {'distance': 4, 'name': b'mlx5_1'},
-         {'distance': 4, 'name': b'mlx5_2'}, {'distance': 4, 'name': b'mlx5_3'}]
+        [{'distance': 2, 'name': 'mlx5_0'}, {'distance': 4, 'name': 'mlx5_1'},
+         {'distance': 4, 'name': 'mlx5_2'}, {'distance': 4, 'name': 'mlx5_3'}]
         >>> td.get_cuda_distances_from_device_index(0, "block")
-        [{'distance': 4, 'name': b'sdb'}, {'distance': 4, 'name': b'sda'}]
+        [{'distance': 4, 'name': 'sdb'}, {'distance': 4, 'name': 'sda'}]
         """
         pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(cuda_device_index)

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -1,0 +1,56 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+# cython: language_level=3
+
+import pynvml
+from topological_distance_dep cimport *
+
+
+cdef class TopologicalDistance:
+    cdef:
+        hwloc_topology_t topo
+
+    def __init__(self):
+        self.topo = <hwloc_topology_t> initialize_topology()
+
+    def __del__(self):
+        cdef hwloc_topology_t topo = <hwloc_topology_t> self.topo
+        hwloc_topology_destroy(topo)
+
+    def get_cuda_distances_from_pci_info(self, domain, bus, device, device_type="openfabrics"):
+        if device_type == "openfabrics":
+            hwloc_osdev_type = HWLOC_OBJ_OSDEV_OPENFABRICS
+        if device_type == "network":
+            hwloc_osdev_type = HWLOC_OBJ_OSDEV_NETWORK
+
+        cdef hwloc_obj_t cuda_pcidev
+        cuda_pcidev = <hwloc_obj_t> get_cuda_pcidev_from_pci_info(
+                <hwloc_topology_t> self.topo, domain, bus, device
+            )
+
+        cdef topological_distance_objs_t *dev_dist
+        cdef int dev_count
+        get_osdev_distance_to_pcidev(&dev_dist, &dev_count, self.topo, cuda_pcidev,
+                                     hwloc_osdev_type)
+
+        cdef topological_distance_and_name_t *dist_name;
+        dist_name = <topological_distance_and_name_t *> (
+                get_topological_distance_and_name(dev_dist, dev_count)
+            )
+
+        ret = [{"distance": <int>(&dist_name[i]).distance,
+               "name": <char *>(&dist_name[i]).name} for i in range(dev_count)]
+
+        free(dev_dist);
+        free(dist_name);
+
+        return ret
+
+    def get_cuda_distances_from_device_index(self, cuda_device_index, device_type="openfabrics"):
+        pynvml.nvmlInit()
+        handle = pynvml.nvmlDeviceGetHandleByIndex(cuda_device_index)
+        pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
+
+        return self.get_cuda_distances_from_pci_info(
+                pci_info.domain, pci_info.bus, pci_info.device, device_type
+            )

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -43,8 +43,8 @@ cdef class TopologicalDistance:
         device: int
             PCI device index of CUDA device
         device_type: string
-            Type of device to find distance, currently supported types are "network"
-            and "openfabrics"
+            Type of device to find distance, currently supported types are "block",
+            "network" and "openfabrics"
 
         Returns
         -------
@@ -69,11 +69,15 @@ cdef class TopologicalDistance:
         >>> td.get_cuda_distances_from_device_index(domain, bus, device, "openfabrics")
         [{'distance': 2, 'name': b'mlx5_0'}, {'distance': 4, 'name': b'mlx5_1'},
          {'distance': 4, 'name': b'mlx5_2'}, {'distance': 4, 'name': b'mlx5_3'}]
+        >>> td.get_cuda_distances_from_device_index(domain, bus, device, "block")
+        [{'distance': 4, 'name': b'sdb'}, {'distance': 4, 'name': b'sda'}]
         """
         if device_type == "openfabrics":
             hwloc_osdev_type = HWLOC_OBJ_OSDEV_OPENFABRICS
-        if device_type == "network":
+        elif device_type == "network":
             hwloc_osdev_type = HWLOC_OBJ_OSDEV_NETWORK
+        elif device_type == "block":
+            hwloc_osdev_type = HWLOC_OBJ_OSDEV_BLOCK
 
         cdef hwloc_obj_t cuda_pcidev
         cuda_pcidev = <hwloc_obj_t> get_cuda_pcidev_from_pci_info(
@@ -107,8 +111,8 @@ cdef class TopologicalDistance:
         cuda_device_index: int
             Index of the CUDA device
         device_type: string
-            Type of device to find distance, currently supported types are "network"
-            and "openfabrics"
+            Type of device to find distance, currently supported types are "block",
+            "network" and "openfabrics"
 
         Returns
         -------
@@ -127,6 +131,8 @@ cdef class TopologicalDistance:
         >>> td.get_cuda_distances_from_device_index(0, "openfabrics")
         [{'distance': 2, 'name': b'mlx5_0'}, {'distance': 4, 'name': b'mlx5_1'},
          {'distance': 4, 'name': b'mlx5_2'}, {'distance': 4, 'name': b'mlx5_3'}]
+        >>> td.get_cuda_distances_from_device_index(0, "block")
+        [{'distance': 4, 'name': b'sdb'}, {'distance': 4, 'name': b'sda'}]
         """
         pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(cuda_device_index)

--- a/ucp/_libs/topological_distance_dep.pxd
+++ b/ucp/_libs/topological_distance_dep.pxd
@@ -1,0 +1,63 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+# cython: language_level=3
+
+#from libc.stdint cimport *
+from libc.stdlib cimport free
+
+
+cdef extern from "hwloc.h":
+    ctypedef struct hwloc_obj_t:
+        pass
+
+    ctypedef struct hwloc_topology_t:
+        pass
+
+    ctypedef enum hwloc_obj_osdev_type_t:
+        pass
+
+    hwloc_obj_osdev_type_t HWLOC_OBJ_OSDEV_BLOCK
+    hwloc_obj_osdev_type_t HWLOC_OBJ_OSDEV_GPU
+    hwloc_obj_osdev_type_t HWLOC_OBJ_OSDEV_NETWORK
+    hwloc_obj_osdev_type_t HWLOC_OBJ_OSDEV_OPENFABRICS
+    hwloc_obj_osdev_type_t HWLOC_OBJ_OSDEV_DMA
+    hwloc_obj_osdev_type_t HWLOC_OBJ_OSDEV_COPROC
+
+    void hwloc_topology_destroy(hwloc_topology_t topology)
+
+
+cdef extern from "src/topological_distance.h":
+    ctypedef struct topological_distance_objs_t:
+        pass
+
+    ctypedef struct topological_distance_and_name_t:
+        int distance
+        char name
+
+    int compare_topological_distance_objs_t(const void *obj1, const void *obj2)
+
+    hwloc_topology_t initialize_topology()
+
+    hwloc_obj_t hwloc_get_common_pcidev_ancestor_obj(
+            hwloc_topology_t topology,
+            hwloc_obj_t obj1, hwloc_obj_t obj2
+        )
+
+    void print_obj(hwloc_obj_t obj)
+
+    void print_topological_distance_objs(const topological_distance_objs_t *objs_dist,
+                                         int n)
+
+    topological_distance_and_name_t * get_topological_distance_and_name(
+            const topological_distance_objs_t *objs_dist, int n
+        )
+
+    hwloc_obj_t get_cuda_pcidev_from_pci_info(hwloc_topology_t topo,
+                                              int domain, int bus, int dev)
+
+    int count_osdev_objects(hwloc_topology_t topo, hwloc_obj_osdev_type_t type)
+
+    void get_osdev_distance_to_pcidev(topological_distance_objs_t **objs_dist,
+                                      int *objs_dist_count,
+                                      hwloc_topology_t topo, hwloc_obj_t pcidev,
+                                      hwloc_obj_osdev_type_t type)

--- a/ucp/_libs/topological_distance_dep.pxd
+++ b/ucp/_libs/topological_distance_dep.pxd
@@ -2,7 +2,6 @@
 # See file LICENSE for terms.
 # cython: language_level=3
 
-#from libc.stdint cimport *
 from libc.stdlib cimport free
 
 
@@ -39,9 +38,9 @@ cdef extern from "src/topological_distance.h":
     hwloc_topology_t initialize_topology()
 
     hwloc_obj_t hwloc_get_common_pcidev_ancestor_obj(
-            hwloc_topology_t topology,
-            hwloc_obj_t obj1, hwloc_obj_t obj2
-        )
+        hwloc_topology_t topology,
+        hwloc_obj_t obj1, hwloc_obj_t obj2
+    )
 
     void print_obj(hwloc_obj_t obj)
 
@@ -49,8 +48,8 @@ cdef extern from "src/topological_distance.h":
                                          int n)
 
     topological_distance_and_name_t * get_topological_distance_and_name(
-            const topological_distance_objs_t *objs_dist, int n
-        )
+        const topological_distance_objs_t *objs_dist, int n
+    )
 
     hwloc_obj_t get_cuda_pcidev_from_pci_info(hwloc_topology_t topo,
                                               int domain, int bus, int dev)


### PR DESCRIPTION
This will help applications such as dask-cuda identify the closest InfiniBand device to a GPU.

Note that I only added one test and that requires either to be running on a DGX-1 or DGX-2. Since these changes are very much hardware dependent, I don't know if we could have a test to run on generic hardware. Ideas for a test like that are welcome.