### PR TITLE
Add endpoint error handler

### DIFF
--- a/tests/debug-tests/test_endpoint_error_callback.py
+++ b/tests/debug-tests/test_endpoint_error_callback.py
@@ -1,5 +1,7 @@
 # This test requires InfiniBand, to run:
-# UCXPY_IFNAME=ib0 UCX_NET_DEVICES=mlx5_0:1 UCX_TLS=rc,tcp,sockcm,cuda_copy UCX_SOCKADDR_TLS_PRIORITY=sockcm py.test --cache-clear tests/debug-tests/test_endpoint_error_callback.py
+# UCXPY_IFNAME=ib0 UCX_NET_DEVICES=mlx5_0:1 \
+# UCX_TLS=rc,tcp,sockcm,cuda_copy UCX_SOCKADDR_TLS_PRIORITY=sockcm \
+# py.test --cache-clear tests/debug-tests/test_endpoint_error_callback.py
 
 import asyncio
 import logging

--- a/tests/debug-tests/test_endpoint_error_callback.py
+++ b/tests/debug-tests/test_endpoint_error_callback.py
@@ -1,0 +1,173 @@
+# This test requires InfiniBand, to run:
+# UCXPY_IFNAME=ib0 UCX_NET_DEVICES=mlx5_0:1 UCX_TLS=rc,tcp,sockcm,cuda_copy UCX_SOCKADDR_TLS_PRIORITY=sockcm py.test --cache-clear tests/debug-tests/test_endpoint_error_callback.py
+
+import asyncio
+import logging
+import multiprocessing
+import os
+import queue
+import random
+import signal
+import sys
+
+from distributed.comm.utils import to_frames
+from distributed.protocol import to_serialize
+
+import cloudpickle
+import pytest
+import ucp
+from ucp.utils import get_ucxpy_logger
+from utils import get_cuda_devices, get_num_gpus, recv, send
+
+cupy = pytest.importorskip("cupy")
+
+
+def get_log_queue_handler():
+    handler = logging.StreamHandler()
+
+    log_queue = queue.Queue(-1)  # no limit on size
+    queue_handler = logging.handlers.QueueHandler(log_queue)
+    listener = logging.handlers.QueueListener(log_queue, handler)
+
+    ucxpy_logger = get_ucxpy_logger()
+    ucxpy_logger.addHandler(queue_handler)
+
+    formatter = logging.Formatter("%(message)s")
+    handler.setFormatter(formatter)
+
+    return log_queue, listener
+
+
+async def get_ep(name, port):
+    addr = ucp.get_address()
+    ep = await ucp.create_endpoint(addr, port)
+    return ep
+
+
+def client(port, func):
+    # wait for server to come up
+    # receive object
+    # process suicides
+
+    ucp.init()
+
+    # must create context before importing
+    # cudf/cupy/etc
+
+    async def read():
+        await asyncio.sleep(1)
+        ep = await get_ep("client", port)
+        msg = None
+        import cupy
+
+        cupy.cuda.set_allocator(None)
+
+        frames, msg = recv(ep)
+
+        # Client process suicides to force an "Endpoint timeout"
+        # on the server
+        os.kill(os.getpid(), signal.SIGKILL)
+
+    asyncio.get_event_loop().run_until_complete(read())
+
+
+def server(port, func):
+    # create listener receiver
+    # add queue logger
+    # write cudf object
+    # terminates ep/listener
+    # checks that "Endpoint timeout" was logged
+    ucp.init()
+
+    log_queue, log_listener = get_log_queue_handler()
+    log_listener.start()
+
+    async def f(listener_port):
+        # coroutine shows up when the client asks
+        # to connect
+        async def write(ep):
+            import cupy
+
+            cupy.cuda.set_allocator(None)
+
+            print("CREATING CUDA OBJECT IN SERVER...")
+            cuda_obj_generator = cloudpickle.loads(func)
+            cuda_obj = cuda_obj_generator()
+            msg = {"data": to_serialize(cuda_obj)}
+            frames = await to_frames(msg, serializers=("cuda", "dask", "pickle"))
+
+            # Send meta data
+            try:
+                await send(ep, frames)
+            except Exception:
+                # Avoids process hanging on "Endpoint timeout"
+                pass
+
+            print("Shutting Down Server...")
+            await ep.close()
+            lf.close()
+
+        lf = ucp.create_listener(write, port=listener_port)
+        try:
+            while not lf.closed():
+                await asyncio.sleep(0.1)
+        except ucp.UCXCloseError:
+            pass
+
+    log_listener.stop()
+
+    asyncio.get_event_loop().run_until_complete(f(port))
+
+    # Check log for the expected "Endpoint timeout" and exits with
+    # status 0 if encountered, -1 otherwise.
+    while not log_queue.empty():
+        log = log_queue.get()
+        print(log)
+        if "Endpoint timeout" in log.getMessage():
+            sys.exit(0)
+    sys.exit(-1)
+
+
+def cupy_obj():
+    import cupy
+
+    size = 10 ** 8
+    return cupy.arange(size)
+
+
+@pytest.mark.skipif(
+    get_num_gpus() <= 2, reason="Machine does not have more than two GPUs"
+)
+def test_send_recv_cu():
+    base_env = os.environ
+    env_client = base_env.copy()
+    # grab first two devices
+    cvd = get_cuda_devices()[:2]
+    cvd = ",".join(map(str, cvd))
+    # reverse CVD for other worker
+    env_client["CUDA_VISIBLE_DEVICES"] = cvd[::-1]
+
+    port = random.randint(13000, 15500)
+    # serialize function and send to the client and server
+    # server will use the return value of the contents,
+    # serialize the values, then send serialized values to client.
+    # client will compare return values of the deserialized
+    # data sent from the server
+
+    func = cloudpickle.dumps(cupy_obj)
+    ctx = multiprocessing.get_context("spawn")
+    server_process = ctx.Process(name="server", target=server, args=[port, func])
+    client_process = ctx.Process(name="client", target=client, args=[port, func])
+
+    server_process.start()
+    # cudf will ping the driver for validity of device
+    # this will influence device on which a cuda context is created.
+    # work around is to update env with new CVD before spawning
+    os.environ.update(env_client)
+    client_process.start()
+
+    server_process.join()
+    client_process.join()
+
+    assert server_process.exitcode == 0
+    assert client_process.exitcode == 1

