### PR TITLE
Add option to use RMM with local-send-recv

### DIFF
--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -204,7 +204,9 @@ def parse_args():
     )
     args = parser.parse_args()
     if args.cuda_profile and args.object_type != "cupy":
-        raise RuntimeError("`--cuda-profile` requires `--object_type=cupy`")
+        raise RuntimeError(
+            "`--cuda-profile` requires `--object_type=cupy`"
+        )
     return args
 
 

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -203,9 +203,10 @@ def parse_args():
         help="Initial RMM pool size (default  1/2 total GPU memory)",
     )
     args = parser.parse_args()
-    if args.cuda_profile and args.object_type != "cupy":
+    if args.cuda_profile and args.object_type == "numpy":
         raise RuntimeError(
             "`--cuda-profile` requires `--object_type=cupy`"
+            " or `--object_type=rmm`"
         )
     return args
 

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -205,8 +205,7 @@ def parse_args():
     args = parser.parse_args()
     if args.cuda_profile and args.object_type == "numpy":
         raise RuntimeError(
-            "`--cuda-profile` requires `--object_type=cupy`"
-            " or `--object_type=rmm`"
+            "`--cuda-profile` requires `--object_type=cupy` or `--object_type=rmm`"
         )
     return args
 

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -234,10 +234,10 @@ def main():
     print(f"object      | {args.object_type}")
     print(f"reuse alloc | {args.reuse_alloc}")
     print("==========================")
-    if args.object_type == "cupy":
-        print(f"Device(s)   | {args.server_dev}, {args.client_dev}")
-    else:
+    if args.object_type == "numpy":
         print(f"Device(s)    | Single CPU")
+    else:
+        print(f"Device(s)   | {args.server_dev}, {args.client_dev}")
     print(
         f"Average     | {format_bytes(2 * args.n_iter * args.n_bytes / sum(times))}/s"
     )

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -30,7 +30,7 @@ def server(queue, args):
         rmm.reinitialize(
             pool_allocator=True,
             managed_memory=False,
-            initial_pool_size=0,
+            initial_pool_size=args.rmm_init_pool_size,
             devices=[args.server_dev],
         )
         np.cuda.runtime.setDevice(args.server_dev)
@@ -85,7 +85,7 @@ def client(queue, port, args):
         rmm.reinitialize(
             pool_allocator=True,
             managed_memory=False,
-            initial_pool_size=0,
+            initial_pool_size=args.rmm_init_pool_size,
             devices=[args.client_dev],
         )
         np.cuda.runtime.setDevice(args.client_dev)
@@ -194,6 +194,13 @@ def parse_args():
         help="Setting CUDA profiler.start()/stop() around send/recv "
         "typically used with `nvprof --profile-from-start off "
         "--profile-child-processes`",
+    )
+    parser.add_argument(
+        "--rmm-init-pool-size",
+        metavar="BYTES",
+        default=None,
+        type=int,
+        help="Initial RMM pool size (default  1/2 total GPU memory)",
     )
     args = parser.parse_args()
     if args.cuda_profile and args.object_type != "cupy":


### PR DESCRIPTION
This adds an option to use RMM in the `local-send-recv` benchmark. This still uses CuPy arrays. However under-the-hood allocations are backed by an RMM pool. Initially the pool is empty, but grows to accommodate our needs.