### PR TITLE
Progress after endpoint create

### DIFF
--- a/tests/test_multiple_nodes.py
+++ b/tests/test_multiple_nodes.py
@@ -47,3 +47,14 @@ async def test_one_server_many_clients():
     for _ in range(100):
         clients.append(client_node(lf.port))
     await asyncio.gather(*clients, loop=asyncio.get_event_loop())
+
+
+@pytest.mark.asyncio
+async def test_two_servers_many_clients():
+    lf1 = ucp.create_listener(server_node)
+    lf2 = ucp.create_listener(server_node)
+    clients = []
+    for _ in range(100):
+        clients.append(client_node(lf1.port))
+        clients.append(client_node(lf2.port))
+    await asyncio.gather(*clients, loop=asyncio.get_event_loop())

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -297,6 +297,7 @@ class ApplicationContext:
         """
         self.continuous_ucx_progress()
         ucx_ep = self.worker.ep_create(ip_address, port)
+        self.worker.progress()
 
         # We create the Endpoint in four steps:
         #  1) Generate unique IDs to use as tags


### PR DESCRIPTION
UCX hangs when many clients (~100) call `ep_create()` without any call to `progress()` in between.

This PR adds a test of the case and fix the hang by calling `progress()` right after the call to `ep_create()`, which is probably a good idea in any case.