### PR TITLE
Add psutil as a dependency

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -56,7 +56,7 @@ conda install "cudatoolkit=$CUDA_REL" \
 conda install -c conda-forge "async_generator" "automake" "libtool" \
                               "cmake" "automake" "autoconf" "cython>=0.29.14,<3.0.0a0" \
                               "pytest" "pkg-config" "pytest-asyncio" \
-                              "pynvml" "libhwloc"
+                              "pynvml" "libhwloc" "psutil"
 
 # Install the master version of dask and distributed
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"

--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -14,6 +14,7 @@ dependencies:
 - recommonmark
 - pandoc=<2.0.0
 - pip
+- psutil
 - libhwloc
 - ucx
 - ucx-py

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -46,7 +46,7 @@ Build Dependencies
 
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
-        libhwloc \
+        libhwloc psutil \
         python=3.7 setuptools cython>=0.29.14,<3.0.0a0
 
 Test Dependencies


### PR DESCRIPTION
`psutil` was introduced as a dependency in https://github.com/rapidsai/ucx-py/pull/423, but it was not updated as such, this PR addresses it.