### PR TITLE
[Merge] Epoll wait follows worker arming 

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -536,6 +536,8 @@ cdef class ApplicationContext:
                     break
 
         def _fd_reader_callback():
+            # Notice, we can safely overwrite `self.dangling_arm_task`
+            # since previous arm task is finished by now.
             self.dangling_arm_task = event_loop.create_task(_arm())
 
         event_loop.add_reader(self.epoll_fd, _fd_reader_callback)

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -371,6 +371,7 @@ cdef class ApplicationContext:
         if self.blocking_progress_mode:
             status = ucp_worker_get_efd(self.worker, &ucp_epoll_fd)
             assert_ucs_status(status)
+            self.progress()
             status = ucp_worker_arm(self.worker)
             assert_ucs_status(status)
 

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -505,7 +505,7 @@ cdef class ApplicationContext:
 
         async def _arm():
             # When arming the worker, the following must be true:
-            #  - Nothing more in UCX to progress. See doc of ucp_worker_arm()
+            #  - No more progress in UCX (see doc of ucp_worker_arm())
             #  - All asyncio tasks that isn't waiting on UCX must be executed
             #    so that the asyncio's next state is epoll wait.
             #    See <https://github.com/rapidsai/ucx-py/issues/413>


### PR DESCRIPTION
This PR fixes https://github.com/rapidsai/ucx-py/issues/413 by making sure that asyncio's next state after calling `ucp_worker_arm()` is epoll wait.