### PR TITLE
Provide utility function for C string to unicode conversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ ext_modules = [
     ),
     Extension(
         "ucp._libs.send_recv",
-        sources=[
-            "ucp/_libs/send_recv.pyx",
-            "ucp/_libs/src/c_util.c",
-        ],
+        sources=["ucp/_libs/send_recv.pyx", "ucp/_libs/src/c_util.c"],
         depends=[
             "ucp/_libs/src/c_util.h",
             "ucp/_libs/core_dep.pxd",
@@ -46,10 +43,7 @@ ext_modules = [
     ),
     Extension(
         "ucp._libs.core",
-        sources=[
-            "ucp/_libs/core.pyx",
-            "ucp/_libs/src/c_util.c",
-        ],
+        sources=["ucp/_libs/core.pyx", "ucp/_libs/src/c_util.c"],
         depends=[
             "ucp/_libs/src/c_util.h",
             "ucp/_libs/core_dep.pxd",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ ext_modules = [
         sources=[
             "ucp/_libs/send_recv.pyx",
             "ucp/_libs/src/c_util.c",
-            "ucp/_libs/utils.pyx",
         ],
         depends=[
             "ucp/_libs/src/c_util.h",
@@ -50,7 +49,6 @@ ext_modules = [
         sources=[
             "ucp/_libs/core.pyx",
             "ucp/_libs/src/c_util.c",
-            "ucp/_libs/utils.pyx",
         ],
         depends=[
             "ucp/_libs/src/c_util.h",
@@ -67,7 +65,6 @@ ext_modules = [
         sources=[
             "ucp/_libs/topological_distance.pyx",
             "ucp/_libs/src/topological_distance.c",
-            "ucp/_libs/utils.pyx",
         ],
         depends=[
             "ucp/_libs/src/topological_distance.h",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ ext_modules = [
         sources=[
             "ucp/_libs/send_recv.pyx",
             "ucp/_libs/src/c_util.c",
+            "ucp/_libs/utils.pyx",
         ],
         depends=[
             "ucp/_libs/src/c_util.h",
@@ -49,6 +50,7 @@ ext_modules = [
         sources=[
             "ucp/_libs/core.pyx",
             "ucp/_libs/src/c_util.c",
+            "ucp/_libs/utils.pyx",
         ],
         depends=[
             "ucp/_libs/src/c_util.h",
@@ -65,6 +67,7 @@ ext_modules = [
         sources=[
             "ucp/_libs/topological_distance.pyx",
             "ucp/_libs/src/topological_distance.c",
+            "ucp/_libs/utils.pyx",
         ],
         depends=[
             "ucp/_libs/src/topological_distance.h",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ ext_modules = [
     Extension(
         "ucp._libs.send_recv",
         sources=["ucp/_libs/send_recv.pyx", "ucp/_libs/src/c_util.c"],
-        depends=["ucp/_libs/src/c_util.h", "ucp/_libs/core_dep.pxd"],
+        depends=[
+            "ucp/_libs/src/c_util.h",
+            "ucp/_libs/core_dep.pxd",
+        ],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
         libraries=libraries,
@@ -40,7 +43,10 @@ ext_modules = [
     Extension(
         "ucp._libs.core",
         sources=["ucp/_libs/core.pyx", "ucp/_libs/src/c_util.c"],
-        depends=["ucp/_libs/src/c_util.h", "ucp/_libs/core_dep.pxd"],
+        depends=[
+            "ucp/_libs/src/c_util.h",
+            "ucp/_libs/core_dep.pxd",
+        ],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
         libraries=libraries,

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ ext_modules = [
         depends=[
             "ucp/_libs/src/c_util.h",
             "ucp/_libs/core_dep.pxd",
+            "ucp/_libs/utils.pxd",
         ],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
@@ -46,6 +47,7 @@ ext_modules = [
         depends=[
             "ucp/_libs/src/c_util.h",
             "ucp/_libs/core_dep.pxd",
+            "ucp/_libs/utils.pxd",
         ],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
@@ -61,6 +63,7 @@ ext_modules = [
         depends=[
             "ucp/_libs/src/topological_distance.h",
             "ucp/_libs/topological_distance_dep.pxd",
+            "ucp/_libs/utils.pxd",
         ],
         include_dirs=include_dirs,
         library_dirs=library_dirs,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ ext_modules = [
     ),
     Extension(
         "ucp._libs.send_recv",
-        sources=["ucp/_libs/send_recv.pyx", "ucp/_libs/src/c_util.c"],
+        sources=[
+            "ucp/_libs/send_recv.pyx",
+            "ucp/_libs/src/c_util.c",
+        ],
         depends=[
             "ucp/_libs/src/c_util.h",
             "ucp/_libs/core_dep.pxd",
@@ -43,7 +46,10 @@ ext_modules = [
     ),
     Extension(
         "ucp._libs.core",
-        sources=["ucp/_libs/core.pyx", "ucp/_libs/src/c_util.c"],
+        sources=[
+            "ucp/_libs/core.pyx",
+            "ucp/_libs/src/c_util.c",
+        ],
         depends=[
             "ucp/_libs/src/c_util.h",
             "ucp/_libs/core_dep.pxd",

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -42,7 +42,7 @@ cdef ucp_config_t * read_ucx_config(dict user_options) except *:
     if status != UCS_OK:
         raise UCXConfigError(
             "Couldn't read the UCX options: %s" %
-            ucs_status_string(status)
+            c_str_to_unicode(ucs_status_string(status))
         )
 
     # Modify the UCX configuration options based on `config_dict`
@@ -52,7 +52,7 @@ cdef ucp_config_t * read_ucx_config(dict user_options) except *:
             raise UCXConfigError("Option %s doesn't exist" % k)
         elif status != UCS_OK:
             msg = "Couldn't set option %s to %s: %s" % \
-                  (k, v, ucs_status_string(status))
+                  (k, v, c_str_to_unicode(ucs_status_string(status)))
             raise UCXConfigError(msg)
     return config
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -66,8 +66,8 @@ cdef get_ucx_config_options(ucp_config_t *config):
     ret = {}
     ucp_config_print(config, text_fd, NULL, UCS_CONFIG_PRINT_CONFIG)
     fflush(text_fd)
-    cdef bytes py_text = <bytes> text
-    for line in py_text.decode().splitlines():
+    cdef unicode py_text = c_str_to_unicode(text)
+    for line in py_text.splitlines():
         k, v = line.split("=")
         k = k[len("UCX_"):]
         ret[k] = v
@@ -713,10 +713,10 @@ class _Endpoint:
         cdef ucp_ep_h ep = <ucp_ep_h><uintptr_t>self._ucp_endpoint
         ucp_ep_print_info(ep, text_fd)
         fflush(text_fd)
-        cdef bytes py_text = <bytes> text
+        cdef unicode py_text = c_str_to_unicode(text)
         fclose(text_fd)
         free(text)
-        return py_text.decode()
+        return py_text
 
     def cuda_support(self):
         return self._cuda_support

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -41,7 +41,8 @@ cdef ucp_config_t * read_ucx_config(dict user_options) except *:
     status = ucp_config_read(NULL, NULL, &config)
     if status != UCS_OK:
         raise UCXConfigError(
-            "Couldn't read the UCX options: %s" % ucs_status_string(status)
+            "Couldn't read the UCX options: %s" %
+            ucs_status_string(status)
         )
 
     # Modify the UCX configuration options based on `config_dict`

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -20,13 +20,14 @@ from ..exceptions import (
 )
 
 from .send_recv import tag_send, tag_recv, stream_send, stream_recv
+from utils cimport c_str_to_unicode
 from .utils import get_buffer_nbytes
 
 
 cdef assert_ucs_status(ucs_status_t status, msg_context=None):
     if status != UCS_OK:
         msg = "[%s] " % msg_context if msg_context is not None else ""
-        msg += (<object> ucs_status_string(status)).decode("utf-8")
+        msg += c_str_to_unicode(ucs_status_string(status))
         raise UCXError(msg)
 
 

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -4,6 +4,7 @@
 
 import pynvml
 from topological_distance_dep cimport *
+from utils cimport c_str_to_unicode
 
 
 cdef class TopologicalDistance:
@@ -97,7 +98,7 @@ cdef class TopologicalDistance:
         )
 
         ret = [{"distance": <int>(&dist_name[i]).distance,
-               "name": (<char *>(&dist_name[i]).name).decode("utf-8")}
+               "name": c_str_to_unicode((&dist_name[i]).name)}
                for i in range(dev_count)]
 
         free(dev_dist)

--- a/ucp/_libs/utils.pxd
+++ b/ucp/_libs/utils.pxd
@@ -1,3 +1,5 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 # cython: language_level=3
+
+cpdef unicode c_str_to_unicode(const char* c_str)

--- a/ucp/_libs/utils.pxd
+++ b/ucp/_libs/utils.pxd
@@ -1,2 +1,3 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
+# cython: language_level=3

--- a/ucp/_libs/utils.pxd
+++ b/ucp/_libs/utils.pxd
@@ -1,0 +1,2 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -2,7 +2,10 @@
 # See file LICENSE for terms.
 # cython: language_level=3
 
+from libc.string cimport strlen
+
 import asyncio
+import codecs
 import uuid
 from functools import reduce
 import operator
@@ -10,6 +13,17 @@ from libc.stdint cimport uintptr_t
 from cpython.memoryview cimport PyMemoryView_GET_BUFFER
 from core_dep cimport *
 from ..exceptions import UCXError, UCXCloseError
+
+
+cpdef unicode c_str_to_unicode(const char* c_str):
+    if c_str is NULL:
+        raise ValueError("Cannot convert `NULL` pointer to `unicode`.")
+
+    cdef size_t c_str_len = strlen(c_str)
+    cdef const char[::1] c_str_mv = <const char[:c_str_len:1]>c_str
+    cdef unicode py_unicode = codecs.decode(c_str_mv, "utf-8")
+
+    return py_unicode
 
 
 def get_buffer_data(buffer, check_writable=False):


### PR DESCRIPTION
Adds a simple utility function to make it easier to facilitate conversion of C strings (`char*`) to Python strings (`unicode`). As a bonus leverages the Python buffer protocol to avoid unneeded copies.