### PR TITLE
Use the isort setup as cuDF

### DIFF
--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -10,12 +10,14 @@ import pstats
 import sys
 from time import perf_counter as clock
 
+import cupy
+import numpy as np
+
 from dask.utils import format_bytes, format_time
 
 import cudf
-import cupy
-import numpy as np
 import rmm
+
 import ucp
 from ucp.utils import run_on_local_network
 

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -18,7 +18,6 @@ UCX_SOCKADDR_TLS_PRIORITY=sockcm python local-send-recv.py --server-dev 0 \
 --client-dev 5 --object_type rmm --reuse-alloc --n-bytes 1GB --client-only \
 --server-address 192.168.40.44 --port 53496 --n-iter 100
 """
-
 import argparse
 import asyncio
 import multiprocessing as mp
@@ -46,6 +45,7 @@ def server(queue, args):
         np.cuda.runtime.setDevice(args.server_dev)
     else:
         import cupy as np
+
         import rmm
 
         rmm.reinitialize(
@@ -101,6 +101,7 @@ def client(queue, port, server_address, args):
         np.cuda.runtime.setDevice(args.client_dev)
     else:
         import cupy as np
+
         import rmm
 
         rmm.reinitialize(

--- a/debug-tests/client.py
+++ b/debug-tests/client.py
@@ -4,7 +4,6 @@ import time
 
 import pynvml
 import pytest
-import ucp
 from debug_utils import (
     ITERATIONS,
     parse_args,
@@ -13,6 +12,8 @@ from debug_utils import (
     total_nvlink_transfer,
 )
 from utils import recv, send
+
+import ucp
 
 pynvml.nvmlInit()
 

--- a/debug-tests/debug_utils.py
+++ b/debug-tests/debug_utils.py
@@ -1,12 +1,13 @@
 import argparse
 import os
 
-from distributed.utils import parse_bytes
-
 import cloudpickle
 import cupy
-import rmm
 from utils import get_num_gpus
+
+from distributed.utils import parse_bytes
+
+import rmm
 
 ITERATIONS = 100
 
@@ -107,8 +108,9 @@ def start_process(args, process_function):
 
 
 def cudf_obj():
-    import cudf
     import numpy as np
+
+    import cudf
 
     size = 2 ** 26
     return cudf.DataFrame(
@@ -119,6 +121,7 @@ def cudf_obj():
 def cudf_from_cupy_obj():
     import cupy
     import numpy as np
+
     import cudf
 
     size = 9 ** 5

--- a/debug-tests/server.py
+++ b/debug-tests/server.py
@@ -1,14 +1,15 @@
 import asyncio
 import os
 
+import cloudpickle
+import pytest
+from debug_utils import ITERATIONS, parse_args, set_rmm, start_process
+from utils import recv, send
+
 from distributed.comm.utils import to_frames
 from distributed.protocol import to_serialize
 
-import cloudpickle
-import pytest
 import ucp
-from debug_utils import ITERATIONS, parse_args, set_rmm, start_process
-from utils import recv, send
 
 cmd = "nvidia-smi nvlink --setcontrol 0bz"  # Get output in bytes
 # subprocess.check_call(cmd, shell=True)

--- a/debug-tests/test_send_recv_many_workers.py
+++ b/debug-tests/test_send_recv_many_workers.py
@@ -4,16 +4,17 @@ import os
 import random
 import threading
 
-from distributed.comm.utils import to_frames
-from distributed.protocol import to_serialize
-
 import cloudpickle
 import numpy as np
 import pytest
-import ucp
 from debug_utils import get_cuda_devices, set_rmm
-from ucp._libs.topological_distance import TopologicalDistance
 from utils import recv, send
+
+from distributed.comm.utils import to_frames
+from distributed.protocol import to_serialize
+
+import ucp
+from ucp._libs.topological_distance import TopologicalDistance
 
 cupy = pytest.importorskip("cupy")
 rmm = pytest.importorskip("rmm")
@@ -156,8 +157,9 @@ def server(env, port, func, enable_rmm, num_workers, proc_conn):
 
 
 def dataframe():
-    import cudf
     import numpy as np
+
+    import cudf
 
     # always generate the same random numbers
     np.random.seed(0)

--- a/examples/cupy-example.py
+++ b/examples/cupy-example.py
@@ -1,12 +1,12 @@
 import asyncio
 import time
 
-import dask.array as da
+import cupy
+
+from dask import array as da
 from dask_cuda import LocalCUDACluster
 from dask_cuda.initialize import initialize
 from distributed import Client
-
-import cupy
 
 enable_tcp_over_ucx = True
 enable_infiniband = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,16 @@ known_dask=
     dask
     distributed
     dask_cuda
-sections=FUTURE,STDLIB,DASK,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_rapids=
+    rmm
+    cuml
+    cugraph
+    dask_cudf
+    cudf
+known_first_party=
+    ucp
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,THIRDPARTY,DASK,RAPIDS,FIRSTPARTY,LOCALFOLDER
 skip=
     .eggs
     .git

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ known_dask=
     dask
     distributed
     dask_cuda
-sections=FUTURE,STDLIB,DASK,FIRSTPARTY,LOCALFOLDER
+sections=FUTURE,STDLIB,DASK,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 skip=
     .eggs
     .git

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,10 @@ from __future__ import absolute_import, print_function
 import os
 from distutils.sysconfig import get_config_var, get_python_inc
 
-import versioneer
 from setuptools import find_packages, setup
 from setuptools.extension import Extension
+
+import versioneer
 
 try:
     from Cython.Distutils.build_ext import new_build_ext as build_ext

--- a/tests/debug-tests/test_endpoint_error_callback.py
+++ b/tests/debug-tests/test_endpoint_error_callback.py
@@ -2,7 +2,6 @@
 # UCXPY_IFNAME=ib0 UCX_NET_DEVICES=mlx5_0:1 \
 # UCX_TLS=rc,tcp,sockcm,cuda_copy UCX_SOCKADDR_TLS_PRIORITY=sockcm \
 # py.test --cache-clear tests/debug-tests/test_endpoint_error_callback.py
-
 import asyncio
 import logging
 import multiprocessing
@@ -12,14 +11,15 @@ import random
 import signal
 import sys
 
+import cloudpickle
+import pytest
+from utils import get_cuda_devices, get_num_gpus, recv, send
+
 from distributed.comm.utils import to_frames
 from distributed.protocol import to_serialize
 
-import cloudpickle
-import pytest
 import ucp
 from ucp.utils import get_ucxpy_logger
-from utils import get_cuda_devices, get_num_gpus, recv, send
 
 cupy = pytest.importorskip("cupy")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,9 @@
 import os
 
 import pytest
-import ucp
 from utils import captured_logger
+
+import ucp
 
 
 def test_get_config():

--- a/tests/test_custom_send_recv.py
+++ b/tests/test_custom_send_recv.py
@@ -1,11 +1,12 @@
 import asyncio
 import pickle
 
+import numpy as np
+import pytest
+
 from distributed.comm.utils import to_frames  # noqa
 from distributed.utils import nbytes  # noqa
 
-import numpy as np
-import pytest
 import ucp
 
 cudf = pytest.importorskip("cudf")

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -5,6 +5,7 @@ from io import StringIO
 from queue import Empty
 
 import numpy as np
+
 import ucp
 
 mp = mp.get_context("spawn")

--- a/tests/test_guarantee_msg_order.py
+++ b/tests/test_guarantee_msg_order.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+
 import ucp
 
 

--- a/tests/test_libs_utils.py
+++ b/tests/test_libs_utils.py
@@ -5,6 +5,7 @@ import mmap
 import operator
 
 import pytest
+
 from ucp._libs.utils import get_buffer_data, get_buffer_nbytes
 
 builtin_buffers = [

--- a/tests/test_multiple_nodes.py
+++ b/tests/test_multiple_nodes.py
@@ -2,6 +2,7 @@ import asyncio
 
 import numpy as np
 import pytest
+
 import ucp
 
 

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -1,4 +1,5 @@
 import pytest
+
 import ucp
 
 

--- a/tests/test_run_on_local_network.py
+++ b/tests/test_run_on_local_network.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import numpy as np
+
 import ucp.utils
 
 

--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+
 import ucp
 
 np = pytest.importorskip("numpy")

--- a/tests/test_send_recv_two_workers.py
+++ b/tests/test_send_recv_two_workers.py
@@ -3,16 +3,18 @@ import multiprocessing
 import os
 import random
 
+import cloudpickle
+import numpy as np
+import pytest
+from utils import get_cuda_devices, get_num_gpus, recv, send
+
 from distributed.comm.utils import to_frames
 from distributed.protocol import to_serialize
 from distributed.utils import nbytes
 
-import cloudpickle
 import cudf.tests.utils
-import numpy as np
-import pytest
+
 import ucp
-from utils import get_cuda_devices, get_num_gpus, recv, send
 
 cmd = "nvidia-smi nvlink --setcontrol 0bz"  # Get output in bytes
 # subprocess.check_call(cmd, shell=True)
@@ -123,8 +125,9 @@ def server(port, func):
 
 
 def dataframe():
-    import cudf
     import numpy as np
+
+    import cudf
 
     # always generate the same random numbers
     np.random.seed(0)

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -3,6 +3,7 @@ import sys
 
 import numpy as np
 import pytest
+
 import ucp
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+
 import ucp
 
 

--- a/tests/test_topological_distance.py
+++ b/tests/test_topological_distance.py
@@ -2,6 +2,7 @@ import os
 
 import pynvml
 import pytest
+
 from ucp._libs.topological_distance import TopologicalDistance
 
 

--- a/tests/test_ucx_getters.py
+++ b/tests/test_ucx_getters.py
@@ -1,4 +1,5 @@
 import pytest
+
 import ucp
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,11 +3,13 @@ import logging
 import os
 from contextlib import contextmanager
 
+import numpy as np
+
 from distributed.comm.utils import from_frames
 from distributed.utils import nbytes
 
-import numpy as np
 import rmm
+
 import ucp
 
 normal_env = {

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -1,24 +1,25 @@
 # Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 # cython: language_level=3
-
-import socket
 import logging
+import socket
 import weakref
-from libc.stdio cimport FILE, fflush, fclose
+
+from posix.stdio cimport open_memstream
+
+from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
+from libc.stdint cimport uintptr_t
+from libc.stdio cimport FILE, fclose, fflush
 from libc.stdlib cimport free
 from libc.string cimport memset
-from libc.stdint cimport uintptr_t
-from posix.stdio cimport open_memstream
-from cpython.ref cimport PyObject, Py_INCREF, Py_DECREF
-
 from ucx_api_dep cimport *
+
 from ..exceptions import (
-    log_errors,
-    UCXError,
-    UCXConfigError,
     UCXCanceled,
+    UCXConfigError,
+    UCXError,
     UCXMsgTruncated,
+    log_errors,
 )
 from ..utils import nvtx_annotate
 from .utils import get_buffer_data

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -1,13 +1,14 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 # cython: language_level=3
-
 import asyncio
-from functools import reduce
 import operator
-from libc.stdint cimport uintptr_t
+from functools import reduce
+
 from cpython.memoryview cimport PyMemoryView_GET_BUFFER
-from ..exceptions import UCXError, UCXCloseError
+from libc.stdint cimport uintptr_t
+
+from ..exceptions import UCXCloseError, UCXError
 
 
 def get_buffer_data(buffer, check_writable=False):


### PR DESCRIPTION
Fixed `isort` error in CI like this [one](https://gpuci.gpuopenanalytics.com/blue/organizations/jenkins/rapidsai%2Fgpuci%2Fucx-py%2Fprb%2Fucx-py-style/detail/ucx-py-style/722/pipeline). 

Apparently, `THIRDPARTY` must be defined under `sections`. We now use the same order as [cuDF]( https://github.com/rapidsai/cudf/blob/6dc286ba67d2ec7e73674351be7011604b7a2fe7/python/cudf/setup.cfg#L15)
