### PR TITLE
Optimize buffer utility functions

### DIFF
--- a/ucp/_libs/__init__.pxd
+++ b/ucp/_libs/__init__.pxd
@@ -1,0 +1,4 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+
+# cython: language_level=3

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 # cython: language_level=3

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -1,5 +1,6 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
+
 # cython: language_level=3
 
 import pynvml

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -3,7 +3,7 @@
 # cython: language_level=3
 
 import pynvml
-from topological_distance_dep cimport *
+from .topological_distance_dep cimport *
 
 
 cdef class TopologicalDistance:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -1,6 +1,8 @@
 # Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
+
 # cython: language_level=3
+
 import logging
 import socket
 import weakref

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -13,6 +13,7 @@ from libc.stdio cimport FILE, fclose, fflush
 from libc.stdlib cimport free
 from libc.string cimport memset
 from .ucx_api_dep cimport *
+from .utils cimport get_buffer_data
 
 from ..exceptions import (
     UCXCanceled,
@@ -22,7 +23,6 @@ from ..exceptions import (
     log_errors,
 )
 from ..utils import nvtx_annotate
-from .utils import get_buffer_data
 
 
 # Struct used as requests by UCX

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -722,9 +722,7 @@ def tag_send_nb(
     name: str, optional
         Descriptive name of the operation
     """
-    cdef void *data = <void*><uintptr_t>(
-        get_buffer_data(buffer, check_writable=False)
-    )
+    cdef void *data = <void*>get_buffer_data(buffer, check_writable=False)
     cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
     cdef ucs_status_ptr_t status = ucp_tag_send_nb(
         ep._handle,
@@ -836,9 +834,7 @@ def tag_recv_nb(
         when the `worker` closes.
     """
 
-    cdef void *data = <void*><uintptr_t>(
-        get_buffer_data(buffer, check_writable=True)
-    )
+    cdef void *data = <void*>get_buffer_data(buffer, check_writable=True)
     cdef ucp_tag_recv_callback_t _tag_recv_cb = (
         <ucp_tag_recv_callback_t>_tag_recv_callback
     )
@@ -904,8 +900,7 @@ def stream_send_nb(
     name: str, optional
         Descriptive name of the operation
     """
-    cdef void *data = <void*><uintptr_t>(get_buffer_data(buffer,
-                                         check_writable=False))
+    cdef void *data = <void*>get_buffer_data(buffer, check_writable=False)
     cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
     cdef ucs_status_ptr_t status = ucp_stream_send_nb(
         ep._handle,
@@ -999,9 +994,7 @@ def stream_recv_nb(
         Descriptive name of the operation
     """
 
-    cdef void *data = <void*><uintptr_t>(
-        get_buffer_data(buffer, check_writable=True)
-    )
+    cdef void *data = <void*>get_buffer_data(buffer, check_writable=True)
     cdef size_t length
     cdef ucp_stream_recv_callback_t _stream_recv_cb = (
         <ucp_stream_recv_callback_t>_stream_recv_callback

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -12,6 +12,7 @@ from libc.stdint cimport uintptr_t
 from libc.stdio cimport FILE, fclose, fflush
 from libc.stdlib cimport free
 from libc.string cimport memset
+
 from .ucx_api_dep cimport *
 from .utils cimport get_buffer_data
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -12,7 +12,7 @@ from libc.stdint cimport uintptr_t
 from libc.stdio cimport FILE, fclose, fflush
 from libc.stdlib cimport free
 from libc.string cimport memset
-from ucx_api_dep cimport *
+from .ucx_api_dep cimport *
 
 from ..exceptions import (
     UCXCanceled,

--- a/ucp/_libs/utils.pxd
+++ b/ucp/_libs/utils.pxd
@@ -1,0 +1,11 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+
+# cython: language_level=3
+
+
+from libc.stdint cimport uintptr_t
+
+
+cpdef uintptr_t get_buffer_data(buffer, bint check_writable=*) except *
+cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) except *

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 # cython: language_level=3

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -63,17 +63,18 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         itemsize = int(numpy.dtype(iface["typestr"]).itemsize)
         # Making sure that the elements in shape is integers
         shape = [int(s) for s in iface["shape"]]
+        ndim = len(shape)
         nbytes = reduce(operator.mul, shape, itemsize)
         # Check that data is contiguous
         strides = iface.get("strides")
-        if len(shape) > 0 and strides is not None:
+        if ndim > 0 and strides is not None:
             strides = [int(s) for s in strides]
-            if len(strides) != len(shape):
+            if len(strides) != ndim:
                 raise ValueError(
                     "The length of shape and strides must be equal"
                 )
             s = itemsize
-            for i in reversed(range(len(shape))):
+            for i in reversed(range(ndim)):
                 if s != strides[i]:
                     raise ValueError("Array must be contiguous")
                 s *= shape[i]

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -82,8 +82,8 @@ cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) ex
     else:
         mview = memoryview(buffer)
         nbytes = mview.nbytes
-        if not mview.contiguous:
-            raise ValueError("buffer must be contiguous")
+        if not mview.c_contiguous:
+            raise ValueError("buffer must be C-contiguous")
 
     if check_min_size is not None:
         min_size = check_min_size

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -15,9 +15,7 @@ cpdef uintptr_t get_buffer_data(buffer, bint check_writable=False) except *:
     is read only and check_writable=True is set.
     """
 
-    cdef dict iface = getattr(buffer, "__array_interface__", None)
-    if iface is None:
-        iface = getattr(buffer, "__cuda_array_interface__", None)
+    cdef dict iface = getattr(buffer, "__cuda_array_interface__", None)
 
     cdef uintptr_t data_ptr
     cdef bint data_readonly
@@ -45,18 +43,16 @@ cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) ex
     if `check_min_size` is greater than the size of the buffer
     """
 
-    cdef dict iface = getattr(buffer, "__array_interface__", None)
-    if iface is None:
-        iface = getattr(buffer, "__cuda_array_interface__", None)
-        if not cuda_support and iface is not None:
-            raise ValueError(
-                "UCX is not configured with CUDA support, please add "
-                "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment"
-                "variable and that the ucx-proc=*=gpu package is "
-                "installed. See "
-                "https://ucx-py.readthedocs.io/en/latest/install.html for "
-                "more information."
-            )
+    cdef dict iface = getattr(buffer, "__cuda_array_interface__", None)
+    if not cuda_support and iface is not None:
+        raise ValueError(
+            "UCX is not configured with CUDA support, please add "
+            "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment"
+            "variable and that the ucx-proc=*=gpu package is "
+            "installed. See "
+            "https://ucx-py.readthedocs.io/en/latest/install.html for "
+            "more information."
+        )
 
     cdef tuple shape, strides
     cdef Py_ssize_t i, s, itemsize, ndim, nbytes, min_size

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -6,6 +6,7 @@
 
 from cpython.memoryview cimport PyMemoryView_GET_BUFFER
 from libc.stdint cimport uintptr_t
+cimport cython
 
 
 cpdef uintptr_t get_buffer_data(buffer, bint check_writable=False) except *:
@@ -36,6 +37,8 @@ cpdef uintptr_t get_buffer_data(buffer, bint check_writable=False) except *:
     return data_ptr
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) except *:
     """
     Returns the size of the buffer in bytes. Returns ValueError

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -10,8 +10,6 @@ from functools import reduce
 from cpython.memoryview cimport PyMemoryView_GET_BUFFER
 from libc.stdint cimport uintptr_t
 
-from ..exceptions import UCXCloseError, UCXError
-
 
 def get_buffer_data(buffer, check_writable=False):
     """

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -86,6 +86,10 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         if not mview.contiguous:
             raise ValueError("buffer must be contiguous")
 
-    if check_min_size is not None and nbytes < check_min_size:
-        raise ValueError("the nbytes is greater than the size of the buffer!")
+    if check_min_size is not None:
+        min_size = check_min_size
+        if nbytes < min_size:
+            raise ValueError(
+                "the nbytes is greater than the size of the buffer!"
+            )
     return nbytes

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -70,8 +70,9 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         shape = [int(s) for s in iface["shape"]]
         nbytes = reduce(operator.mul, shape, 1) * itemsize
         # Check that data is contiguous
-        if len(shape) > 0 and iface.get("strides") is not None:
-            strides = [int(s) for s in iface['strides']]
+        strides = iface.get("strides")
+        if len(shape) > 0 and strides is not None:
+            strides = [int(s) for s in strides]
             if len(strides) != len(shape):
                 msg = "The length of shape and strides must be equal"
                 raise ValueError(msg)

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -31,11 +31,6 @@ def get_buffer_data(buffer, check_writable=False):
         data_ptr = int(<uintptr_t>PyMemoryView_GET_BUFFER(mview).buf)
         data_readonly = mview.readonly
 
-    # Workaround for numba giving None, rather than an 0.
-    # https://github.com/cupy/cupy/issues/2104 for more info.
-    if data_ptr is None:
-        data_ptr = 0
-
     if data_ptr == 0:
         raise NotImplementedError("zero-sized buffers isn't supported")
 

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -5,8 +5,8 @@
 
 
 from cpython.memoryview cimport PyMemoryView_GET_BUFFER
+from cython cimport boundscheck, wraparound
 from libc.stdint cimport uintptr_t
-cimport cython
 
 
 cpdef uintptr_t get_buffer_data(buffer, bint check_writable=False) except *:
@@ -37,8 +37,8 @@ cpdef uintptr_t get_buffer_data(buffer, bint check_writable=False) except *:
     return data_ptr
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
+@boundscheck(False)
+@wraparound(False)
 cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) except *:
     """
     Returns the size of the buffer in bytes. Returns ValueError

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -68,7 +68,7 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         itemsize = int(numpy.dtype(iface["typestr"]).itemsize)
         # Making sure that the elements in shape is integers
         shape = [int(s) for s in iface["shape"]]
-        nbytes = reduce(operator.mul, shape, 1) * itemsize
+        nbytes = reduce(operator.mul, shape, itemsize)
         # Check that data is contiguous
         strides = iface.get("strides")
         if len(shape) > 0 and strides is not None:

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -4,7 +4,6 @@
 # cython: language_level=3
 
 
-import asyncio
 import operator
 from functools import reduce
 

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -28,7 +28,7 @@ def get_buffer_data(buffer, check_writable=False):
         data_ptr, data_readonly = iface["data"]
     else:
         mview = memoryview(buffer)
-        data_ptr = int(<uintptr_t>PyMemoryView_GET_BUFFER(mview).buf)
+        data_ptr = <uintptr_t>PyMemoryView_GET_BUFFER(mview).buf
         data_readonly = mview.readonly
 
     if data_ptr == 0:

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -20,11 +20,9 @@ def get_buffer_data(buffer, check_writable=False):
     is read only and check_writable=True is set.
     """
 
-    iface = None
-    if hasattr(buffer, "__cuda_array_interface__"):
-        iface = buffer.__cuda_array_interface__
-    elif hasattr(buffer, "__array_interface__"):
-        iface = buffer.__array_interface__
+    iface = getattr(buffer, "__array_interface__", None)
+    if iface is None:
+        iface = getattr(buffer, "__cuda_array_interface__", None)
 
     if iface is not None:
         data_ptr, data_readonly = iface["data"]
@@ -53,10 +51,10 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
     if `check_min_size` is greater than the size of the buffer
     """
 
-    iface = None
-    if hasattr(buffer, "__cuda_array_interface__"):
-        iface = buffer.__cuda_array_interface__
-        if not cuda_support:
+    iface = getattr(buffer, "__array_interface__", None)
+    if iface is None:
+        iface = getattr(buffer, "__cuda_array_interface__", None)
+        if not cuda_support and iface is not None:
             msg = "UCX is not configured with CUDA support, please add " \
                   "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment" \
                   "variable and that the ucx-proc=*=gpu package is " \
@@ -64,8 +62,6 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
                   "https://ucx-py.readthedocs.io/en/latest/install.html for " \
                   "more information."
             raise ValueError(msg)
-    elif hasattr(buffer, "__array_interface__"):
-        iface = buffer.__array_interface__
 
     if iface is not None:
         import numpy

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -55,13 +55,14 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
     if iface is None:
         iface = getattr(buffer, "__cuda_array_interface__", None)
         if not cuda_support and iface is not None:
-            msg = "UCX is not configured with CUDA support, please add " \
-                  "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment" \
-                  "variable and that the ucx-proc=*=gpu package is " \
-                  "installed. See " \
-                  "https://ucx-py.readthedocs.io/en/latest/install.html for " \
-                  "more information."
-            raise ValueError(msg)
+            raise ValueError(
+                "UCX is not configured with CUDA support, please add "
+                "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment"
+                "variable and that the ucx-proc=*=gpu package is "
+                "installed. See "
+                "https://ucx-py.readthedocs.io/en/latest/install.html for "
+                "more information."
+            )
 
     if iface is not None:
         import numpy

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -1,6 +1,9 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
+
 # cython: language_level=3
+
+
 import asyncio
 import operator
 from functools import reduce

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -27,7 +27,7 @@ def get_buffer_data(buffer, check_writable=False):
         iface = buffer.__array_interface__
 
     if iface is not None:
-        data_ptr, data_readonly = iface['data']
+        data_ptr, data_readonly = iface["data"]
     else:
         mview = memoryview(buffer)
         data_ptr = int(<uintptr_t>PyMemoryView_GET_BUFFER(mview).buf)
@@ -69,13 +69,13 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
 
     if iface is not None:
         import numpy
-        itemsize = int(numpy.dtype(iface['typestr']).itemsize)
+        itemsize = int(numpy.dtype(iface["typestr"]).itemsize)
         # Making sure that the elements in shape is integers
-        shape = [int(s) for s in iface['shape']]
+        shape = [int(s) for s in iface["shape"]]
         nbytes = reduce(operator.mul, shape, 1) * itemsize
         # Check that data is contiguous
         if len(shape) > 0 and iface.get("strides", None) is not None:
-            strides = [int(s) for s in iface['strides']]
+            strides = [int(s) for s in iface["strides"]]
             if len(strides) != len(shape):
                 msg = "The length of shape and strides must be equal"
                 raise ValueError(msg)

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -55,7 +55,7 @@ cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) ex
         )
 
     cdef tuple shape, strides
-    cdef Py_ssize_t i, s, itemsize, ndim, nbytes, min_size
+    cdef Py_ssize_t i, s, itemsize, ndim, nbytes
     if iface is not None:
         import numpy
         itemsize = numpy.dtype(iface["typestr"]).itemsize
@@ -85,6 +85,7 @@ cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) ex
         if not mview.c_contiguous:
             raise ValueError("buffer must be C-contiguous")
 
+    cdef Py_ssize_t min_size
     if check_min_size is not None:
         min_size = check_min_size
         if nbytes < min_size:

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -16,6 +16,7 @@ def get_buffer_data(buffer, check_writable=False):
     Returns data pointer of the buffer. Raising ValueError if the buffer
     is read only and check_writable=True is set.
     """
+
     iface = None
     if hasattr(buffer, "__cuda_array_interface__"):
         iface = buffer.__cuda_array_interface__

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -70,8 +70,9 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         if len(shape) > 0 and strides is not None:
             strides = [int(s) for s in strides]
             if len(strides) != len(shape):
-                msg = "The length of shape and strides must be equal"
-                raise ValueError(msg)
+                raise ValueError(
+                    "The length of shape and strides must be equal"
+                )
             s = itemsize
             for i in reversed(range(len(shape))):
                 if s != strides[i]:

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -71,7 +71,7 @@ cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) ex
             nbytes *= <Py_ssize_t>shape[i]
         # Check that data is contiguous
         strides = iface.get("strides")
