### PR TITLE
Pass `size` as keyword argument to `DeviceBuffer`

### DIFF
--- a/tests/test_send_recv_two_workers.py
+++ b/tests/test_send_recv_two_workers.py
@@ -21,7 +21,7 @@ ITERATIONS = 1
 
 
 def cuda_array(size):
-    return rmm.DeviceBuffer(size)
+    return rmm.DeviceBuffer(size=size)
 
 
 async def get_ep(name, port):


### PR DESCRIPTION
As `DeviceBuffer` requires arguments passed to its constructor are keyword arguments, make sure to pass `size` as a keyword argument as well.