### PR TITLE
Drop `void` return type when raising exceptions

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -255,7 +255,7 @@ async def listener_handler(ucp_endpoint, ctx, ucp_worker, func, guarantee_msg_or
         await _func(pub_ep)
 
 
-cdef void _listener_callback(ucp_ep_h ep, void *args) except *:
+cdef _listener_callback(ucp_ep_h ep, void *args):
     cdef _listener_callback_args *a = <_listener_callback_args *> args
     cdef object ctx = <object> a.py_ctx
     cdef object func = <object> a.py_func

--- a/ucp/_libs/send_recv.pyx
+++ b/ucp/_libs/send_recv.pyx
@@ -53,7 +53,7 @@ cdef create_future_from_comm_status(ucs_status_ptr_t status,
     return ret
 
 
-cdef void _send_callback(void *request, ucs_status_t status) except *:
+cdef _send_callback(void *request, ucs_status_t status):
     cdef ucp_request *req = <ucp_request*> request
     if req.future == NULL:
         # This callback function was called before ucp_tag_send_nb() returned
@@ -92,8 +92,8 @@ def tag_send(uintptr_t ucp_ep, buffer, size_t nbytes,
     return create_future_from_comm_status(status, nbytes, pending_msg)
 
 
-cdef void _tag_recv_callback(void *request, ucs_status_t status,
-                             ucp_tag_recv_info_t *info) except *:
+cdef _tag_recv_callback(void *request, ucs_status_t status,
+                        ucp_tag_recv_info_t *info):
     cdef ucp_request *req = <ucp_request*> request
     if req.future == NULL:
         # This callback function was called before ucp_tag_recv_nb() returned


### PR DESCRIPTION
Fixes https://github.com/rapidsai/ucx-py/issues/435

After poking at this a bit locally, it seems Cython's `except *` is picking up exceptions set through `asyncio` even when it shouldn't. Not sure if this behavior is due to Python or Cython. That said, we can avoid using `except *` here by using `cdef` without the `void` return type (this is the same as `cdef object`). Based on running things locally this seems to behave correctly for me. Though please check as well.