### PR TITLE
Allow `ucx-proc` to be unspecified

### DIFF
--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -10,7 +10,6 @@ dependencies:
 - sphinxcontrib-websupport
 - nbsphinx
 - numpydoc
-- ucx-proc=*=cpu
 - recommonmark
 - pandoc=<2.0.0
 - pip


### PR DESCRIPTION
Based on UCX's `dlopen` behavior, it should be ok to install the GPU build on a CPU only machine. So leave `ucx-proc` unspecified and allow Conda to just pick one. This should help with our doc building issues where `ucx-proc`'s CPU build is not found.

cc @quasiben