### PR TITLE
Cleanup setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ except ImportError:
     from setuptools.command.build_ext import build_ext
 
 
+with open("README.md", "r") as fh:
+    readme = fh.read()
+
 include_dirs = [os.path.dirname(get_python_inc())]
 library_dirs = [get_config_var("LIBDIR")]
 libraries = ["ucp", "uct", "ucm", "ucs", "hwloc"]
@@ -72,7 +75,7 @@ setup(
     python_requires=">=3.6",
     install_requires=["numpy", "psutil"],
     description="Python Bindings for the Unified Communication X library (UCX)",
-    long_description=open("README.md").read(),
+    long_description=readme,
     author="NVIDIA Corporation",
     license="BSD-3-Clause",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from distutils.sysconfig import get_config_var, get_python_inc
 
 import versioneer
-from setuptools import setup
+from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
 try:
@@ -73,7 +73,7 @@ install_requires = [
 
 setup(
     name="ucx-py",
-    packages=["ucp"],
+    packages=find_packages(exclude=["tests*"]),
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     version=versioneer.get_version(),

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     long_description=readme,
     author="NVIDIA Corporation",
     license="BSD-3-Clause",
+    zip_safe=False,
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,11 @@ cmdclass = dict()
 cmdclass.update(versioneer.get_cmdclass())
 cmdclass["build_ext"] = build_ext
 
+install_requires = [
+    "numpy",
+    "psutil",
+]
+
 setup(
     name="ucx-py",
     packages=["ucp"],
@@ -73,7 +78,7 @@ setup(
     cmdclass=cmdclass,
     version=versioneer.get_version(),
     python_requires=">=3.6",
-    install_requires=["numpy", "psutil"],
+    install_requires=install_requires,
     description="Python Bindings for the Unified Communication X library (UCX)",
     long_description=readme,
     author="NVIDIA Corporation",


### PR DESCRIPTION
Makes a few adjustments to our `setup.py`. Most notably this marks our package as **not** zip-safe. So hopefully Python won't try to bundle it in a zip file.