### PR TITLE
Use `uintptr_t` to coerce to/from Python `int`s & C pointers

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -6,7 +6,7 @@ import os
 import asyncio
 import weakref
 from functools import partial
-from libc.stdint cimport uint64_t
+from libc.stdint cimport uint64_t, uintptr_t
 import uuid
 import socket
 import logging
@@ -258,9 +258,9 @@ cdef void _listener_callback(ucp_ep_h ep, void *args):
     cdef object func = <object> a.py_func
     asyncio.ensure_future(
         listener_handler(
-            PyLong_FromVoidPtr(<void*>ep),
+            int(<uintptr_t><void*>ep),
             ctx,
-            PyLong_FromVoidPtr(<void*>a.ucp_worker),
+            int(<uintptr_t><void*>a.ucp_worker),
             func,
             a.guarantee_msg_order
         )
@@ -453,14 +453,14 @@ cdef class ApplicationContext:
         msg_tag = hash(uuid.uuid4())
         ctrl_tag = hash(uuid.uuid4())
         peer_info = await exchange_peer_info(
-            ucp_endpoint=PyLong_FromVoidPtr(<void*> ucp_ep),
+            ucp_endpoint=int(<uintptr_t><void*>ucp_ep),
             msg_tag=msg_tag,
             ctrl_tag=ctrl_tag,
             guarantee_msg_order=guarantee_msg_order
         )
         ep = _Endpoint(
-            ucp_endpoint=PyLong_FromVoidPtr(<void*> ucp_ep),
-            ucp_worker=PyLong_FromVoidPtr(<void*> self.worker),
+            ucp_endpoint=int(<uintptr_t><void*>ucp_ep),
+            ucp_worker=int(<uintptr_t><void*>self.worker),
             ctx=self,
             msg_tag_send=peer_info['msg_tag'],
             msg_tag_recv=msg_tag,
@@ -528,7 +528,7 @@ cdef class ApplicationContext:
             self._non_blocking_progress_mode(loop)
 
     def get_ucp_worker(self):
-        return PyLong_FromVoidPtr(<void*>self.worker)
+        return int(<uintptr_t><void*>self.worker)
 
     def get_config(self):
         return self.config
@@ -582,17 +582,17 @@ class _Endpoint:
         self._closed = True
         logging.debug("Endpoint.abort(): %s" % hex(self.uid))
 
-        cdef ucp_worker_h worker = <ucp_worker_h> PyLong_AsVoidPtr(self._ucp_worker)  # noqa
+        cdef ucp_worker_h worker = <ucp_worker_h><uintptr_t>self._ucp_worker
 
         for msg in self.pending_msg_list:
             if 'future' in msg and not msg['future'].done():
                 logging.debug("Future cancelling: %s" % msg['log'])
                 ucp_request_cancel(
                     worker,
-                    PyLong_AsVoidPtr(msg['ucp_request'])
+                    <void*><uintptr_t>msg['ucp_request']
                 )
 
-        cdef ucp_ep_h ep = <ucp_ep_h> PyLong_AsVoidPtr(self._ucp_endpoint)
+        cdef ucp_ep_h ep = <ucp_ep_h><uintptr_t>self._ucp_endpoint
         cdef ucs_status_ptr_t status = ucp_ep_close_nb(ep, UCP_EP_CLOSE_MODE_FLUSH)
         if UCS_PTR_STATUS(status) != UCS_OK:
             assert not UCS_PTR_IS_ERR(status)
@@ -702,7 +702,7 @@ class _Endpoint:
         cdef size_t text_len
         cdef FILE *text_fd = open_memstream(&text, &text_len)
         assert(text_fd != NULL)
-        cdef ucp_ep_h ep = <ucp_ep_h> PyLong_AsVoidPtr(self._ucp_endpoint)
+        cdef ucp_ep_h ep = <ucp_ep_h><uintptr_t>self._ucp_endpoint
         ucp_ep_print_info(ep, text_fd)
         fflush(text_fd)
         cdef bytes py_text = <bytes> text

--- a/ucp/_libs/core_dep.pxd
+++ b/ucp/_libs/core_dep.pxd
@@ -8,7 +8,6 @@ from libc.stdlib cimport malloc, free
 from libc.stdio cimport FILE, stdin, stdout, stderr, printf, fflush, fclose
 from posix.stdio cimport open_memstream
 from posix.unistd cimport close
-from cpython.long cimport PyLong_AsVoidPtr, PyLong_FromVoidPtr
 from cpython.ref cimport PyObject, Py_INCREF, Py_DECREF
 
 

--- a/ucp/_libs/send_recv.pyx
+++ b/ucp/_libs/send_recv.pyx
@@ -5,6 +5,7 @@
 import asyncio
 import logging
 import uuid
+from libc.stdint cimport uintptr_t
 from core_dep cimport *
 from .utils import get_buffer_data
 from ..exceptions import UCXError, UCXCanceled
@@ -77,9 +78,9 @@ cdef void _send_callback(void *request, ucs_status_t status):
 
 
 def tag_send(ucp_ep, buffer, nbytes, tag, pending_msg=None):
-    cdef ucp_ep_h ep = <ucp_ep_h> PyLong_AsVoidPtr(ucp_ep)
-    cdef void *data = PyLong_AsVoidPtr(get_buffer_data(buffer,
-                                       check_writable=False))
+    cdef ucp_ep_h ep = <ucp_ep_h><uintptr_t>ucp_ep
+    cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
+                                         check_writable=False))
     cdef ucs_status_ptr_t status = ucp_tag_send_nb(ep,
                                                    data,
                                                    nbytes,
@@ -121,9 +122,9 @@ cdef void _tag_recv_callback(void *request, ucs_status_t status,
 
 
 def tag_recv(ucp_worker, buffer, nbytes, tag, pending_msg=None):
-    cdef ucp_worker_h worker = <ucp_worker_h> PyLong_AsVoidPtr(ucp_worker)
-    cdef void *data = PyLong_AsVoidPtr(get_buffer_data(buffer,
-                                       check_writable=True))
+    cdef ucp_worker_h worker = <ucp_worker_h><uintptr_t>ucp_worker
+    cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
+                                         check_writable=True))
     cdef ucs_status_ptr_t status = ucp_tag_recv_nb(worker,
                                                    data,
                                                    nbytes,
@@ -135,9 +136,9 @@ def tag_recv(ucp_worker, buffer, nbytes, tag, pending_msg=None):
 
 
 def stream_send(ucp_ep, buffer, nbytes, pending_msg=None):
-    cdef ucp_ep_h ep = <ucp_ep_h> PyLong_AsVoidPtr(ucp_ep)
-    cdef void *data = PyLong_AsVoidPtr(get_buffer_data(buffer,
-                                       check_writable=False))
+    cdef ucp_ep_h ep = <ucp_ep_h><uintptr_t>ucp_ep
+    cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
+                                         check_writable=False))
     cdef ucs_status_ptr_t status = ucp_stream_send_nb(ep,
                                                       data,
                                                       nbytes,
@@ -178,9 +179,9 @@ cdef void _stream_recv_callback(void *request, ucs_status_t status,
 
 
 def stream_recv(ucp_ep, buffer, nbytes, pending_msg=None):
-    cdef ucp_ep_h ep = <ucp_ep_h> PyLong_AsVoidPtr(ucp_ep)
-    cdef void *data = PyLong_AsVoidPtr(get_buffer_data(buffer,
-                                       check_writable=True))
+    cdef ucp_ep_h ep = <ucp_ep_h><uintptr_t>ucp_ep
+    cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
+                                         check_writable=True))
     cdef size_t length
     cdef ucp_request *req
     cdef ucs_status_ptr_t status = ucp_stream_recv_nb(ep,

--- a/ucp/_libs/send_recv.pyx
+++ b/ucp/_libs/send_recv.pyx
@@ -46,7 +46,7 @@ cdef create_future_from_comm_status(ucs_status_ptr_t status,
             req.expected_receive = expected_receive
             if pending_msg is not None:
                 pending_msg['future'] = ret
-                pending_msg['ucp_request'] = PyLong_FromVoidPtr(<void*>req)
+                pending_msg['ucp_request'] = int(<uintptr_t><void*>req)
                 pending_msg['expected_receive'] = expected_receive
             Py_INCREF(log_str)
             req.log_str = <PyObject*> log_str

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -6,6 +6,7 @@ import asyncio
 import uuid
 from functools import reduce
 import operator
+from libc.stdint cimport uintptr_t
 from core_dep cimport *
 from ..exceptions import UCXError, UCXCloseError
 
@@ -16,7 +17,7 @@ def _data_from_memoryview(object mview):
     of ´mview´ as a Python integer.
     """
     cdef Py_buffer* buf = PyMemoryView_GET_BUFFER(<PyObject*>mview)
-    return PyLong_FromVoidPtr(buf.buf)
+    return int(<uintptr_t>buf.buf)
 
 
 def get_buffer_data(buffer, check_writable=False):


### PR DESCRIPTION
Follow the convention in other RAPIDS Cython code of using `uintptr_t` as an intermediate when coercing a Python `int` to a C pointer or vice versa.