### PR TITLE
Use `sphinx-markdown-tables` from conda-forge

### DIFF
--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 # required for building docs
 - sphinx
+- sphinx-markdown-tables
 - sphinx_rtd_theme
 - sphinxcontrib-websupport
 - nbsphinx
@@ -18,5 +19,3 @@ dependencies:
 - libhwloc
 - ucx
 - ucx-py
-- pip:
-  - sphinx-markdown-tables


### PR DESCRIPTION
As `sphinx-markdown-tables` is now in `conda-forge`, just use the package from there.