### PR TITLE
Create and run local network

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,7 @@ import versioneer
 from setuptools import setup
 from setuptools.extension import Extension
 
-include_dirs = [os.path.dirname(get_python_inc())] + [
-    "/home/mkristensen/anaconda3/envs/rap-nightly/include"
-]
+include_dirs = [os.path.dirname(get_python_inc())]
 library_dirs = [get_config_var("LIBDIR")]
 libraries = ["ucp", "uct", "ucm", "ucs", "hwloc"]
 extra_compile_args = ["-std=c99"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ import versioneer
 from setuptools import setup
 from setuptools.extension import Extension
 
-include_dirs = [os.path.dirname(get_python_inc())]
+include_dirs = [os.path.dirname(get_python_inc())] + [
+    "/home/mkristensen/anaconda3/envs/rap-nightly/include"
+]
 library_dirs = [get_config_var("LIBDIR")]
 libraries = ["ucp", "uct", "ucm", "ucs", "hwloc"]
 extra_compile_args = ["-std=c99"]

--- a/tests/test_run_on_local_network.py
+++ b/tests/test_run_on_local_network.py
@@ -1,0 +1,24 @@
+import asyncio
+import numpy as np
+import ucp.utils
+
+async def worker(rank, eps, args):
+    futures = []
+    # Send my rank to all others
+    for ep in eps.values():
+        futures.append(ep.send(np.array([rank], dtype="u4")))
+    # Recv from all others
+    recv_list = []
+    for ep in eps.values():
+        recv_list.append(np.empty(1, dtype="u4"))
+        futures.append(ep.recv(recv_list[-1]))
+    await asyncio.gather(*futures)
+
+    # We expect to get the sum of all ranks excluding ours
+    expect = sum(range(len(eps)+1)) - rank
+    got = np.concatenate(recv_list).sum()
+    assert expect == got
+
+
+def test_all_comm(n_workers=4):
+    ucp.utils.run_on_local_network(n_workers, worker)

--- a/tests/test_run_on_local_network.py
+++ b/tests/test_run_on_local_network.py
@@ -1,6 +1,8 @@
 import asyncio
+
 import numpy as np
 import ucp.utils
+
 
 async def worker(rank, eps, args):
     futures = []
@@ -15,7 +17,7 @@ async def worker(rank, eps, args):
     await asyncio.gather(*futures)
 
     # We expect to get the sum of all ranks excluding ours
-    expect = sum(range(len(eps)+1)) - rank
+    expect = sum(range(len(eps) + 1)) - rank
     got = np.concatenate(recv_list).sum()
     assert expect == got
 

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -39,3 +39,38 @@ def get_address(ifname=None):
             s.fileno(), 0x8915, struct.pack("256s", ifname[:15])  # SIOCGIFADDR
         )[20:24]
     )
+
+
+def get_closest_net_devices(gpu_dev):
+    """
+    Get the names of the closest net devices to `gpu_dev`
+
+    Parameters
+    ----------
+    gpu_dev : str
+        GPU device id
+
+    Returns
+    -------
+    dev_names : str
+        Names of the closest net devices
+
+    Examples
+    --------
+    >>> get_closest_net_devices(0)
+    'eth0'
+    """
+    from ucp._libs.topological_distance import TopologicalDistance
+
+    dev = int(gpu_dev)
+    net_dev = ""
+    td = TopologicalDistance()
+    ibs = td.get_cuda_distances_from_device_index(dev, "openfabrics")
+    if len(ibs) > 0:
+        net_dev += ibs[0]["name"] + ":1,"
+    ifnames = td.get_cuda_distances_from_device_index(dev, "network")
+    if len(ifnames) > 0:
+        net_dev += ifnames[0]["name"]
+    return net_dev
+
+

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -1,9 +1,10 @@
+import asyncio
 import fcntl
+import multiprocessing as mp
 import os
 import socket
 import struct
-import asyncio
-import multiprocessing as mp
+
 import numpy as np
 
 mp = mp.get_context("spawn")
@@ -129,7 +130,7 @@ def run_on_local_network(
     n_workers : int
         Number of workers (nodes) in the network.
     worker_func: callable (can be a coroutine)
-        Function that each worker execute. 
+        Function that each worker execute.
         Must have signature: `worker(rank, eps, args)` where
             - rank is the worker id
             - eps is a dict of ranks to ucx endpoints

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -107,7 +107,7 @@ def _worker_process(
             await eps[i].send(np.array([rank], dtype=np.uint64))
 
         while len(eps) != n_workers - 1:
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.1)
 
         if asyncio.iscoroutinefunction(func):
             await func(rank, eps, args)


### PR DESCRIPTION
This PR implements `utils.run_on_local_network()`, which spawns, connects, and runs a number of workers.

```python

def run_on_local_network(
    n_workers, worker_func, worker_args=None, server_address=None, ucx_options_list=None
):
    """
    Creates a local UCX network of `n_workers` that runs `worker_func`

    Parameters
    ----------
    n_workers : int
        Number of workers (nodes) in the network.
    worker_func: callable (can be a coroutine)
        Function that each worker execute. 
        Must have signature: `worker(rank, eps, args)` where
            - rank is the worker id
            - eps is a dict of ranks to ucx endpoints
            - args given here as `worker_args`
    worker_args: object
        The argument to pass to `worker_func`.
    server_address: str
        Server address for the workers. If None, get_address() is used.
    ucx_options_list: list of dict
        Options to pass to UCX when initializing workers, one for each worker.

    Returns
    -------
    dev_names : str
        Names of the closest net devices
    """
```