-        if ndim > 0 and strides is not None:
+        if strides is not None and ndim > 0:
             if len(strides) != ndim:
                 raise ValueError(
                     "The length of shape and strides must be equal"

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -74,8 +74,8 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         shape = [int(s) for s in iface["shape"]]
         nbytes = reduce(operator.mul, shape, 1) * itemsize
         # Check that data is contiguous
-        if len(shape) > 0 and iface.get("strides", None) is not None:
-            strides = [int(s) for s in iface["strides"]]
+        if len(shape) > 0 and iface.get("strides") is not None:
+            strides = [int(s) for s in iface['strides']]
             if len(strides) != len(shape):
                 msg = "The length of shape and strides must be equal"
                 raise ValueError(msg)
@@ -84,7 +84,7 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
                 if s != strides[i]:
                     raise ValueError("Array must be contiguous")
                 s *= shape[i]
-        if iface.get("mask", None) is not None:
+        if iface.get("mask") is not None:
             raise NotImplementedError("mask attribute not supported")
     else:
         mview = memoryview(buffer)

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -29,7 +29,7 @@ def get_buffer_data(buffer, check_writable=False):
     else:
         mview = memoryview(buffer)
         data_ptr = <uintptr_t>PyMemoryView_GET_BUFFER(mview).buf
-        data_readonly = mview.readonly
+        data_readonly = <bint>PyMemoryView_GET_BUFFER(mview).readonly
 
     if data_ptr == 0:
         raise NotImplementedError("zero-sized buffers isn't supported")


### PR DESCRIPTION
Rewrites buffer utility functions to get more optimizations out of Cython. This includes typing variables where possible, leveraging `for`-loops that are easier for Cython to lower to C, making use of Cython `memoryview`s, and some code simplification (where possible).

cc @pentschev @madsbk @quasiben