### PR TITLE
Cast callback function pointers to expected type

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -420,12 +420,12 @@ cdef class ApplicationContext:
         Py_INCREF(callback_func)
 
         cdef ucp_listener_params_t params
-        cdef ucp_listener_accept_callback_t cb = (
+        cdef ucp_listener_accept_callback_t _listener_cb = (
             <ucp_listener_accept_callback_t>_listener_callback
         )
         if c_util_get_ucp_listener_params(&params,
                                           port,
-                                          cb,
+                                          _listener_cb,
                                           <void*> &ret._cb_args):
             raise MemoryError("Failed allocation of ucp_ep_params_t")
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -349,7 +349,9 @@ cdef class ApplicationContext:
                                UCP_FEATURE_STREAM)
 
         ucp_params.request_size = sizeof(ucp_request)
-        ucp_params.request_init = ucp_request_reset
+        ucp_params.request_init = (
+            <ucp_request_init_callback_t>ucp_request_reset
+        )
 
         cdef ucp_config_t *config = read_ucx_config(config_dict)
         status = ucp_init(&ucp_params, config, &self.context)
@@ -418,9 +420,12 @@ cdef class ApplicationContext:
         Py_INCREF(callback_func)
 
         cdef ucp_listener_params_t params
+        cdef ucp_listener_accept_callback_t cb = (
+            <ucp_listener_accept_callback_t>_listener_callback
+        )
         if c_util_get_ucp_listener_params(&params,
                                           port,
-                                          _listener_callback,
+                                          cb,
                                           <void*> &ret._cb_args):
             raise MemoryError("Failed allocation of ucp_ep_params_t")
 

--- a/ucp/_libs/send_recv.pyx
+++ b/ucp/_libs/send_recv.pyx
@@ -82,13 +82,13 @@ def tag_send(uintptr_t ucp_ep, buffer, size_t nbytes,
     cdef ucp_ep_h ep = <ucp_ep_h>ucp_ep
     cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
                                          check_writable=False))
-    cdef ucp_send_callback_t cb = <ucp_send_callback_t>_send_callback
+    cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
     cdef ucs_status_ptr_t status = ucp_tag_send_nb(ep,
                                                    data,
                                                    nbytes,
                                                    ucp_dt_make_contig(1),
                                                    tag,
-                                                   cb)
+                                                   _send_cb)
     return create_future_from_comm_status(status, nbytes, pending_msg)
 
 
@@ -128,7 +128,7 @@ def tag_recv(uintptr_t ucp_worker, buffer, size_t nbytes,
     cdef ucp_worker_h worker = <ucp_worker_h>ucp_worker
     cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
                                          check_writable=True))
-    cdef ucp_tag_recv_callback_t cb = (
+    cdef ucp_tag_recv_callback_t _tag_recv_cb = (
         <ucp_tag_recv_callback_t>_tag_recv_callback
     )
     cdef ucs_status_ptr_t status = ucp_tag_recv_nb(worker,
@@ -137,7 +137,7 @@ def tag_recv(uintptr_t ucp_worker, buffer, size_t nbytes,
                                                    ucp_dt_make_contig(1),
                                                    tag,
                                                    -1,
-                                                   cb)
+                                                   _tag_recv_cb)
     return create_future_from_comm_status(status, nbytes, pending_msg)
 
 
@@ -145,12 +145,12 @@ def stream_send(uintptr_t ucp_ep, buffer, size_t nbytes, pending_msg=None):
     cdef ucp_ep_h ep = <ucp_ep_h>ucp_ep
     cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
                                          check_writable=False))
-    cdef ucp_send_callback_t cb = <ucp_send_callback_t>_send_callback
+    cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
     cdef ucs_status_ptr_t status = ucp_stream_send_nb(ep,
                                                       data,
                                                       nbytes,
                                                       ucp_dt_make_contig(1),
-                                                      cb,
+                                                      _send_cb,
                                                       0)
     return create_future_from_comm_status(status, nbytes, pending_msg)
 
