### PR TITLE
Define `*_h` types as pointers to `struct`s

### DIFF
--- a/ucp/_libs/core_dep.pxd
+++ b/ucp/_libs/core_dep.pxd
@@ -20,8 +20,10 @@ cdef extern from "src/c_util.h":
     ctypedef struct ucp_listener_params_t:
         pass
 
-    ctypedef struct ucp_ep_h:
+    ctypedef struct ucp_ep:
         pass
+
+    ctypedef ucp_ep* ucp_ep_h
 
     ctypedef struct ucp_ep_params_t:
         pass
@@ -41,11 +43,15 @@ cdef extern from "src/c_util.h":
 
 
 cdef extern from "ucp/api/ucp.h":
-    ctypedef struct ucp_context_h:
+    ctypedef struct ucp_context:
         pass
 
-    ctypedef struct ucp_worker_h:
+    ctypedef ucp_context* ucp_context_h
+
+    ctypedef struct ucp_worker:
         pass
+
+    ctypedef ucp_worker* ucp_worker_h
 
     ctypedef enum ucs_status_t:
         pass


### PR DESCRIPTION
As UCX defines a `*` with a `struct` type and then `*_h` as a pointer to that `struct`, correct the definitions in `core_dep.pxd` to accordingly.

1. Make `ucp_ep` a `struct` and `ucp_ep_h` a pointer
2. Make `ucp_context` a `struct` and `ucp_context_h` a pointer
3. Make `ucp_worker` a `struct` and `ucp_worker_h` a pointer

ref1: https://github.com/openucx/ucx/blob/v1.6.1/src/ucp/api/ucp_def.h#L83
ref2: https://github.com/openucx/ucx/blob/v1.6.1/src/ucp/api/ucp_def.h#L51
ref3: https://github.com/openucx/ucx/blob/v1.6.1/src/ucp/api/ucp_def.h#L231