### PR TITLE
Reorder `exchange_peer_info` send/recv operations

### DIFF
--- a/ucp/core.py
+++ b/ucp/core.py
@@ -35,7 +35,9 @@ def _get_ctx():
     return _ctx
 
 
-async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, guarantee_msg_order, listener):
+async def exchange_peer_info(
+    endpoint, msg_tag, ctrl_tag, guarantee_msg_order, listener
+):
     """Help function that exchange endpoint information"""
 
     msg_tag = int(msg_tag)
@@ -128,7 +130,7 @@ async def _listener_handler(endpoint, ctx, func, guarantee_msg_order):
         msg_tag=msg_tag,
         ctrl_tag=ctrl_tag,
         guarantee_msg_order=guarantee_msg_order,
-	listener=True,
+        listener=True,
     )
     ep = Endpoint(
         endpoint=endpoint,
@@ -292,7 +294,7 @@ class ApplicationContext:
             msg_tag=msg_tag,
             ctrl_tag=ctrl_tag,
             guarantee_msg_order=guarantee_msg_order,
-	    listener=False,
+            listener=False,
         )
         ep = Endpoint(
             endpoint=ucx_ep,


### PR DESCRIPTION
Reorders `exchange_peer_info` operations based on whether the endpoint is a listener or client endpoint.

This seems to fix the `ValueError("Both peers must set guarantee_msg_order identically")` exception being raised when workers start creating endpoints to each other. In 10 IB+NVLink runs on 4 nodes (32 GPUs) that exception wasn't raised a single time, nor did I experience hangs. Without changes here I would see the exception every run and it would hang about 50% of the time.