### PR TITLE
[Critical] Setting UCX_SOCKADDR_TLS_PRIORITY=sockcm

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -30,10 +30,10 @@ if "UCX_CUDA_IPC_CACHE" not in os.environ:
 
 if "UCX_SOCKADDR_TLS_PRIORITY" not in os.environ:
     logger.debug(
-        "Setting env UCX_SOCKADDR_TLS_PRIORITY=all, "
+        "Setting env UCX_SOCKADDR_TLS_PRIORITY=sockcm, "
         "which is required to connect multiple nodes"
     )
-    os.environ["UCX_SOCKADDR_TLS_PRIORITY"] = "all"
+    os.environ["UCX_SOCKADDR_TLS_PRIORITY"] = "sockcm"
 
 # Set the root logger before importing modules that use it
 _level_enum = logging.getLevelName(os.getenv("UCXPY_LOG_LEVEL", "WARNING"))


### PR DESCRIPTION
It turns out that `UCX_SOCKADDR_TLS_PRIORITY=all` doesn't work in the general case. We need to set `UCX_SOCKADDR_TLS_PRIORITY=sockcm`.

Since [`LocalCUDACluster`](https://github.com/rapidsai/dask-cuda/blob/97f485d1f449b9d6a45d79a86971d604d458cfa2/dask_cuda/local_cuda_cluster.py#L64) doesn't sets it by default and `DGX` is deprecated, it will fail for a new user.
