### PR TITLE
add glossary page and update more TLS config options

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -69,11 +69,28 @@ Values:
 
 Transport Methods (Simplified):
 
-- ``rc`` -> InfiniBand (ibv_post_send, ibv_post_recv, ibv_poll_cq)
+- ``all`` -> use all the available transports
+- ``rc`` -> InfiniBand (ibv_post_send, ibv_post_recv, ibv_poll_cq) uses rc_v and rc_x (preferably if available)
 - ``cuda_copy`` -> cuMemHostRegister, cuMemcpyAsync
 - ``cuda_ipc`` -> CUDA Interprocess Communication (cuIpcCloseMemHandle, cuIpcOpenMemHandle, cuMemcpyAsync)
 - ``sockcm`` -> connection management over sockets
-- ``tcp`` -> TCP over sockets (often used with sockcm)
+- ``sm/shm`` -> all shared memory transports (mm, cma, knem)
+- ``mm`` -> shared memory transports - only memory mappers
+- ``ugni`` -> ugni_smsg and ugni_rdma (uses ugni_udt for bootstrap)
+- ``ib`` -> all infiniband transports (rc/rc_mlx5, ud/ud_mlx5, dc_mlx5)
+- ``rc_v`` -> rc verbs (uses ud for bootstrap)
+- ``rc_x`` -> rc with accelerated verbs (uses ud_mlx5 for bootstrap)
+- ``ud_v`` -> ud verbs
+- ``ud_x`` -> ud with accelerated verbs
+- ``ud  `` -> ud_v and ud_x (preferably if available)
+- ``dc/dc_x`` -> dc with accelerated verbs
+- ``tcp`` -> sockets over TCP/IP
+- ``cuda`` -> CUDA (NVIDIA GPU) memory support
+- ``rocm`` -> ROCm (AMD GPU) memory support
+
+``SOCKADDR_TLS_PRIORITY``
+
+Priority of sockaddr transports
 
 
 InfiniBand Device

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,0 +1,95 @@
+Glossary
+--------
+
+- ACK	Acknowledge
+- am	Active Message
+- AMO	Atomic Memory Operation
+- ANL	Argonne National Laboratory
+- AZP	AZure Pipeline
+- bcopy	Byte copy
+- Bistro	Binary Instrumentation
+- BTL	Byte Transfer Layer
+- cm	Connection Manager
+- CMA	Cross Memory Attach
+- CQ	Completion Queue(Infiniband)
+- CQE	Completion Queue Entry(Infiniband)
+- csmock	static analysis tools
+- CUDA	Compute Unified Device Architecture(NVIDIA)
+- DC	Dynamically Connected transport(Infiniband)
+- ep	EndPoint
+- FC	Flow Control
+- fd	File Descriptor
+- GDR	GPUDirect RDMA
+- gtest	Google Test
+- HPC	High Performance Computing
+- HWTM	HardWare Tag Matching
+- IB	Infiniband
+- iface	Interaface
+- IPC	Inter Process Communication
+- JUCX	Java API over UCP
+- KLM	A new sophisticated way of creating memory regions.- (Mellanox specific)
+- KNEM	Kernel Nemesis
+- LLNL	Lawrence Livermore National Laboratory
+- madvise	give advice about use of memory. See manual - madvise(2)
+- md	Memory Domain
+- MEMH	Memory Handle
+- MLX	Mellanox Technologies
+- mlx5	Connect-X5 VPI
+- mm	Memory Mapper
+- MPI	Message Passing INterface
+- MPICH	A MPI Implementation
+- MTT	The MPI Testing Tool
+- NAK	Negative Acknowledge
+- ODP	OnDemand Paging
+- OFA	OpenFabrics Alliance
+- OMPI	OpenMPI
+- OOB	Out of band
+- OOO	Out of Order
+- OPA	Omni-Path Architecture
+- Open MPI	A MPI Implementation
+- ORNL	Oak Ridge National Laboratory
+- PCIe	PCI Express
+- PGAS	Partitioned Global Address Space
+- POSIX	Portable operating system interface
+- ppn	processes per node
+- PR	Pull Request
+- PROGRESS64	A C library of scalable functions for - concurrent programs, primarily focused on networking - applications.(https://github.com/ARM-software/- progress64)
+- QP	Queue Pair(Infiniband)
+- RC	Reliable Connection (Infiniband)
+- rcache	Registration Cache
+- RDMA	Remote Direct Memory Access
+- REQ	Request
+- rkey	Remote KEY
+- RMA	Remote Memory Access
+- RNR	Receiver Not Ready
+- RoCE	RDMA over Converged Ethernet
+- ROCm	Radeon Open Compute platform(AMD)
+- RTE	Run Time Environment
+- RX	Receive
+- Skb	Socket Buffer
+- sm	Shared Memory
+- SM	Subnet Manager(Infiniband)
+- SockCM	Socket Connection Manager
+- SRQ	Shared Receive Queue
+- SYSV	UNIX System V
+- tl	Transport Layer
+- TLS	Transpot LayerS
+- TM	Tag Matching
+- TX	Transmit
+- UC	Unreliable Connection (Infiniband)
+- UCF	Unified Communication Framework
+- UCM	Unified Communication Memory
+- UCP	Unified Communication Protocols Higher level API
+- UCS	Unified Communication Service Common utilities.
+- UCT	Unified Communication Transport Lower level API
+- UCX	Unified Communication X
+- UD	Unreliable Datagram (Infiniband)
+- uGNI	user level generic network interface(Cray)
+- UMR	User mode memory registration
+- VPI	Virtual Protocol Interconnect
+- WQ	Work Queue(Infiniband)
+- WQE	Work Queue Elements (pronounce WOOKIE)
+- WR	Work Request
+- XPMEM	cross partition memory
+- XRC	eXtended Reliable Connection(Infiniband)
+- Zcopy	Zero Copy

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,3 +19,4 @@ UCX-PY is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a lo
    dask
    deployment
    api
+   glossary


### PR DESCRIPTION
PR updates TLS options and adds a glossary page for the many acronyms in the UCX/networking ecosystem

Thanks to @hiroyuki-sato for the supplying the [glossary](https://github.com/hiroyuki-sato/openucx-docs/)