--- a/tests/debug-tests/test_endpoint_error_callback.py
+++ b/tests/debug-tests/test_endpoint_error_callback.py
@@ -23,6 +23,9 @@ from utils import get_cuda_devices, get_num_gpus, recv, send
 
 cupy = pytest.importorskip("cupy")
 
+UCX_TLS = os.environ.get("UCX_TLS")
+rc_enabled = UCX_TLS is not None and "rc" in UCX_TLS
+
 
 def get_log_queue_handler():
     handler = logging.StreamHandler()
@@ -139,6 +142,9 @@ def cupy_obj():
 
 @pytest.mark.skipif(
     get_num_gpus() <= 2, reason="Machine does not have more than two GPUs"
+)
+@pytest.mark.skipif(
+    not rc_enabled, reason="Transport `rc` is not enabled"
 )
 def test_send_recv_cu():
     base_env = os.environ

--- a/tests/debug-tests/test_endpoint_error_callback.py
+++ b/tests/debug-tests/test_endpoint_error_callback.py
@@ -143,9 +143,7 @@ def cupy_obj():
 @pytest.mark.skipif(
     get_num_gpus() <= 2, reason="Machine does not have more than two GPUs"
 )
-@pytest.mark.skipif(
-    not rc_enabled, reason="Transport `rc` is not enabled"
-)
+@pytest.mark.skipif(not rc_enabled, reason="Transport `rc` is not enabled")
 def test_send_recv_cu():
     base_env = os.environ
     env_client = base_env.copy()

--- a/tests/debug-tests/test_endpoint_error_callback.py
+++ b/tests/debug-tests/test_endpoint_error_callback.py
@@ -128,7 +128,8 @@ def server(port, func, endpoint_error_handling):
     asyncio.get_event_loop().run_until_complete(f(port))
 
     # Check log for the expected "Endpoint timeout" and exits with
