### PR TITLE
Use Cython's `new_build_ext` (if available)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ import versioneer
 from setuptools import setup
 from setuptools.extension import Extension
 
-from setuptools.command.build_ext import build_ext
+try:
+    from Cython.Distutils.build_ext import new_build_ext as build_ext
+except ImportError:
+    from setuptools.command.build_ext import build_ext
 
 
 include_dirs = [os.path.dirname(get_python_inc())]

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ import versioneer
 from setuptools import setup
 from setuptools.extension import Extension
 
+from setuptools.command.build_ext import build_ext
+
 
 include_dirs = [os.path.dirname(get_python_inc())]
 library_dirs = [get_config_var("LIBDIR")]
@@ -66,6 +68,7 @@ ext_modules = [
 
 cmdclass = dict()
 cmdclass.update(versioneer.get_cmdclass())
+cmdclass["build_ext"] = build_ext
 
 setup(
     name="ucx-py",

--- a/setup.py
+++ b/setup.py
@@ -64,11 +64,14 @@ ext_modules = [
     ),
 ]
 
+cmdclass = dict()
+cmdclass.update(versioneer.get_cmdclass())
+
 setup(
     name="ucx-py",
     packages=["ucp"],
     ext_modules=ext_modules,
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass=cmdclass,
     version=versioneer.get_version(),
     python_requires=">=3.6",
     description="Python Bindings for the Unified Communication X library (UCX)",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ import versioneer
 from setuptools import setup
 from setuptools.extension import Extension
 
+
 include_dirs = [os.path.dirname(get_python_inc())]
 library_dirs = [get_config_var("LIBDIR")]
 libraries = ["ucp", "uct", "ucm", "ucs", "hwloc"]


### PR DESCRIPTION
Try to use Cython's `new_build_ext` (planned to replace it's current `build_ext`) in order to benefit from features (like parallel builds). Though maintain a fallback to Setuptools in cases where Cython might not be present as needed for building (like checking the version). Note Setuptools would like to adopt this behavior in the future, but hasn't yet ( https://github.com/pypa/setuptools/issues/1270 ).