### PR TITLE
Setting UCX_SOCKADDR_TLS_PRIORITY=all as default

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -28,6 +28,12 @@ if "UCX_CUDA_IPC_CACHE" not in os.environ:
     )
     os.environ["UCX_CUDA_IPC_CACHE"] = "n"
 
+if "UCX_SOCKADDR_TLS_PRIORITY" not in os.environ:
+    logger.debug(
+        "Setting env UCX_SOCKADDR_TLS_PRIORITY=sockcm, which is required to connect multiple nodes"
+    )
+    os.environ["UCX_SOCKADDR_TLS_PRIORITY"] = "sockcm"
+
 # Set the root logger before importing modules that use it
 _level_enum = logging.getLevelName(os.getenv("UCXPY_LOG_LEVEL", "WARNING"))
 logging.basicConfig(level=_level_enum, format="%(levelname)s %(message)s")

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -30,10 +30,10 @@ if "UCX_CUDA_IPC_CACHE" not in os.environ:
 
 if "UCX_SOCKADDR_TLS_PRIORITY" not in os.environ:
     logger.debug(
-        "Setting env UCX_SOCKADDR_TLS_PRIORITY=sockcm, "
+        "Setting env UCX_SOCKADDR_TLS_PRIORITY=all, "
         "which is required to connect multiple nodes"
     )
-    os.environ["UCX_SOCKADDR_TLS_PRIORITY"] = "sockcm"
+    os.environ["UCX_SOCKADDR_TLS_PRIORITY"] = "all"
 
 # Set the root logger before importing modules that use it
 _level_enum = logging.getLevelName(os.getenv("UCXPY_LOG_LEVEL", "WARNING"))

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -30,7 +30,8 @@ if "UCX_CUDA_IPC_CACHE" not in os.environ:
 
 if "UCX_SOCKADDR_TLS_PRIORITY" not in os.environ:
     logger.debug(
-        "Setting env UCX_SOCKADDR_TLS_PRIORITY=sockcm, which is required to connect multiple nodes"
+        "Setting env UCX_SOCKADDR_TLS_PRIORITY=sockcm, "
+        "which is required to connect multiple nodes"
     )
     os.environ["UCX_SOCKADDR_TLS_PRIORITY"] = "sockcm"
 


### PR DESCRIPTION
As far as I can see, we always have to set `UCX_SOCKADDR_TLS_PRIORITY=sockcm` in order to run on multiple nodes. And since there isn't any drawback?, let's set it as default.

Notice, I am setting the option as an environment variable. It is possible to set it as a UCX option but I think this is more readable.