### PR TITLE
Move install instructions out of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,100 +2,13 @@
 
 # Python Bindings for UCX
 
-## Installing preliminary Conda packages
+## Installing
 
-Some preliminary Conda packages can be installed as so. Replace `<CUDA version>`
-with either `9.2`, `10.0`, or `10.1`. Also replace `<processor type>`
-with `cpu` or `gpu`.
+Users can either [install with Conda]( https://ucx-py.readthedocs.io/en/latest/install.html#conda ) or [build from source]( https://ucx-py.readthedocs.io/en/latest/install.html#source ).
 
-```bash
-conda create -n ucx -c conda-forge -c conda-forge/label/rc_ucx cudatoolkit=<CUDA version> ucx-proc=*=<processor type> ucx ucx-py python=3.7
-```
+## Testing
 
-The UCX recipe can be found [here](https://github.com/conda-forge/ucx-split-feedstock/tree/rc/recipe).
-
-Note: These packages depend on the following system libraries being present:
-`libibverbs`, `librdmacm`, and `libnuma` (`numactl` on Enterprise Linux). So
-please install these with your Linux system's package manager.
-
-## Build from source
-
-The following instructions assume you'll be using `ucx-py` on a CUDA enabled system. The instructions assume you're using CUDA 9.2 for unspecific reasons. Change the `CUDA_HOME` environment variable, and the environment created and used by `conda` to `cudf_dev_10.0.yml` in order to support CUDA 10.
-
-### Using Dask, cuDF, and UCX together
-
-These three libraries provide a powerful combination of HPC message passing
-tools. Using them involves using the correct dependencies, in the correct
-order:
-
-### NVIDIA repositories
-
-#### cuDF
-
-```bash
-git clone git@github.com:rapidsai/cudf.git
-cd cudf
-export CUDA_HOME=/usr/local/cuda-9.2
-export CUDACXX=$CUDA_HOME/bin/nvcc
-conda env create --name cudf_dev_92 --file conda/environments/cudf_dev_cuda9.2.yml
-conda activate cudf_dev_92
-git submodule update --init --remote --recursive
-./build.sh
-cd ..
-```
-
-#### Dask
-
-```bash
-git clone https://github.com/dask/dask.git
-cd dask
-pip install -e .
-cd ..
-```
-
-#### Dask distributed
-
-```bash
-git clone https://github.com/dask/distributed.git
-cd distributed
-pip install -e .
-cd ..
-```
-
-#### conda-forge Dependencies
-
-```bash
-conda install -c conda-forge automake make cmake libtool pkg-config pytest-asyncio cython cupy distributed setuptools
-```
-
-#### dask-cuda
-
-```bash
-conda install -c rapidsai-nightly -c nvidia -c conda-forge dask-cuda
-```
-
-#### UCX
-
-```bash
-git clone https://github.com/openucx/ucx
-cd ucx
-./autogen.sh
-mkdir build
-cd build
-../configure --prefix=$CONDA_PREFIX --enable-debug --with-cuda=$CUDA_HOME --enable-mt CPPFLAGS="-I//$CUDA_HOME/include"
-make -j install
-```
-
-#### ucx-py
-
-```bash
-git clone git@github.com:rapidsai/ucx-py.git
-cd ucx-py
-python setup.py build_ext --inplace
-python -m pip install -e .
-```
-
-You should be done! Test the result of your build with
+To run ucx-py's tests, just use ``pytest``:
 
 ```bash
 pytest -v

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -56,7 +56,8 @@ RAPIDS Dependencies
 
 ::
 
-    conda install -c rapidsai-nightly -c nvidia -c conda-forge dask-cuda rmm
+    conda install -n ucx -c rapidsai-nightly -c nvidia -c conda-forge \
+        dask-cuda rmm
 
 UCX
 ~~~

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -54,7 +54,7 @@ Test Dependencies
 
 ::
 
-    conda install -n ucx -c rapidsai-nightly -c nvidia -c conda-forge \
+    conda install -n ucx -c rapidsai -c nvidia -c conda-forge \
         pytest pytest-asyncio \
         cupy numba>=0.46 rmm \
         distributed

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -6,7 +6,9 @@ Prerequisites
 
 UCX depends on the following system libraries being present: ``libibverbs``,
 ``librdmacm``, and ``libnuma`` (``numactl`` on Enterprise Linux).  Please
-install these with your Linux system's package manager.
+install these with your Linux system's package manager. When building from
+source you will also need the ``*-dev`` (``*-devel`` on Enterprise Linux)
+packages as well.
 
 Conda
 -----

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -77,7 +77,7 @@ UCX
     ../contrib/configure-devel --prefix=$CONDA_PREFIX --with-cuda=$CUDA_HOME --enable-mt CPPFLAGS="-I/$CUDA_HOME/include"
     make -j install
 
-UCX-PY
+UCX-Py
 ~~~~~~
 
 ::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -44,7 +44,7 @@ conda-forge Dependencies
 
 ::
 
-    conda create -n ucx-foo -c conda-forge \
+    conda create -n ucx -c conda-forge \
         automake make cmake libtool pkg-config \
         libhwloc \
         python=3.7 setuptools cython cupy distributed numba>=0.46 \

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -43,6 +43,13 @@ conda-forge Dependencies
 
     conda install -c conda-forge automake make cmake libtool pkg-config pytest-asyncio cython cupy distributed setuptools
 
+dask-cuda
+~~~~~~~~~
+
+::
+
+    conda install -c rapidsai-nightly -c nvidia -c conda-forge dask-cuda
+
 UCX
 ~~~
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -38,7 +38,8 @@ The following instructions assume you'll be using ucx-py on a CUDA enabled syste
 
 
 
-1) Install UCX
+UCX
+~~~
 
 ::
 
@@ -53,7 +54,8 @@ The following instructions assume you'll be using ucx-py on a CUDA enabled syste
     ../contrib/configure-devel --prefix=$CONDA_PREFIX --with-cuda=$CUDA_HOME --enable-mt CPPFLAGS="-I/$CUDA_HOME/include"
     make -j install
 
-2) Install UCX-PY
+UCX-PY
+~~~~~~
 
 ::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -50,12 +50,12 @@ conda-forge Dependencies
         pytest pytest-asyncio \
         ipython
 
-dask-cuda
-~~~~~~~~~
+RAPIDS Dependencies
+~~~~~~~~~~~~~~~~~~~
 
 ::
 
-    conda install -c rapidsai-nightly -c nvidia -c conda-forge dask-cuda
+    conda install -c rapidsai-nightly -c nvidia -c conda-forge dask-cuda rmm
 
 UCX
 ~~~

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -39,24 +39,25 @@ Source
 The following instructions assume you'll be using ucx-py on a CUDA enabled system and is in a `Conda environment <https://docs.conda.io/projects/conda/en/latest/>`_.
 
 
-conda-forge Dependencies
-~~~~~~~~~~~~~~~~~~~~~~~~
+Build Dependencies
+~~~~~~~~~~~~~~~~~~
 
 ::
 
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
         libhwloc \
-        python=3.7 setuptools cython cupy distributed numba>=0.46 \
-        pytest pytest-asyncio
+        python=3.7 setuptools cython
 
-RAPIDS Dependencies
-~~~~~~~~~~~~~~~~~~~
+Test Dependencies
+~~~~~~~~~~~~~~~~~
 
 ::
 
     conda install -n ucx -c rapidsai-nightly -c nvidia -c conda-forge \
-        dask-cuda rmm
+        pytest pytest-asyncio \
+        cupy numba>=0.46 rmm \
+        distributed
 
 UCX
 ~~~

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -57,6 +57,7 @@ UCX
 
     git clone https://github.com/openucx/ucx
     cd ucx
+    git checkout v1.7.x
     ./autogen.sh
     mkdir build
     cd build

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -64,6 +64,7 @@ UCX
 
 ::
 
+    conda activate ucx
     git clone https://github.com/openucx/ucx
     cd ucx
     git checkout v1.7.x
@@ -81,6 +82,7 @@ UCX-PY
 
 ::
 
+    conda activate ucx
     git clone git@github.com:rapidsai/ucx-py.git
     cd ucx-py
     python setup.py build_ext --inplace

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,6 +4,9 @@ Install
 Conda
 -----
 
+Some preliminary Conda packages can be installed as so. Replace
+``<CUDA version>`` with either ``9.2``, ``10.0``, or ``10.1``.
+
 With GPU support:
 
 ::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -36,7 +36,12 @@ Source
 The following instructions assume you'll be using ucx-py on a CUDA enabled system and is in a `Conda environment <https://docs.conda.io/projects/conda/en/latest/>`_.
 
 
+conda-forge Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~
 
+::
+
+    conda install -c conda-forge automake make cmake libtool pkg-config pytest-asyncio cython cupy distributed setuptools
 
 UCX
 ~~~

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -14,7 +14,8 @@ Conda
 -----
 
 Some preliminary Conda packages can be installed as so. Replace
-``<CUDA version>`` with either ``9.2``, ``10.0``, or ``10.1``.
+``<CUDA version>`` with either ``9.2``, ``10.0``, or ``10.1``. These are
+available both on ``rapidsai`` and ``rapidsai-nightly``.
 
 With GPU support:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,6 +1,13 @@
 Install
 =======
 
+Prerequisites
+-------------
+
+UCX depends on the following system libraries being present: ``libibverbs``,
+``librdmacm``, and ``libnuma`` (numactl on Enterprise Linux).  Please install
+these with your Linux system's package manager.
+
 Conda
 -----
 
@@ -26,7 +33,6 @@ Source
 
 The following instructions assume you'll be using ucx-py on a CUDA enabled system and is in a `Conda environment <https://docs.conda.io/projects/conda/en/latest/>`_.
 
-Note: UCX depends on the following system libraries being present: ``libibverbs``, ``librdmacm``, and ``libnuma`` (numactl on Enterprise Linux).  Please install these with your Linux system's package manager.
 
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -45,7 +45,7 @@ conda-forge Dependencies
 ::
 
     conda create -n ucx -c conda-forge \
-        automake make cmake libtool pkg-config \
+        automake make libtool pkg-config \
         libhwloc \
         python=3.7 setuptools cython cupy distributed numba>=0.46 \
         pytest pytest-asyncio \

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,8 +5,8 @@ Prerequisites
 -------------
 
 UCX depends on the following system libraries being present: ``libibverbs``,
-``librdmacm``, and ``libnuma`` (numactl on Enterprise Linux).  Please install
-these with your Linux system's package manager.
+``librdmacm``, and ``libnuma`` (``numactl`` on Enterprise Linux).  Please
+install these with your Linux system's package manager.
 
 Conda
 -----

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -48,8 +48,7 @@ conda-forge Dependencies
         automake make libtool pkg-config \
         libhwloc \
         python=3.7 setuptools cython cupy distributed numba>=0.46 \
-        pytest pytest-asyncio \
-        ipython
+        pytest pytest-asyncio
 
 RAPIDS Dependencies
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As the install instructions are mostly in the docs anyways, this fills in some missing details in the docs and removes them from the README in the spirit of DRY. Should keep things easier to maintain. Discussion on this would be very welcome.