### PR TITLE
Fixed wrong indentation in abort of an endpoint

### DIFF
--- a/ucp/core.py
+++ b/ucp/core.py
@@ -471,7 +471,7 @@ class Endpoint:
                 logger.debug("Future cancelling: %s" % msg["log"])
                 self._ctx.worker.request_cancel(msg["ucp_request"])
 
-                self._ep.close()
+        self._ep.close()
         self._ep = None
         self._ctx = None
 


### PR DESCRIPTION
Fixed wrong indentation in `Endpoint.abort()`, which made the endpoint not close if there wasn't any outstanding messages :flushed: