### PR TITLE
Rename package to ucx-py in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ ext_modules = [
 ]
 
 setup(
-    name="ucxpy",
+    name="ucx-py",
     packages=["ucp"],
     ext_modules=ext_modules,
     cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
The package name is `ucx-py` for both [rapidsai](https://anaconda.org/rapidsai/ucx-py) and [conda-forge](https://anaconda.org/conda-forge/ucx-py) channels, therefore I think renaming it is good to make things consistent.