### PR TITLE
Cleaning up the shutdown of Context, Endpoint, and Listener

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -322,7 +322,7 @@ cdef class ApplicationContext:
         ucp_worker_h worker
         int epoll_fd
         object event_loops_binded_for_progress
-        object progress_tasks
+        list progress_tasks
         bint blocking_progress_mode
         object dangling_arm_task
 

--- a/ucp/public_api.py
+++ b/ucp/public_api.py
@@ -231,7 +231,7 @@ class Listener:
     def close(self):
         """Closing the listener"""
         if not self._closed:
-            self._b.destroy()
+            self._b.abort()
             self._closed = True
             self._b = None
 


### PR DESCRIPTION
This PR makes sure that the shutdown order of Context, Endpoints, and Listeners is correct.

Context now has a weak reference to all _child_ objects and makes sure to abort them before destroying the UCX context. 