### PR TITLE
Implementing exchange_peer_info() using struct

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -11,6 +11,7 @@ from random import randint
 import psutil
 import uuid
 import socket
+import struct
 import logging
 from os import close as close_fd
 
@@ -42,36 +43,30 @@ def asyncio_handle_exception(loop, context):
     log("Ignored except: %s %s" % (type(msg), msg))
 
 
-cdef struct PeerInfoMsg:
-    uint64_t msg_tag
-    uint64_t ctrl_tag
-    bint guarantee_msg_order
-
-
 async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, guarantee_msg_order):
     """Help function that exchange endpoint information"""
 
-    cdef PeerInfoMsg my_info = {
-        'msg_tag': msg_tag,
-        'ctrl_tag': ctrl_tag,
-        'guarantee_msg_order': guarantee_msg_order
-    }
-    cdef PeerInfoMsg[::1] my_info_mv = <PeerInfoMsg[:1:1]>(&my_info)
-    cdef PeerInfoMsg peer_info
-    cdef PeerInfoMsg[::1] peer_info_mv = <PeerInfoMsg[:1:1]>(&peer_info)
+    msg_tag = int(msg_tag)
+    ctrl_tag = int(ctrl_tag)
+    guarantee_msg_order = bool(guarantee_msg_order)
+    my_info = struct.pack("QQ?", msg_tag, ctrl_tag, guarantee_msg_order)
+    peer_info = bytearray(len(my_info))
 
     await asyncio.gather(
-        ucx_api.stream_recv(endpoint, peer_info_mv, peer_info_mv.nbytes),
-        ucx_api.stream_send(endpoint, my_info_mv, my_info_mv.nbytes),
+        ucx_api.stream_recv(endpoint, peer_info, len(peer_info)),
+        ucx_api.stream_send(endpoint, my_info, len(my_info)),
+    )
+    peer_msg_tag, peer_ctrl_tag, peer_guarantee_msg_order = struct.unpack(
+        "QQ?", peer_info
     )
 
-    if peer_info.guarantee_msg_order != guarantee_msg_order:
+    if peer_guarantee_msg_order != guarantee_msg_order:
         raise ValueError("Both peers must set guarantee_msg_order identically")
 
     return {
-        'msg_tag': peer_info.msg_tag,
-        'ctrl_tag': peer_info.ctrl_tag,
-        'guarantee_msg_order': peer_info.guarantee_msg_order
+        "msg_tag": peer_msg_tag,
+        "ctrl_tag": peer_ctrl_tag,
+        "guarantee_msg_order": peer_guarantee_msg_order,
     }
 
 


### PR DESCRIPTION
Implementing `exchange_peer_info()` using the `struct` module instead of cython's struct.

This PR is part of the effort to restrict the use of Cython to `ucx_api.pyx`