### PR TITLE
Use UCX-Py in docs [skip ci]

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,8 +1,8 @@
 Configuration
 =============
 
-UCX/UCX-PY can be configured with a wide variety of options and optimizations including: transport, caching, etc.  Users can configure
-UCX/UCX-PY either with environment variables or programmatically during initialization.  Below we demonstrate setting ``UCX_MEMTYPE_CACHE`` to
+UCX/UCX-Py can be configured with a wide variety of options and optimizations including: transport, caching, etc.  Users can configure
+UCX/UCX-Py either with environment variables or programmatically during initialization.  Below we demonstrate setting ``UCX_MEMTYPE_CACHE`` to
 ``n`` and checking the configuration:
 
 .. code-block:: python
@@ -29,7 +29,7 @@ Env Vars
 DEBUG
 ~~~~~
 
-Debug variables for both UCX and UCX-PY can be set
+Debug variables for both UCX and UCX-Py can be set
 
 UCXPY_LOG_LEVEL/UCX_LOG_LEVEL
 `````````````````````````````
@@ -44,14 +44,14 @@ MEMORY
 UCX_MEMTYPE_CACHE
 `````````````````
 
-This is a UCX Memory optimization which toggles whether UCX library intercepts cu*alloc* calls.  UCX-PY defaults this value to  ``n``.  There `known issues <https://github.com/openucx/ucx/wiki/NVIDIA-GPU-Support#known-issues>`_ when using this feature.
+This is a UCX Memory optimization which toggles whether UCX library intercepts cu*alloc* calls.  UCX-Py defaults this value to  ``n``.  There `known issues <https://github.com/openucx/ucx/wiki/NVIDIA-GPU-Support#known-issues>`_ when using this feature.
 
 Values: n/y
 
 UCX_CUDA_IPC_CACHE
 ``````````````````
 
-This is a UCX CUDA Memory optimization which enables/disables a remote endpoint IPC memhandle mapping cache. UCX/UCX-py defaults this value to ``y``
+This is a UCX CUDA Memory optimization which enables/disables a remote endpoint IPC memhandle mapping cache. UCX/UCX-Py defaults this value to ``y``
 
 Values: n/y
 

--- a/docs/source/dask.rst
+++ b/docs/source/dask.rst
@@ -1,7 +1,7 @@
 Using with Dask
 ===============
 
-``UCX/UCX-PY`` can be used with `Dask <https://dask.org/>`_ as a drop-in replacement for the communication protocol between workers.  Below we show how to use UCX-PY with both helper utilities such as `dask-cuda <https://github.com/rapidsai/dask-cuda>`_
+``UCX/UCX-Py`` can be used with `Dask <https://dask.org/>`_ as a drop-in replacement for the communication protocol between workers.  Below we show how to use UCX-Py with both helper utilities such as `dask-cuda <https://github.com/rapidsai/dask-cuda>`_
 and manually starting a dask cluster with UCX enabled.  Additionally, we demonstrate using UCX with a `cuDF Example`_ and `CuPy Example`_.
 
 Starting with Dask-cuda

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
-UCX-PY
+UCX-Py
 ======
 
-UCX-PY is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a low-level high-performance networking library.  UCX and UCX-PY supports several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.
+UCX-Py is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a low-level high-performance networking library.  UCX and UCX-Py supports several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.
 
 
 .. image:: _static/Architecture.png


### PR DESCRIPTION
PR corrects naming style of UCX-Py

cc @pentschev 