### PR TITLE
Correct UCX_RNDV_THRESH environment variable name

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -53,9 +53,9 @@ This is a UCX CUDA Memory optimization which enables/disables a remote endpoint 
 
 Values: n/y
 
-``UCX_RNDV_THRESHOLD``
+``UCX_RNDV_THRESH``
 
-This is a configurable parameter used by UCX to help determine which transport method should be used.  For example, on machines with multiple GPUs, and with NVLink enabled, UCX can deliver messages either through TCP or NVLink.  Sending GPU buffers over TCP is costly as it triggers a device-to-host on the sender side, and then host-to-device transfer on the receiver side --  we want to avoid these kinds of transfers when NVLink is available.  If a buffer is below the threshold, `Rendezvous-Protocol <https://github.com/openucx/ucx/wiki/Rendezvous-Protocol>`_ is triggered and for UCX-Py users, this will typically mean messages will be delivered through TCP.  Depending on the application, messages can be quite small, therefore, we recommend setting a small value if the application uses NVLink or InfiniBand: ``UCX_RNDV_THRESHOLD=8192``
+This is a configurable parameter used by UCX to help determine which transport method should be used.  For example, on machines with multiple GPUs, and with NVLink enabled, UCX can deliver messages either through TCP or NVLink.  Sending GPU buffers over TCP is costly as it triggers a device-to-host on the sender side, and then host-to-device transfer on the receiver side --  we want to avoid these kinds of transfers when NVLink is available.  If a buffer is below the threshold, `Rendezvous-Protocol <https://github.com/openucx/ucx/wiki/Rendezvous-Protocol>`_ is triggered and for UCX-Py users, this will typically mean messages will be delivered through TCP.  Depending on the application, messages can be quite small, therefore, we recommend setting a small value if the application uses NVLink or InfiniBand: ``UCX_RNDV_THRESH=8192``
 
 
 ``UCX_RNDV_SCHEME``


### PR DESCRIPTION
From the wiki, this appears to be named `UCX_RNDV_THRESH`. So have updated it here. However not totally sure about this. So please check.