### PR TITLE
Simplify PyMemoryView_GET_BUFFER call

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -54,7 +54,7 @@ conda install "cudatoolkit=$CUDA_REL" \
 
 # needed for asynccontextmanager in py36
 conda install -c conda-forge "async_generator" "automake" "libtool" \
-                              "cmake" "automake" "autoconf" "cython" \
+                              "cmake" "automake" "autoconf" "cython>=0.29.14,<3.0.0a0" \
                               "pytest" "pkg-config" "pytest-asyncio" \
                               "pynvml" "libhwloc"
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -47,7 +47,7 @@ Build Dependencies
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
         libhwloc \
-        python=3.7 setuptools cython
+        python=3.7 setuptools cython>=0.29.14,<3.0.0a0
 
 Test Dependencies
 ~~~~~~~~~~~~~~~~~

--- a/ucp/_libs/core_dep.pxd
+++ b/ucp/_libs/core_dep.pxd
@@ -12,10 +12,6 @@ from cpython.long cimport PyLong_AsVoidPtr, PyLong_FromVoidPtr
 from cpython.ref cimport PyObject, Py_INCREF, Py_DECREF
 
 
-cdef extern from "Python.h":
-    Py_buffer* PyMemoryView_GET_BUFFER(PyObject *mview)
-
-
 cdef extern from "src/c_util.h":
     ctypedef struct ucp_listener_params_t:
         pass

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -6,6 +6,7 @@ import asyncio
 import uuid
 from functools import reduce
 import operator
+from libc.stdint cimport uintptr_t
 from core_dep cimport *
 from ..exceptions import UCXError, UCXCloseError
 
@@ -16,7 +17,7 @@ def _data_from_memoryview(object mview):
     of ´mview´ as a Python integer.
     """
     cdef Py_buffer* buf = PyMemoryView_GET_BUFFER(<PyObject*>mview)
-    return PyLong_FromVoidPtr(buf.buf)
+    return int(<uintptr_t>buf.buf)
 
 
 def get_buffer_data(buffer, check_writable=False):

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -7,6 +7,7 @@ import uuid
 from functools import reduce
 import operator
 from libc.stdint cimport uintptr_t
+from cpython.memoryview cimport PyMemoryView_GET_BUFFER
 from core_dep cimport *
 from ..exceptions import UCXError, UCXCloseError
 
@@ -16,7 +17,7 @@ def _data_from_memoryview(object mview):
     Help function that returns a pointer to the data
     of ´mview´ as a Python integer.
     """
-    cdef Py_buffer* buf = PyMemoryView_GET_BUFFER(<PyObject*>mview)
+    cdef Py_buffer* buf = PyMemoryView_GET_BUFFER(mview)
     return int(<uintptr_t>buf.buf)
 
 

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -12,14 +12,6 @@ from core_dep cimport *
 from ..exceptions import UCXError, UCXCloseError
 
 
-def _data_from_memoryview(object mview):
-    """
-    Help function that returns a pointer to the data
-    of ´mview´ as a Python integer.
-    """
-    return int(<uintptr_t>PyMemoryView_GET_BUFFER(mview).buf)
-
-
 def get_buffer_data(buffer, check_writable=False):
     """
     Returns data pointer of the buffer. Raising ValueError if the buffer
@@ -35,7 +27,7 @@ def get_buffer_data(buffer, check_writable=False):
         data_ptr, data_readonly = iface['data']
     else:
         mview = memoryview(buffer)
-        data_ptr = _data_from_memoryview(mview)
+        data_ptr = int(<uintptr_t>PyMemoryView_GET_BUFFER(mview).buf)
         data_readonly = mview.readonly
 
     # Workaround for numba giving None, rather than an 0.

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -17,8 +17,7 @@ def _data_from_memoryview(object mview):
     Help function that returns a pointer to the data
     of ´mview´ as a Python integer.
     """
-    cdef Py_buffer* buf = PyMemoryView_GET_BUFFER(mview)
-    return int(<uintptr_t>buf.buf)
+    return int(<uintptr_t>PyMemoryView_GET_BUFFER(mview).buf)
 
 
 def get_buffer_data(buffer, check_writable=False):


### PR DESCRIPTION
As Cython supplies `PyMemoryView_GET_BUFFER` in its API as of 0.29.14+, simplify the code by using their API. Make a few more simplifications to `_data_from_memoryview` so that it can be simply inlined.