### PR TITLE
Closing Fixes

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -422,10 +422,14 @@ class _Endpoint:
                     self._ctrl_tag_send,
                     pending_msg=self.pending_msg_list[-1]
                 )
-            except UCXError:
+            except UCXError as e:
+                log = "UCX Closing Error on worker %d\n%s" % (hex(self.uid), str(e))
+                logging.error(log)
                 pass  # The peer might already be shutting down
-            # Give all current outstanding send() calls a chance to return
-            self._ctx.worker.progress()
+            else:
+                # Only if there were no errors closing peer
+                # Give all current outstanding send() calls a chance to return
+                self._ctx.worker.progress()
             await asyncio.sleep(0)
         finally:
             self.abort()

--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -422,10 +422,10 @@ class _Endpoint:
                     self._ctrl_tag_send,
                     pending_msg=self.pending_msg_list[-1]
                 )
+            # The peer might already be shutting down
             except UCXError as e:
                 log = "UCX Closing Error on worker %d\n%s" % (hex(self.uid), str(e))
                 logging.error(log)
-                pass  # The peer might already be shutting down
             else:
                 # Only if there were no errors closing peer
                 # Give all current outstanding send() calls a chance to return


### PR DESCRIPTION
In some dask workflows we occasionally get an error like the following:

>   File "ucp/_libs/core.pyx", line 640, in close
AttributeError: 'NoneType' object has no attribute 'progress'

Thus far I've only been able to generate this error when using multiple nodes and IB with the following reproducer:

```python
from distributed import Client
client = Client("ucx://...")

client.upload_file('file.txt')
```

I still don't understand why things are happening this way, but it seems like ucx-py or ucx has already closed/aborted the endpoint by the time ucx-py gets to the  cython `close` function.  At this point, the worker is None and is unable to call `progress`.   This PR moves the progess call under `else` so it is only called if the try succeeds without exception