### PR TITLE
Mark sure Python exceptions get raised

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -255,7 +255,7 @@ async def listener_handler(ucp_endpoint, ctx, ucp_worker, func, guarantee_msg_or
         await _func(pub_ep)
 
 
-cdef void _listener_callback(ucp_ep_h ep, void *args):
+cdef void _listener_callback(ucp_ep_h ep, void *args) except *:
     cdef _listener_callback_args *a = <_listener_callback_args *> args
     cdef object ctx = <object> a.py_ctx
     cdef object func = <object> a.py_func

--- a/ucp/_libs/send_recv.pyx
+++ b/ucp/_libs/send_recv.pyx
@@ -53,7 +53,7 @@ cdef create_future_from_comm_status(ucs_status_ptr_t status,
     return ret
 
 
-cdef void _send_callback(void *request, ucs_status_t status):
+cdef void _send_callback(void *request, ucs_status_t status) except *:
     cdef ucp_request *req = <ucp_request*> request
     if req.future == NULL:
         # This callback function was called before ucp_tag_send_nb() returned
@@ -93,7 +93,7 @@ def tag_send(uintptr_t ucp_ep, buffer, size_t nbytes,
 
 
 cdef void _tag_recv_callback(void *request, ucs_status_t status,
-                             ucp_tag_recv_info_t *info):
+                             ucp_tag_recv_info_t *info) except *:
     cdef ucp_request *req = <ucp_request*> request
     if req.future == NULL:
         # This callback function was called before ucp_tag_recv_nb() returned
@@ -156,7 +156,7 @@ def stream_send(uintptr_t ucp_ep, buffer, size_t nbytes, pending_msg=None):
 
 
 cdef void _stream_recv_callback(void *request, ucs_status_t status,
-                                size_t length):
+                                size_t length) except *:
     cdef ucp_request *req = <ucp_request*> request
     if req.future == NULL:
         # This callback function was called before ucp_stream_recv_nb() returned


### PR DESCRIPTION
Make sure any Python exceptions from `cdef` functions with non-Python return types are being propagated upwards.