### PR TITLE
[WIP] Direct nvlink support

### DIFF
--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -16,7 +16,6 @@ mp = mp.get_context("spawn")
 
 
 def server(queue, args):
-    numba.cuda.current_context()
     ucp.init()
 
     if args.object_type == "numpy":
@@ -70,7 +69,6 @@ def server(queue, args):
 
 
 def client(queue, port, args):
-    numba.cuda.current_context()
     import ucp
 
     ucp.init()

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -10,11 +10,13 @@ from distributed.utils import format_bytes, parse_bytes
 
 import numpy
 import ucp
+import numba
 
 mp = mp.get_context("spawn")
 
 
 def server(queue, args):
+    numba.cuda.current_context()
     ucp.init()
 
     if args.object_type == "numpy":
@@ -68,6 +70,7 @@ def server(queue, args):
 
 
 def client(queue, port, args):
+    numba.cuda.current_context()
     import ucp
 
     ucp.init()

--- a/tests/test_own_ipc_comm.py
+++ b/tests/test_own_ipc_comm.py
@@ -9,7 +9,6 @@ import cupy
 
 
 async def worker(rank, eps, args):
-    numba.cuda.current_context()
     rmm.reinitialize(pool_allocator=True, initial_pool_size=1000000)
     cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
 

--- a/tests/test_own_ipc_comm.py
+++ b/tests/test_own_ipc_comm.py
@@ -1,0 +1,34 @@
+import asyncio
+import os
+
+import numpy as np
+import ucp.utils
+import rmm
+import numba
+import cupy
+
+
+async def worker(rank, eps, args):
+    numba.cuda.current_context()
+    rmm.reinitialize(pool_allocator=True, initial_pool_size=1000000)
+    cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+
+    if rank == 0:
+        res = []
+        for ep in eps.values():
+
+            data = rmm.DeviceBuffer(size=10)
+            await ep.recv(data)
+            res.append(cupy.asnumpy(cupy.asarray(data)).sum())
+        assert int(sum(res)) == sum(range(10, (len(eps)+1)*10, 10))
+    else:
+        #data = rmm.DeviceBuffer(size=10)
+        #d = cupy.asarray(data)
+        d = cupy.empty((10,), dtype="u1")
+        d[:] = rank
+        await eps[0].send(d)
+
+
+def test_own_ipc_comm(n_workers=2):
+    os.environ["UCXPY_OWN_CUDA_IPC"] = "1"
+    ucp.utils.run_on_local_network(n_workers, worker)

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -84,6 +84,7 @@ def get_closest_net_devices(gpu_dev):
 def _worker_process(
     queue, rank, server_address, n_workers, ucx_options_list, func, args
 ):
+    #os.environ["CUDA_VISIBLE_DEVICES"] = "%s" % rank
     import ucp
 
     if ucx_options_list is not None:


### PR DESCRIPTION
This PR implements our own nvlink support that doesn't use UCX. It started as an experiment to debug performance issue with nvlink and UCX but I ended up implementing direct nvlink support in ucxpy :)

Hopefully, UCX and how we use it gets to a point where this isn't necessary but until then I think this is useful; both to get a baseline of what we can expect of UCX and also for UCX performance debugging.

In order to use this new nvlink implementation, set `UCXPY_OWN_CUDA_IPC=1` **and** make sure to use RMM memory allocations.

Notice, this PR is **not** ready for review --  I still need to do a lot of code cleaning e.g right now must of it is implemented in `public_api.py` and should be moved into `core.pyx`

Running the `local-send-recv.py` benchmark, I get **3 times speedup** on large messages (1GB) and - **26 times speedup** on small messages (1MB). 

Beside better performance, this implementation is not sensitive to other UCX options. For instance, it doesn't degrade performance to have infiniband enabled while using nvlink.

#### On DGX-1 with new nvlink implementation (1GB)
```
$ UCXPY_OWN_CUDA_IPC=1 python local-send-recv.py -n "1GB" --server-dev 1 --client-dev 2 --object_type rmm 
Roundtrip benchmark
--------------------------
n_iter      | 10
n_bytes     | 1000.00 MB
object      | rmm
reuse alloc | False
==========================
Device(s)   | 1, 2
Average     | 37.40 GB/s
--------------------------
Iterations
--------------------------
000         | 12.94 GB/s
001         | 46.83 GB/s
002         | 47.59 GB/s
003         | 47.58 GB/s
004         | 47.51 GB/s
```
#### On DGX-1 with old UCX implementation (1GB)
```
$ python local-send-recv.py -n "1GB" --server-dev 1 --client-dev 2 --object_type rmm 
Roundtrip benchmark
--------------------------
n_iter      | 10
n_bytes     | 1000.00 MB
object      | rmm
reuse alloc | False
==========================
Device(s)   | 1, 2
Average     | 14.88 GB/s
--------------------------
Iterations
--------------------------
000         | 10.01 GB/s
001         | 15.50 GB/s
002         | 15.35 GB/s
003         | 15.74 GB/s
004         | 15.78 GB/s
```

#### On DGX-1 with new nvlink implementation (1MB)
```
$ UCXPY_OWN_CUDA_IPC=1 python local-send-recv.py -n "1MB" --server-dev 1 --client-dev 2 --object_type rmm 
Roundtrip benchmark
--------------------------
n_iter      | 10
n_bytes     | 1000.00 kB
object      | rmm
reuse alloc | False
==========================
Device(s)   | 1, 2
Average     | 1.81 GB/s
--------------------------
Iterations
--------------------------
000         |389.90 MB/s
001         |  3.11 GB/s
002         |  3.15 GB/s
003         |  3.01 GB/s
004         |  3.09 GB/s
005         |  2.37 GB/s
```
#### On DGX-1 with old UCX implementation (1MB)
```
$ python local-send-recv.py -n "1MB" --server-dev 1 --client-dev 2 --object_type rmm 
Roundtrip benchmark
--------------------------
n_iter      | 10
n_bytes     | 1000.00 kB
object      | rmm
reuse alloc | False
==========================
Device(s)   | 1, 2
Average     | 132.03 MB/s
--------------------------
Iterations
--------------------------
000         |121.56 MB/s
001         |108.79 MB/s
002         |137.85 MB/s
003         |138.23 MB/s
004         |136.94 MB/s

```