@@ -191,14 +191,14 @@ def stream_recv(uintptr_t ucp_ep, buffer, size_t nbytes, pending_msg=None):
                                          check_writable=True))
     cdef size_t length
     cdef ucp_request *req
-    cdef ucp_stream_recv_callback_t cb = (
+    cdef ucp_stream_recv_callback_t _stream_recv_cb = (
         <ucp_stream_recv_callback_t>_stream_recv_callback
     )
     cdef ucs_status_ptr_t status = ucp_stream_recv_nb(ep,
                                                       data,
                                                       nbytes,
                                                       ucp_dt_make_contig(1),
-                                                      cb,
+                                                      _stream_recv_cb,
                                                       &length,
                                                       0)
     return create_future_from_comm_status(status, nbytes, pending_msg)

--- a/ucp/_libs/send_recv.pyx
+++ b/ucp/_libs/send_recv.pyx
@@ -82,12 +82,13 @@ def tag_send(uintptr_t ucp_ep, buffer, size_t nbytes,
     cdef ucp_ep_h ep = <ucp_ep_h>ucp_ep
     cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
                                          check_writable=False))
+    cdef ucp_send_callback_t cb = <ucp_send_callback_t>_send_callback
     cdef ucs_status_ptr_t status = ucp_tag_send_nb(ep,
                                                    data,
                                                    nbytes,
                                                    ucp_dt_make_contig(1),
                                                    tag,
-                                                   _send_callback)
+                                                   cb)
     return create_future_from_comm_status(status, nbytes, pending_msg)
 
 
@@ -127,13 +128,16 @@ def tag_recv(uintptr_t ucp_worker, buffer, size_t nbytes,
     cdef ucp_worker_h worker = <ucp_worker_h>ucp_worker
     cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
                                          check_writable=True))
+    cdef ucp_tag_recv_callback_t cb = (
+        <ucp_tag_recv_callback_t>_tag_recv_callback
+    )
     cdef ucs_status_ptr_t status = ucp_tag_recv_nb(worker,
                                                    data,
                                                    nbytes,
                                                    ucp_dt_make_contig(1),
                                                    tag,
                                                    -1,
-                                                   _tag_recv_callback)
+                                                   cb)
     return create_future_from_comm_status(status, nbytes, pending_msg)
 
 
@@ -141,11 +145,12 @@ def stream_send(uintptr_t ucp_ep, buffer, size_t nbytes, pending_msg=None):
     cdef ucp_ep_h ep = <ucp_ep_h>ucp_ep
     cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
                                          check_writable=False))
+    cdef ucp_send_callback_t cb = <ucp_send_callback_t>_send_callback
     cdef ucs_status_ptr_t status = ucp_stream_send_nb(ep,
                                                       data,
                                                       nbytes,
                                                       ucp_dt_make_contig(1),
-                                                      _send_callback,
+                                                      cb,
                                                       0)
     return create_future_from_comm_status(status, nbytes, pending_msg)
 
@@ -186,11 +191,14 @@ def stream_recv(uintptr_t ucp_ep, buffer, size_t nbytes, pending_msg=None):
                                          check_writable=True))
     cdef size_t length
     cdef ucp_request *req
+    cdef ucp_stream_recv_callback_t cb = (
+        <ucp_stream_recv_callback_t>_stream_recv_callback
+    )
     cdef ucs_status_ptr_t status = ucp_stream_recv_nb(ep,
                                                       data,
                                                       nbytes,
                                                       ucp_dt_make_contig(1),
-                                                      _stream_recv_callback,
+                                                      cb,
                                                       &length,
                                                       0)
     return create_future_from_comm_status(status, nbytes, pending_msg)


### PR DESCRIPTION
Ensure Cython recognizes these function pointers match the expected callback type by explicitly casting them to that type. This becomes more important when trying to release the GIL in these code sections. As Cython seems to not recognize these are function pointers and not Python objects.