-    # status 0 if encountered, -1 otherwise.
+    # status -80 if encountered, 0 otherwise. The process will exit
+    # with status -6 when endpoint_error_callback=False.
     while not log_queue.empty():
         log = log_queue.get()
         if "Endpoint timeout" in log.getMessage():

--- a/ucp/_libs/src/c_util.c
+++ b/ucp/_libs/src/c_util.c
@@ -43,7 +43,8 @@ void c_util_get_ucp_listener_params_free(ucp_listener_params_t *param) {
 
 int c_util_get_ucp_ep_params(ucp_ep_params_t *param,
                              const char *ip_address,
-                             uint16_t port) {
+                             uint16_t port,
+                             ucp_err_handler_cb_t err_cb) {
 
     struct sockaddr_in *connect_addr = malloc(sizeof(struct sockaddr_in));
     if(connect_addr == NULL) {
@@ -58,9 +59,9 @@ int c_util_get_ucp_ep_params(ucp_ep_params_t *param,
                                 UCP_EP_PARAM_FIELD_SOCK_ADDR |
                                 UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
                                 UCP_EP_PARAM_FIELD_ERR_HANDLER;
-    param->err_mode           = UCP_ERR_HANDLING_MODE_NONE;
+    param->err_mode           = err_cb == NULL ? UCP_ERR_HANDLING_MODE_NONE : UCP_ERR_HANDLING_MODE_PEER;
     param->flags              = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
-    param->err_handler.cb     = NULL;
+    param->err_handler.cb     = err_cb;
     param->err_handler.arg    = NULL;
     param->sockaddr.addr      = (const struct sockaddr *) connect_addr;
     param->sockaddr.addrlen   = sizeof(struct sockaddr_in);
@@ -75,7 +76,7 @@ int c_util_get_ucp_ep_conn_params(ucp_ep_params_t *param,
                                 UCP_EP_PARAM_FIELD_CONN_REQUEST |
                                 UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
                                 UCP_EP_PARAM_FIELD_ERR_HANDLER;
-    param->err_mode           = UCP_ERR_HANDLING_MODE_NONE;
+    param->err_mode           = err_cb == NULL ? UCP_ERR_HANDLING_MODE_NONE : UCP_ERR_HANDLING_MODE_PEER;
     param->err_handler.cb     = err_cb;
     param->err_handler.arg    = NULL;
     param->conn_request       = conn_request;

--- a/ucp/_libs/src/c_util.c
+++ b/ucp/_libs/src/c_util.c
@@ -14,7 +14,7 @@
 
 int c_util_get_ucp_listener_params(ucp_listener_params_t *param,
                                    uint16_t port,
-                                   ucp_listener_accept_callback_t callback_func,
+                                   ucp_listener_conn_callback_t callback_func,
                                    void *callback_args) {
 
     /* The listener will listen on INADDR_ANY */
@@ -28,11 +28,11 @@ int c_util_get_ucp_listener_params(ucp_listener_params_t *param,
     listen_addr->sin_port        = htons(port);
 
 	param->field_mask         = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
-                                UCP_LISTENER_PARAM_FIELD_ACCEPT_HANDLER;
+                                UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
 	param->sockaddr.addr      = (const struct sockaddr *) listen_addr;
 	param->sockaddr.addrlen   = sizeof(struct sockaddr_in);
-	param->accept_handler.cb  = callback_func;
-	param->accept_handler.arg = callback_args;
+	param->conn_handler.cb  = callback_func;
+	param->conn_handler.arg = callback_args;
     return 0;
 }
 

--- a/ucp/_libs/src/c_util.c
+++ b/ucp/_libs/src/c_util.c
@@ -67,6 +67,21 @@ int c_util_get_ucp_ep_params(ucp_ep_params_t *param,
     return 0;
 }
 
+int c_util_get_ucp_ep_conn_params(ucp_ep_params_t *param,
+                                  ucp_conn_request_h conn_request,
+                                  ucp_err_handler_cb_t err_cb) {
+
+    param->field_mask         = UCP_EP_PARAM_FIELD_FLAGS |
+                                UCP_EP_PARAM_FIELD_CONN_REQUEST |
+                                UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
+                                UCP_EP_PARAM_FIELD_ERR_HANDLER;
+    param->err_mode           = UCP_ERR_HANDLING_MODE_NONE;
+    param->err_handler.cb     = err_cb;
+    param->err_handler.arg    = NULL;
+    param->conn_request       = conn_request;
+    return 0;
+}
+
 void c_util_get_ucp_ep_params_free(ucp_ep_params_t *param) {
     free((void*) param->sockaddr.addr);
 }

--- a/ucp/_libs/src/c_util.c
+++ b/ucp/_libs/src/c_util.c
@@ -27,12 +27,12 @@ int c_util_get_ucp_listener_params(ucp_listener_params_t *param,
     listen_addr->sin_addr.s_addr = INADDR_ANY;
     listen_addr->sin_port        = htons(port);
 
-	param->field_mask         = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
+    param->field_mask         = UCP_LISTENER_PARAM_FIELD_SOCK_ADDR |
                                 UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
-	param->sockaddr.addr      = (const struct sockaddr *) listen_addr;
-	param->sockaddr.addrlen   = sizeof(struct sockaddr_in);
-	param->conn_handler.cb  = callback_func;
-	param->conn_handler.arg = callback_args;
+    param->sockaddr.addr      = (const struct sockaddr *) listen_addr;
+    param->sockaddr.addrlen   = sizeof(struct sockaddr_in);
+    param->conn_handler.cb  = callback_func;
+    param->conn_handler.arg = callback_args;
     return 0;
 }
 
@@ -54,16 +54,16 @@ int c_util_get_ucp_ep_params(ucp_ep_params_t *param,
     connect_addr->sin_addr.s_addr = inet_addr(ip_address);
     connect_addr->sin_port        = htons(port);
 
-	param->field_mask         = UCP_EP_PARAM_FIELD_FLAGS |
+    param->field_mask         = UCP_EP_PARAM_FIELD_FLAGS |
                                 UCP_EP_PARAM_FIELD_SOCK_ADDR |
                                 UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE |
                                 UCP_EP_PARAM_FIELD_ERR_HANDLER;
-	param->err_mode           = UCP_ERR_HANDLING_MODE_NONE;
+    param->err_mode           = UCP_ERR_HANDLING_MODE_NONE;
     param->flags              = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
     param->err_handler.cb     = NULL;
     param->err_handler.arg    = NULL;
     param->sockaddr.addr      = (const struct sockaddr *) connect_addr;
-	param->sockaddr.addrlen   = sizeof(struct sockaddr_in);
+    param->sockaddr.addrlen   = sizeof(struct sockaddr_in);
     return 0;
 }
 

--- a/ucp/_libs/src/c_util.h
+++ b/ucp/_libs/src/c_util.h
@@ -17,7 +17,8 @@ void c_util_get_ucp_listener_params_free(ucp_listener_params_t *param);
 
 int c_util_get_ucp_ep_params(ucp_ep_params_t *param,
                              const char *ip_address,
-                             uint16_t port);
+                             uint16_t port,
+                             ucp_err_handler_cb_t err_cb);
 
 int c_util_get_ucp_ep_conn_params(ucp_ep_params_t *param,
                                   ucp_conn_request_h conn_request,

--- a/ucp/_libs/src/c_util.h
+++ b/ucp/_libs/src/c_util.h
@@ -10,7 +10,7 @@
 
 int c_util_get_ucp_listener_params(ucp_listener_params_t *param,
                                    uint16_t port,
-                                   ucp_listener_accept_callback_t callback_func,
+                                   ucp_listener_conn_callback_t callback_func,
                                    void *callback_args);
 
 void c_util_get_ucp_listener_params_free(ucp_listener_params_t *param);

--- a/ucp/_libs/src/c_util.h
+++ b/ucp/_libs/src/c_util.h
@@ -19,4 +19,8 @@ int c_util_get_ucp_ep_params(ucp_ep_params_t *param,
                              const char *ip_address,
                              uint16_t port);
 
+int c_util_get_ucp_ep_conn_params(ucp_ep_params_t *param,
+                                  ucp_conn_request_h conn_request,
+                                  ucp_err_handler_cb_t err_cb);
+
 void c_util_get_ucp_ep_params_free(ucp_ep_params_t *param);

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -336,7 +336,9 @@ cdef class UCXWorker(UCXObject):
         assert_ucs_status(status)
         return UCXEndpoint(self, <uintptr_t>ucp_ep)
 
-    def ep_create_from_conn_request(self, uintptr_t conn_request, endpoint_error_handling):
+    def ep_create_from_conn_request(
+        self, uintptr_t conn_request, endpoint_error_handling
+    ):
         assert self.initialized
 
         cdef ucp_ep_params_t params

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -305,7 +305,8 @@ cdef class UCXWorker(UCXObject):
         assert self.initialized
         cdef ucp_ep_params_t params
         ip_address = socket.gethostbyname(ip_address)
-        if c_util_get_ucp_ep_params(&params, ip_address.encode(), port):
+        cdef ucp_err_handler_cb_t err_cb = <ucp_err_handler_cb_t>NULL
+        if c_util_get_ucp_ep_params(&params, ip_address.encode(), port, err_cb):
             raise MemoryError("Failed allocation of ucp_ep_params_t")
 
         cdef ucp_ep_h ucp_ep

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -225,7 +225,7 @@ cdef void _ib_err_cb(void *arg, ucp_ep_h ep, ucs_status_t status):
             hex(int(<uintptr_t>ep)), status, status_str
         )
     )
-    logger.info(msg)
+    logger.error(msg)
 
 
 cdef ucp_err_handler_cb_t _get_error_callback(tls, endpoint_error_handling):

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -23,17 +23,28 @@ cdef extern from "src/c_util.h":
     ctypedef struct ucp_ep_params_t:
         pass
 
-    ctypedef void(*ucp_listener_accept_callback_t)(ucp_ep_h ep, void *arg)
+    ctypedef struct ucp_conn_request:
+        pass
+
+    ctypedef ucp_conn_request* ucp_conn_request_h
+
+    ctypedef struct ucp_err_handler_cb_t:
+        pass
+
+    ctypedef void(*ucp_listener_conn_callback_t)(ucp_conn_request_h request, void *arg)
 
     int c_util_get_ucp_listener_params(ucp_listener_params_t *param,
                                        uint16_t port,
-                                       ucp_listener_accept_callback_t callback_func,  # noqa
+                                       ucp_listener_conn_callback_t callback_func,  # noqa
                                        void *callback_args)
     void c_util_get_ucp_listener_params_free(ucp_listener_params_t *param)
 
     int c_util_get_ucp_ep_params(ucp_ep_params_t *param,
                                  const char *ip_address,
                                  uint16_t port)
+    int c_util_get_ucp_ep_conn_params(ucp_ep_params_t *param,
+                                      ucp_conn_request_h conn_request,
+                                      ucp_err_handler_cb_t err_cb)
     void c_util_get_ucp_ep_params_free(ucp_ep_params_t *param)
 
 

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -41,7 +41,8 @@ cdef extern from "src/c_util.h":
 
     int c_util_get_ucp_ep_params(ucp_ep_params_t *param,
                                  const char *ip_address,
-                                 uint16_t port)
+                                 uint16_t port,
+                                 ucp_err_handler_cb_t err_cb)
     int c_util_get_ucp_ep_conn_params(ucp_ep_params_t *param,
                                       ucp_conn_request_h conn_request,
                                       ucp_err_handler_cb_t err_cb)

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -759,12 +759,26 @@ def get_config():
         return _get_ctx().get_config()
 
 
-def create_listener(callback_func, port=None, guarantee_msg_order=False):
-    return _get_ctx().create_listener(callback_func, port, guarantee_msg_order)
+def create_listener(
+    callback_func, port=None, guarantee_msg_order=False, endpoint_error_handling=True
+):
+    return _get_ctx().create_listener(
+        callback_func,
+        port,
+        guarantee_msg_order,
+        endpoint_error_handling=endpoint_error_handling,
+    )
 
 
-async def create_endpoint(ip_address, port, guarantee_msg_order=False):
-    return await _get_ctx().create_endpoint(ip_address, port, guarantee_msg_order)
+async def create_endpoint(
+    ip_address, port, guarantee_msg_order=False, endpoint_error_handling=True
+):
+    return await _get_ctx().create_endpoint(
+        ip_address,
+        port,
+        guarantee_msg_order,
+        endpoint_error_handling=endpoint_error_handling,
+    )
 
 
 def continuous_ucx_progress(event_loop=None):

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -139,7 +139,9 @@ class CtrlMsg:
         )
 
 
-async def _listener_handler(conn_request, ctx, func, port, guarantee_msg_order, endpoint_error_handling):
+async def _listener_handler(
+    conn_request, ctx, func, port, guarantee_msg_order, endpoint_error_handling
+):
     # We create the Endpoint in four steps:
     #  1) Generate unique IDs to use as tags
     #  2) Exchange endpoint info such as tags
@@ -148,7 +150,9 @@ async def _listener_handler(conn_request, ctx, func, port, guarantee_msg_order, 
     msg_tag = hash64bits("msg_tag", seed, port)
     ctrl_tag = hash64bits("ctrl_tag", seed, port)
 
-    endpoint = ctx.worker.ep_create_from_conn_request(conn_request, endpoint_error_handling)
+    endpoint = ctx.worker.ep_create_from_conn_request(
+        conn_request, endpoint_error_handling
+    )
     peer_info = await exchange_peer_info(
         endpoint=endpoint,
         msg_tag=msg_tag,
@@ -225,7 +229,9 @@ class ApplicationContext:
                 self, _epoll_fd_finalizer, self.epoll_fd, self.progress_tasks
             )
 
-    def create_listener(self, callback_func, port, guarantee_msg_order, endpoint_error_handling=True):
+    def create_listener(
+        self, callback_func, port, guarantee_msg_order, endpoint_error_handling=True
+    ):
         """Create and start a listener to accept incoming connections
 
         callback_func is the function or coroutine that takes one
@@ -293,7 +299,9 @@ class ApplicationContext:
         )
         return ret
 
-    async def create_endpoint(self, ip_address, port, guarantee_msg_order, endpoint_error_handling=True):
+    async def create_endpoint(
+        self, ip_address, port, guarantee_msg_order, endpoint_error_handling=True
+    ):
         """Create a new endpoint to a server
 
         Parameters

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -139,7 +139,7 @@ class CtrlMsg:
         )
 
 
-async def _listener_handler(endpoint, ctx, func, port, guarantee_msg_order):
+async def _listener_handler(conn_request, ctx, func, port, guarantee_msg_order):
     # We create the Endpoint in four steps:
     #  1) Generate unique IDs to use as tags
     #  2) Exchange endpoint info such as tags
@@ -147,6 +147,8 @@ async def _listener_handler(endpoint, ctx, func, port, guarantee_msg_order):
     seed = os.urandom(16)
     msg_tag = hash64bits("msg_tag", seed, port)
     ctrl_tag = hash64bits("ctrl_tag", seed, port)
+
+    endpoint = ctx.worker.ep_create_from_conn_request(conn_request)
     peer_info = await exchange_peer_info(
         endpoint=endpoint,
         msg_tag=msg_tag,


### PR DESCRIPTION
This PR uses the `UCP_ERR_HANDLING_MODE_PEER` mode by default for InfiniBand endpoints, preventing a UCX process from exiting with a fatal error should an issue occur. This mode isn't currently supported by UCX with the TCP transport, therefore no callback is added should the `UCX_TLS` not contain `dc`, `ib` or `rc`. It's also possible to prevent endpoints and listeners from using this mode by passing `endpoint_error_handling=False`.

As future work, we may want to add some mechanism to enforce `UCXEndpoint` to be destroyed once an error occurs and the callback is executed. This seems currently not necessary in Dask, once can test this only with IB enabled and kill a worker in the middle of a task and a new one will spawn without any other processes exiting with a fatal error. I'm not yet sure on a pytest to add here, and such test would _not_ be executed by CI anyway given its lack of IB support.

Fixes #500 .