### PR TITLE
Test concatenating trivial CuPy array to message

### DIFF
--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -112,6 +112,17 @@ async def test_send_recv_cupy(size, dtype, blocking_progress_mode):
     await client.recv(resp)
     np.testing.assert_array_equal(cupy.asnumpy(resp), cupy.asnumpy(msg))
 
+    msg = cupy.concatenate(
+        [cupy.arange(0, dtype=dtype), cupy.arange(size, dtype=dtype)]
+    )
+    msg_size = np.array([msg.nbytes], dtype=np.uint64)
+
+    await client.send(msg_size)
+    await client.send(msg)
+    resp = cupy.empty_like(msg)
+    await client.recv(resp)
+    np.testing.assert_array_equal(cupy.asnumpy(resp), cupy.asnumpy(msg))
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("size", msg_sizes)

--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -98,13 +98,14 @@ async def test_send_recv_cupy(size, dtype, blocking_progress_mode):
     ucp.init(blocking_progress_mode=blocking_progress_mode)
     cupy = pytest.importorskip("cupy")
 
-    msg = cupy.arange(size, dtype=dtype)
-    msg_size = np.array([msg.nbytes], dtype=np.uint64)
-
     listener = ucp.create_listener(
         make_echo_server(lambda n: cupy.empty((n,), dtype=np.uint8))
     )
     client = await ucp.create_endpoint(ucp.get_address(), listener.port)
+
+    msg = cupy.arange(size, dtype=dtype)
+    msg_size = np.array([msg.nbytes], dtype=np.uint64)
+
     await client.send(msg_size)
     await client.send(msg)
     resp = cupy.empty_like(msg)


### PR DESCRIPTION
Adding this test to try to reproduce an error seen when consolidating messages ( https://github.com/dask/distributed/pull/3732#discussion_r416329022 ).