### PR TITLE
Make `ucp_ep` a `struct` and `ucp_ep_h` a pointer

### DIFF
--- a/ucp/_libs/core_dep.pxd
+++ b/ucp/_libs/core_dep.pxd
@@ -20,8 +20,10 @@ cdef extern from "src/c_util.h":
     ctypedef struct ucp_listener_params_t:
         pass
 
-    ctypedef struct ucp_ep_h:
+    ctypedef struct ucp_ep:
         pass
+
+    ctypedef ucp_ep* ucp_ep_h
 
     ctypedef struct ucp_ep_params_t:
         pass


### PR DESCRIPTION
As UCX defines `ucp_ep` as a `struct` and `ucp_ep_h` as a pointer to a `ucp_ep` object, correct the definition in `core_dep.pxd` to accordingly.

ref: https://github.com/openucx/ucx/blob/v1.6.1/src/ucp/api/ucp_def.h#L83