### PR TITLE
WIP: Mark C level functions as `nogil`

### DIFF
--- a/ucp/_libs/core_dep.pxd
+++ b/ucp/_libs/core_dep.pxd
@@ -16,7 +16,7 @@ cdef extern from "Python.h":
     Py_buffer* PyMemoryView_GET_BUFFER(PyObject *mview)
 
 
-cdef extern from "src/c_util.h":
+cdef extern from "src/c_util.h" nogil:
     ctypedef struct ucp_listener_params_t:
         pass
 
@@ -40,7 +40,7 @@ cdef extern from "src/c_util.h":
     void c_util_get_ucp_ep_params_free(ucp_ep_params_t *param)
 
 
-cdef extern from "ucp/api/ucp.h":
+cdef extern from "ucp/api/ucp.h" nogil:
     ctypedef struct ucp_context_h:
         pass
 
@@ -201,7 +201,7 @@ cdef extern from "ucp/api/ucp.h":
     ucs_status_t ucp_config_modify(ucp_config_t *config, const char *name,
                                    const char *value)
 
-cdef extern from "sys/epoll.h":
+cdef extern from "sys/epoll.h" nogil:
 
     cdef enum:
         EPOLL_CTL_ADD = 1

--- a/ucp/_libs/topological_distance_dep.pxd
+++ b/ucp/_libs/topological_distance_dep.pxd
@@ -5,7 +5,7 @@
 from libc.stdlib cimport free
 
 
-cdef extern from "hwloc.h":
+cdef extern from "hwloc.h" nogil:
     ctypedef struct hwloc_obj_t:
         pass
 
@@ -25,7 +25,7 @@ cdef extern from "hwloc.h":
     void hwloc_topology_destroy(hwloc_topology_t topology)
 
 
-cdef extern from "src/topological_distance.h":
+cdef extern from "src/topological_distance.h" nogil:
     ctypedef struct topological_distance_objs_t:
         pass
 


### PR DESCRIPTION
These functions should be safe to use without the Python GIL as they are not creating or destroying Python objects. So mark them as such.

Note: This does **not** actually release the GIL. We still have to do that ourselves. However this allows us to use these in code sections where we have already released the GIL. We can also continue to use them when we have the GIL as well.