### PR TITLE
Use rapidsai Conda packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with either `9.2`, `10.0`, or `10.1`. Also replace `<processor type>`
 with `cpu` or `gpu`.
 
 ```bash
-conda create -n ucx -c conda-forge -c conda-forge/label/rc_ucx cudatoolkit=<CUDA version> ucx-proc=*=<processor type> ucx ucx-py python=3.7
+conda create -n ucx -c conda-forge -c rapidsai cudatoolkit=<CUDA version> ucx-proc=*=<processor type> ucx ucx-py python=3.7
 ```
 
 The UCX recipe can be found [here](https://github.com/conda-forge/ucx-split-feedstock/tree/rc/recipe).

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -58,9 +58,6 @@ conda install -c conda-forge "async_generator" "automake" "libtool" \
                               "pytest" "pkg-config" "pytest-asyncio" \
                               "pynvml" "libhwloc"
 
-# install ucx from conda-forge rc channel
-# conda install -c conda-forge/label/rc_ucx "ucx-proc=*=gpu" "ucx"
-
 # Install the master version of dask and distributed
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,6 +18,8 @@ Without GPU support:
     conda create -n ucx -c conda-forge -c rapidsai \
       ucx-proc=*=cpu ucx ucx-py python=3.7
 
+Note: These use UCX's ``v1.7.x`` branch.
+
 Source
 ------
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -8,14 +8,14 @@ With GPU support:
 
 ::
 
-    conda create -n ucx -c conda-forge -c conda-forge/label/rc_ucx \
+    conda create -n ucx -c conda-forge -c rapidsai \
       cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.7
 
 Without GPU support:
 
 ::
 
-    conda create -n ucx -c conda-forge -c conda-forge/label/rc_ucx \
+    conda create -n ucx -c conda-forge -c rapidsai \
       ucx-proc=*=cpu ucx ucx-py python=3.7
 
 Source

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -9,14 +9,14 @@ With GPU support:
 
 ::
 
-    conda create -n ucx -c conda-forge -c conda-forge/label/rc_ucx \
+    conda create -n ucx -c conda-forge -c rapidsai \
       cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.7
 
 Without GPU support:
 
 ::
 
-    conda create -n ucx -c conda-forge -c conda-forge/label/rc_ucx \
+    conda create -n ucx -c conda-forge -c rapidsai \
       ucx-proc=*=cpu ucx ucx-py python=3.7
 
 For a more detailed guide on installation options please refer to the :doc:`install` page.


### PR DESCRIPTION
Updates the docs to point to the `rapidsai` channel for packages.