### PR TITLE
Request UCP_FEATURE_WAKEUP always

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -342,13 +342,11 @@ cdef class ApplicationContext:
                                  UCP_PARAM_FIELD_REQUEST_SIZE |  # noqa
                                  UCP_PARAM_FIELD_REQUEST_INIT)
 
-        # We only need the UCP_FEATURE_WAKEUP flag in blocking progress mode
-        if self.blocking_progress_mode:
-            ucp_params.features = (UCP_FEATURE_TAG |  # noqa
-                                   UCP_FEATURE_WAKEUP |  # noqa
-                                   UCP_FEATURE_STREAM)
-        else:
-            ucp_params.features = (UCP_FEATURE_TAG | UCP_FEATURE_STREAM)
+        # We always request UCP_FEATURE_WAKEUP even when in blocking mode
+        # See <https://github.com/rapidsai/ucx-py/pull/377>
+        ucp_params.features = (UCP_FEATURE_TAG |  # noqa
+                               UCP_FEATURE_WAKEUP |  # noqa
+                               UCP_FEATURE_STREAM)
 
         ucp_params.request_size = sizeof(ucp_request)
         ucp_params.request_init = ucp_request_reset


### PR DESCRIPTION
This PR makes ucxpy request `UCP_FEATURE_WAKEUP` always.
In principle the wake up feature is not required when in non-blocking mode; we are not using any of the [UCX wake-up routines](http://openucx.github.io/ucx/api/v1.5/html/group___u_c_p___w_a_k_e_u_p.html).

But on a DGX-1 using InfiniBand I see the following error when not requesting `UCP_FEATURE_WAKEUP`:

```
$ UCXPY_NON_BLOCKING_MODE=1 python  cudf-merge.py -c 10000000 --devs=0,6 --net-devices=auto
[1576760097.195101] [dgx15:48168:0]   cuda_copy_ep.c:63   UCX  ERROR Failed to allocate cuda event object
[1576760097.195138] [dgx15:48168:0]   cuda_copy_ep.c:63   UCX  ERROR Failed to allocate cuda event object
[1576760097.195147] [dgx15:48168:0]   cuda_copy_ep.c:63   UCX  ERROR Failed to allocate cuda event object
[1576760097.195155] [dgx15:48168:0]   cuda_copy_ep.c:63   UCX  ERROR Failed to allocate cuda event object
[1576760097.195162] [dgx15:48168:0]   cuda_copy_ep.c:63   UCX  ERROR Failed to allocate cuda event object
[1576760097.195168] [dgx15:48168:0]   cuda_copy_ep.c:63   UCX  ERROR Failed to allocate cuda event object
[1576760097.195178] [dgx15:48168:0]   cuda_copy_ep.c:63   UCX  ERROR Failed to allocate cuda event object
```