### PR TITLE
Use default UCX_CUDA_IPC_CACHE value again

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -20,14 +20,6 @@ if "UCX_MEMTYPE_CACHE" not in os.environ:
     logger.debug("Setting env UCX_MEMTYPE_CACHE=n, which is required by UCX")
     os.environ["UCX_MEMTYPE_CACHE"] = "n"
 
-if "UCX_CUDA_IPC_CACHE" not in os.environ:
-    # See <https://github.com/openucx/ucx/issues/4410>
-    logger.debug(
-        "Setting env UCX_CUDA_IPC_CACHE=n, which is required to avoid NVLink memory "
-        "leaks"
-    )
-    os.environ["UCX_CUDA_IPC_CACHE"] = "n"
-
 if "UCX_SOCKADDR_TLS_PRIORITY" not in os.environ:
     logger.debug(
         "Setting env UCX_SOCKADDR_TLS_PRIORITY=sockcm, "


### PR DESCRIPTION
Using a CUDA memory pool with the CUDA IPC cache doesn't cause an OOM error, this is because the pool should not release/reallocate of memory during runtime.

Given that our most common use case today comprises the use of an RMM pool, we may reenable this to facilitate users' life. It's still possible to disable the cache by setting the environment variable `UCX_CUDA_IPC_CACHE=n`, and this may be required for any uses cases that do not include the use of a memory pool at the risk of running OOM otherwise.