### PR TITLE
Endpoint: shutdown peer once

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -372,7 +372,7 @@ class _Endpoint:
         self._recv_count = 0  # Number of calls to self.recv()
         self._finished_recv_count = 0  # Number of returned (finished) self.recv() calls
         self._closed = False
-        self._shutting_down_peer = False  # Told peer to shutdown down
+        self._shutting_down_peer = False  # Told peer to shutdown
         self.pending_msg_list = []
         # UCX supports CUDA if "cuda" is part of the TLS or TLS is "all"
         tls = ctx.get_config()["TLS"]


### PR DESCRIPTION
This PR makes sure that an endpoint only tells peer to shutdown once.

This PR should also fix the close issue seen in https://github.com/rapidsai/ucx-py/pull/473. 
@quasiben, can you to confirm that you don't see the error?:

    File "ucp/_libs/core.pyx", line 640, in close
    AttributeError: 'NoneType' object has no attribute 'progress'
 
