### PR TITLE
Mark `initialized` as `readonly`

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -103,6 +103,7 @@ cdef class UCXContext:
         object __weakref__
         ucp_context_h _handle
         dict _config
+
     cdef public:
         bint initialized
 
@@ -160,6 +161,7 @@ cdef class UCXWorker:
         object __weakref__
         ucp_worker_h _handle
         UCXContext _context
+
     cdef public:
         bint initialized
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -104,7 +104,7 @@ cdef class UCXContext:
         ucp_context_h _handle
         dict _config
 
-    cdef public:
+    cdef readonly:
         bint initialized
 
     def __cinit__(self, config_dict):
@@ -162,7 +162,7 @@ cdef class UCXWorker:
         ucp_worker_h _handle
         UCXContext _context
 
-    cdef public:
+    cdef readonly:
         bint initialized
 
     def __cinit__(self, UCXContext context):
@@ -256,8 +256,10 @@ cdef class UCXEndpoint:
         object __weakref__
         ucp_ep_h _handle
 
-    cdef public:
+    cdef readonly:
         bint initialized
+
+    cdef public:
         UCXWorker worker
 
     def __cinit__(self, worker):


### PR DESCRIPTION
As it sounds like `initialized` should be visible externally, but should not be modifiable. This makes makes it `readonly` so that it can be checked in external usage, but not changed.

cc @pentschev @madsbk