### PR TITLE
Add NVTX annotations

### DIFF
--- a/ucp/_libs/core.pyx
+++ b/ucp/_libs/core.pyx
@@ -22,6 +22,7 @@ from ..exceptions import (
     UCXWarning,
     UCXConfigError,
 )
+from ..utils import nvtx_annotate
 from .. import continuous_ucx_progress
 
 from .utils import get_buffer_nbytes
@@ -447,6 +448,7 @@ class _Endpoint:
     def __del__(self):
         self.abort()
 
+    @nvtx_annotate("UCXPY_SEND", color="green", domain="ucxpy")
     async def send(self, buffer, nbytes=None):
         if self._closed:
             raise UCXCloseError("Endpoint closed")
@@ -473,6 +475,7 @@ class _Endpoint:
             pending_msg=self.pending_msg_list[-1]
         )
 
+    @nvtx_annotate("UCXPY_RECV", color="red", domain="ucxpy")
     async def recv(self, buffer, nbytes=None):
         if self._closed:
             raise UCXCloseError("Endpoint closed")

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -21,6 +21,7 @@ from ..exceptions import (
     UCXCanceled,
     UCXCloseError,
 )
+from ..utils import nvtx_annotate
 from .utils import get_buffer_data
 
 
@@ -219,6 +220,7 @@ cdef class UCXWorker:
         assert_ucs_status(status)
         return True
 
+    @nvtx_annotate("UCXPY_PROGRESS", color="blue", domain="ucxpy")
     def progress(self):
         assert self.initialized
         while ucp_worker_progress(self._handle) != 0:

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -232,6 +232,7 @@ except ImportError:
     # NVTX annotations functionality currently exists in cuDF, if cuDF isn't
     # installed, `annotate` yields only.
     from contextlib import contextmanager
+
     @contextmanager
     def nvtx_annotate(message=None, color=None, domain=None):
         yield

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -224,3 +224,14 @@ def run_on_local_network(
         assert not proc.exitcode
     assert len(results) == n_workers
     return results
+
+
+try:
+    from cudf._lib.nvtx import annotate as nvtx_annotate
+except ImportError:
+    # NVTX annotations functionality currently exists in cuDF, if cuDF isn't
+    # installed, `annotate` yields only.
+    from contextlib import contextmanager
+    @contextmanager
+    def nvtx_annotate(message=None, color=None, domain=None):
+        yield


### PR DESCRIPTION
NVTX annotations add a new row `ucxpy` to profiles, identifying `send`/`recv`/`progress` calls. See example below:

![Screenshot 2020-04-14 at 18 40 44](https://user-images.githubusercontent.com/4398246/79254350-e5898800-7e84-11ea-9222-c0512cd56e31.png)