### PR TITLE
User tags

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -18,7 +18,12 @@ async def test_tag_match():
     lf = ucp.create_listener(server_node)
     ep = await ucp.create_endpoint(ucp.get_address(), lf.port)
     m1, m2 = (bytearray(len(msg1)), bytearray(len(msg2)))
-    f2 = asyncio.create_task(ep.recv(m2, tag="msg2"))
+    # May be dropped in favor of `asyncio.create_task` only
+    # once Python 3.6 is dropped.
+    if hasattr(asyncio, "create_future"):
+        f2 = asyncio.create_task(ep.recv(m2, tag="msg2"))
+    else:
+        f2 = asyncio.ensure_future(ep.recv(m2, tag="msg2"))
 
     # At this point f2 shouldn't be able to finish because its
     # tag "msg2" doesn't match the servers send tag "msg1"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,31 @@
+import asyncio
+
+import pytest
+import ucp
+
+
+@pytest.mark.asyncio
+async def test_tag_match():
+    msg1 = bytes("msg1", "utf-8")
+    msg2 = bytes("msg2", "utf-8")
+
+    async def server_node(ep):
+        f1 = ep.send(msg1, tag="msg1")
+        await asyncio.sleep(1)  # Let msg1 finish
+        f2 = ep.send(msg2, tag="msg2")
+        await asyncio.gather(f1, f2)
+
+    lf = ucp.create_listener(server_node)
+    ep = await ucp.create_endpoint(ucp.get_address(), lf.port)
+    m1, m2 = (bytearray(len(msg1)), bytearray(len(msg2)))
+    f2 = asyncio.create_task(ep.recv(m2, tag="msg2"))
+
+    # At this point f2 shouldn't be able to finish because its
+    # tag "msg2" doesn't match the servers send tag "msg1"
+    done, pending = await asyncio.wait({f2}, timeout=0.01)
+    assert f2 in pending
+    # "msg1" should be ready
+    await ep.recv(m1, tag="msg1")
+    assert m1 == msg1
+    await f2
+    assert m2 == msg2


### PR DESCRIPTION
This PR implements user tags to send/recv. 

This doesn't implement  "any tag", which would require the use of `ucp_tag_recv_nb()`'s `tag_mask`. Let's implement "any tag" in a future PR if there is any interest.

- [x] Implement tags
- [x] Add tests
- [x] CI pas

