### PR TITLE
Set rsock/wsock to blocking

### DIFF
--- a/ucp/continuous_ucx_progress.py
+++ b/ucp/continuous_ucx_progress.py
@@ -63,6 +63,8 @@ class BlockingMode(ProgressTask):
         # all non-IO tasks are finished.
         # See <https://stackoverflow.com/a/48491563>.
         self.rsock, wsock = socket.socketpair()
+        self.rsock.setblocking(0)
+        wsock.setblocking(0)
         wsock.close()
 
         # Bind an asyncio reader to a UCX epoll file descripter


### PR DESCRIPTION
It's still unclear whether this is the right solution or if it impacts performance, but it potentially resolves #480 . When running Dask+UCX-Py with `python -X dev` we keep seeing `ValueError: the socket must be non-blocking` being thrown during `BlockingMode._fd_reader_callback`, which calls `ucp_worker_progress` .