### PR TITLE
Ensure sockets are closed

### DIFF
--- a/ucp/continuous_ucx_progress.py
+++ b/ucp/continuous_ucx_progress.py
@@ -73,6 +73,9 @@ class BlockingMode(ProgressTask):
         # Remove the reader on finalization
         weakref.finalize(self, event_loop.remove_reader, epoll_fd)
 
+    def __del__(self):
+        self.rsock.close()
+
     def _fd_reader_callback(self):
         worker = self.weakref_worker()
         if worker is None or not worker.initialized:

--- a/ucp/continuous_ucx_progress.py
+++ b/ucp/continuous_ucx_progress.py
@@ -70,11 +70,9 @@ class BlockingMode(ProgressTask):
         # Bind an asyncio reader to a UCX epoll file descripter
         event_loop.add_reader(epoll_fd, self._fd_reader_callback)
 
-        # Remove the reader on finalization
+        # Remove the reader and close socket on finalization
         weakref.finalize(self, event_loop.remove_reader, epoll_fd)
-
-    def __del__(self):
-        self.rsock.close()
+        weakref.finalize(self, self.rsock.close)
 
     def _fd_reader_callback(self):
         worker = self.weakref_worker()

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -42,14 +42,12 @@ def get_address(ifname=None):
         ifname = os.environ.get("UCXPY_IFNAME", "ib0")
 
     ifname = ifname.encode()
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    ret = socket.inet_ntoa(
-        fcntl.ioctl(
-            s.fileno(), 0x8915, struct.pack("256s", ifname[:15])  # SIOCGIFADDR
-        )[20:24]
-    )
-    s.close()
-    return ret
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        return socket.inet_ntoa(
+            fcntl.ioctl(
+                s.fileno(), 0x8915, struct.pack("256s", ifname[:15])  # SIOCGIFADDR
+            )[20:24]
+        )
 
 
 def get_closest_net_devices(gpu_dev):

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -43,11 +43,13 @@ def get_address(ifname=None):
 
     ifname = ifname.encode()
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    return socket.inet_ntoa(
+    ret = socket.inet_ntoa(
         fcntl.ioctl(
             s.fileno(), 0x8915, struct.pack("256s", ifname[:15])  # SIOCGIFADDR
         )[20:24]
     )
+    s.close()
+    return ret
 
 
 def get_closest_net_devices(gpu_dev):


### PR DESCRIPTION
Running Python in debug mode reveals the following warnings:

```python
/datasets/pentschev/src/ucx-py/tests/debug-tests/test_send_recv_many_workers.py:54: ResourceWarning: unclosed <socket.socket fd=33, family=AddressFamily.AF_INET, type=SocketKind.SOCK_DGRAM, proto=0, laddr=('0.0.0.0', 0)>
  addr = ucp.get_address()
```

```python
/datasets/pentschev/miniconda3/envs/pydbg-102-0.14.0b200521/lib/python3.8/site-packages/ucp/core.py:197: ResourceWarning: unclosed <socket.socket fd=42, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>
  progress_tasks.clear()
```

This PR ensures those sockets are closed before destroying them.