### PR TITLE
Streamlining the destructors in the UCX API

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -230,6 +230,7 @@ cdef class UCXWorker(UCXObject):
         cdef ucp_params_t ucp_params
         cdef ucp_worker_params_t worker_params
         cdef ucs_status_t status
+        assert context.initialized
         self._context = context
         memset(&worker_params, 0, sizeof(worker_params))
         worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE
@@ -333,6 +334,8 @@ cdef class UCXEndpoint(UCXObject):
 
     cdef _init(self, UCXWorker worker, ucp_ep_h handle):
         """The Constructor"""
+
+        assert worker.initialized
         self.worker = worker
         self._handle = handle
         self.add_handle_finalizer(

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -103,12 +103,12 @@ def get_ucx_version():
     return (a, b, c)
 
 
-def _handle_finalizer_wrapper(children, handle_finalizer, handle_as_int):
+def _handle_finalizer_wrapper(children, handle_finalizer, handle_as_int, *extra_args):
     for weakref_to_child in children:
         child = weakref_to_child()
         if child is not None:
             child.close()
-    handle_finalizer(handle_as_int)
+    handle_finalizer(handle_as_int, *extra_args)
 
 
 cdef class UCXObject:
@@ -147,14 +147,15 @@ cdef class UCXObject:
         """
         self._children.append(weakref.ref(child))
 
-    def add_handle_finalizer(self, handle_finalizer, handle_as_int):
+    def add_handle_finalizer(self, handle_finalizer, handle_as_int, *extra_args):
         """Add a finalizer of `handle_as_int`"""
         self._finalizer = weakref.finalize(
             self,
             _handle_finalizer_wrapper,
             self._children,
             handle_finalizer,
-            handle_as_int
+            handle_as_int,
+            *extra_args
         )
 
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -199,7 +199,7 @@ cdef class UCXContext(UCXObject):
 
         self.add_handle_finalizer(
             _ucx_context_handle_finalizer,
-            int(<uintptr_t><void*>self._handle)
+            int(<uintptr_t>self._handle)
         )
 
         self._config = ucx_config_to_dict(config)
@@ -215,7 +215,7 @@ cdef class UCXContext(UCXObject):
     @property
     def handle(self):
         assert self.initialized
-        return int(<uintptr_t><void*>self._handle)
+        return int(<uintptr_t>self._handle)
 
 
 def _ucx_worker_handle_finalizer(uintptr_t handle_as_int, UCXContext ctx):
@@ -244,7 +244,7 @@ cdef class UCXWorker(UCXObject):
 
         self.add_handle_finalizer(
             _ucx_worker_handle_finalizer,
-            int(<uintptr_t><void*>self._handle),
+            int(<uintptr_t>self._handle),
             self._context
         )
         context.add_child(self)
@@ -291,7 +291,7 @@ cdef class UCXWorker(UCXObject):
     @property
     def handle(self):
         assert self.initialized
-        return int(<uintptr_t><void*>self._handle)
+        return int(<uintptr_t>self._handle)
 
     def request_cancel(self, ucp_request_as_int):
         assert self.initialized
@@ -312,7 +312,7 @@ cdef class UCXWorker(UCXObject):
         cdef ucs_status_t status = ucp_ep_create(self._handle, &params, &ucp_ep)
         c_util_get_ucp_ep_params_free(&params)
         assert_ucs_status(status)
-        return UCXEndpoint(self, <uintptr_t><void*> ucp_ep)
+        return UCXEndpoint(self, <uintptr_t>ucp_ep)
 
 
 def _ucx_endpoint_finalizer(uintptr_t handle_as_int, worker, inflight_msgs):
@@ -382,7 +382,7 @@ cdef class UCXEndpoint(UCXObject):
     @property
     def handle(self):
         assert self.initialized
-        return int(<uintptr_t><void*>self._handle)
+        return int(<uintptr_t>self._handle)
 
 
 cdef void _listener_callback(ucp_ep_h ep, void *args):
@@ -392,7 +392,7 @@ cdef void _listener_callback(ucp_ep_h ep, void *args):
     with log_errors():
         asyncio.ensure_future(
             cb_data['cb_coroutine'](
-                UCXEndpoint(ctx.worker, <uintptr_t><void*>ep),
+                UCXEndpoint(ctx.worker, <uintptr_t>ep),
                 ctx,
                 cb_data['cb_func'],
                 cb_data['guarantee_msg_order']
@@ -435,14 +435,14 @@ cdef class UCXListener(UCXObject):
 
         self.add_handle_finalizer(
             _ucx_listener_handle_finalizer,
-            int(<uintptr_t><void*>self._handle)
+            int(<uintptr_t>self._handle)
         )
         worker.add_child(self)
 
     @property
     def handle(self):
         assert self.initialized
-        return int(<uintptr_t><void*>self._handle)
+        return int(<uintptr_t>self._handle)
 
 
 cdef create_future_from_comm_status(ucs_status_ptr_t status,
@@ -471,7 +471,7 @@ cdef create_future_from_comm_status(ucs_status_ptr_t status,
             ucp_request_reset(req)
             ucp_request_free(req)
         else:
-            req_as_int = int(<uintptr_t><void*>req)
+            req_as_int = int(<uintptr_t>req)
             # The callback function has not been called yet.
             # We fill `ucp_request` for the callback function to use
             Py_INCREF(ret)
@@ -511,7 +511,7 @@ cdef void _send_callback(void *request, ucs_status_t status):
     ucp_request_free(request)
 
     with log_errors():
-        del inflight_msgs[int(<uintptr_t><void*>req)]
+        del inflight_msgs[int(<uintptr_t>req)]
         if event_loop.is_closed() or future.done():
             pass
         elif status == UCS_ERR_CANCELED:
@@ -563,7 +563,7 @@ cdef void _tag_recv_callback(void *request, ucs_status_t status,
     ucp_request_free(request)
 
     with log_errors():
-        del inflight_msgs[int(<uintptr_t><void*>req)]
+        del inflight_msgs[int(<uintptr_t>req)]
         msg = "Error receiving%s " %(" \"%s\":" % log_msg if log_msg else ":")
         if event_loop.is_closed() or future.done():
             pass
@@ -638,7 +638,7 @@ cdef void _stream_recv_callback(void *request, ucs_status_t status,
     ucp_request_free(request)
 
     with log_errors():
-        del inflight_msgs[int(<uintptr_t><void*>req)]
+        del inflight_msgs[int(<uintptr_t>req)]
         msg = "Error receiving %s" %(" \"%s\":" % log_msg if log_msg else ":")
         if event_loop.is_closed() or future.done():
             pass

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -671,6 +671,6 @@ def stream_recv(UCXEndpoint ep, buffer, size_t nbytes, log_msg=None):
         ucp_dt_make_contig(1),
         _stream_recv_cb,
         &length,
-        0
+        UCP_STREAM_RECV_FLAG_WAITALL,
     )
     return create_future_from_comm_status(status, nbytes, log_msg, ep._inflight_msgs)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -570,7 +570,7 @@ cdef void _tag_recv_callback(void *request, ucs_status_t status,
             future.set_result(True)
 
 
-def tag_recv(UCXWorker worker, buffer, size_t nbytes,
+def tag_recv(UCXEndpoint ep, buffer, size_t nbytes,
              ucp_tag_t tag, pending_msg=None):
 
     cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
@@ -579,7 +579,7 @@ def tag_recv(UCXWorker worker, buffer, size_t nbytes,
         <ucp_tag_recv_callback_t>_tag_recv_callback
     )
     cdef ucs_status_ptr_t status = ucp_tag_recv_nb(
-        worker._handle,
+        ep.worker._handle,
         data,
         nbytes,
         ucp_dt_make_contig(1),

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -388,7 +388,7 @@ cdef UCXEndpoint ucx_ep_create(ucp_ep_h ep, UCXWorker worker):
     return ret
 
 
-def ucx_ep_create_from_uintptr(ep, worker):
+def ucx_ep_create_from_uintptr(uintptr_t ep, worker):
     ret = UCXEndpoint()
     ret._init(worker, <ucp_ep_h>ep)
     return ret

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -103,7 +103,9 @@ def get_ucx_version():
     return (a, b, c)
 
 
-def _handle_finalizer_wrapper(children, handle_finalizer, handle_as_int, *extra_args, **extra_kargs):
+def _handle_finalizer_wrapper(
+    children, handle_finalizer, handle_as_int, *extra_args, **extra_kargs
+):
     for weakref_to_child in children:
         child = weakref_to_child()
         if child is not None:

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -165,6 +165,7 @@ cdef extern from "ucp/api/ucp.h":
                                         size_t count, ucp_datatype_t datatype,
                                         ucp_send_callback_t cb, unsigned flags)
 
+    unsigned UCP_STREAM_RECV_FLAG_WAITALL
     ucs_status_ptr_t ucp_stream_recv_nb(ucp_ep_h ep, void *buffer,
                                         size_t count, ucp_datatype_t datatype,
                                         ucp_stream_recv_callback_t cb,

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -243,6 +243,7 @@ cdef struct ucp_request:
     PyObject *future
     PyObject *event_loop
     PyObject *log_str
+    PyObject *inflight_msgs
     size_t expected_receive
     int64_t received
 
@@ -253,5 +254,6 @@ cdef inline void ucp_request_reset(void* request):
     req.future = NULL
     req.event_loop = NULL
     req.log_str = NULL
+    req.inflight_msgs = NULL
     req.expected_receive = 0
     req.received = -1

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -131,6 +131,7 @@ cdef extern from "ucp/api/ucp.h":
     ctypedef uint64_t ucp_datatype_t
 
     bint UCS_PTR_IS_ERR(ucs_status_ptr_t)
+    bint UCS_PTR_IS_PTR(ucs_status_ptr_t)
     ucs_status_t UCS_PTR_STATUS(ucs_status_ptr_t)
 
     ctypedef void (*ucp_send_callback_t)(void *request, ucs_status_t status)  # noqa

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -242,7 +242,7 @@ cdef struct ucp_request:
     bint finished
     PyObject *future
     PyObject *event_loop
-    PyObject *log_str
+    PyObject *log_msg
     PyObject *inflight_msgs
     size_t expected_receive
     int64_t received
@@ -253,7 +253,7 @@ cdef inline void ucp_request_reset(void* request):
     req.finished = False
     req.future = NULL
     req.event_loop = NULL
-    req.log_str = NULL
+    req.log_msg = NULL
     req.inflight_msgs = NULL
     req.expected_receive = 0
     req.received = -1

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -266,8 +266,8 @@ class ApplicationContext:
 
         logger.info("create_listener() - Start listening on port %d" % port)
         ret = ucx_api.UCXListener(
+            self.worker,
             port,
-            self,
             {
                 "cb_func": callback_func,
                 "cb_coroutine": _listener_handler,
@@ -407,7 +407,7 @@ class Listener:
     def close(self):
         """Closing the listener"""
         if not self._closed:
-            self._b.abort()
+            self._b.close()
             self._closed = True
             self._b = None
 

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -106,7 +106,7 @@ class CtrlMsg:
         ep.pending_msg_list.append({"log": log})
         msg = bytearray(CtrlMsg.nbytes)
         shutdown_fut = ucx_api.tag_recv(
-            ep._ctx.worker,
+            ep._ep,
             msg,
             len(msg),
             ep._ctrl_tag_recv,
@@ -586,7 +586,7 @@ class Endpoint:
         if self._guarantee_msg_order:
             tag += self._recv_count
         ret = await ucx_api.tag_recv(
-            self._ctx.worker, buffer, nbytes, tag, pending_msg=self.pending_msg_list[-1]
+            self._ep, buffer, nbytes, tag, pending_msg=self.pending_msg_list[-1]
         )
         self._finished_recv_count += 1
         if (

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -387,10 +387,6 @@ class Listener:
         """Closing the listener"""
         self._b.close()
 
-    def abort(self):
-        """Closing the listener"""
-        self._b.close()
-
 
 class Endpoint:
     """An endpoint represents a connection to a peer


### PR DESCRIPTION
This PR make sure that all calls to the UCX is using valid UCX handles and streamlines the destruction of UCX handles. 