### PR TITLE
Send/Recv object

### DIFF
--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 
 import pytest
 
@@ -169,4 +170,24 @@ async def test_send_recv_obj(blocking_progress_mode):
     msg = bytearray(b"hello")
     await client.send_obj(msg)
     got = await client.recv_obj()
+    assert msg == got
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocking_progress_mode", [True, False])
+async def test_send_recv_obj_numpy(blocking_progress_mode):
+    ucp.init(blocking_progress_mode=blocking_progress_mode)
+
+    allocator = functools.partial(np.empty, dtype=np.uint8)
+
+    async def echo_obj_server(ep):
+        obj = await ep.recv_obj(allocator=allocator)
+        await ep.send_obj(obj)
+
+    listener = ucp.create_listener(echo_obj_server)
+    client = await ucp.create_endpoint(ucp.get_address(), listener.port)
+
+    msg = bytearray(b"hello")
+    await client.send_obj(msg)
+    got = await client.recv_obj(allocator=allocator)
     assert msg == got

--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -152,3 +152,21 @@ async def test_send_recv_error(blocking_progress_mode):
         match=r"length mismatch: 3 \(got\) != 100 \(expected\)",
     ):
         await client.recv(msg)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocking_progress_mode", [True, False])
+async def test_send_recv_obj(blocking_progress_mode):
+    ucp.init(blocking_progress_mode=blocking_progress_mode)
+
+    async def echo_obj_server(ep):
+        obj = await ep.recv_obj()
+        await ep.send_obj(obj)
+
+    listener = ucp.create_listener(echo_obj_server)
+    client = await ucp.create_endpoint(ucp.get_address(), listener.port)
+
+    msg = bytearray(b"hello")
+    await client.send_obj(msg)
+    got = await client.recv_obj()
+    assert msg == got

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -677,7 +677,8 @@ class Endpoint:
     async def send_obj(self, obj, tag=None):
         """Send `obj` to connected peer that calls `recv_obj()`.
 
-        The message include size information of the object.
+        The transfer includes an extra message containing the size of `obj`,
+        which increses the overhead slightly.
 
         Parameters
         ----------
@@ -685,6 +686,10 @@ class Endpoint:
             The object to send.
         tag: hashable, optional
             Set a tag that the receiver must match.
+
+        Example
+        -------
+        >>> await ep.send_obj(pickle.dumps([1,2,3]))
         """
 
         nbytes = get_buffer_nbytes(
@@ -698,6 +703,9 @@ class Endpoint:
 
         As opposed to `recv()`, this function returns the received object.
 
+        The transfer includes an extra message containing the size of `obj`,
+        which increses the overhead slightly.
+
         Parameters
         ----------
         tag: hashable, optional
@@ -708,6 +716,10 @@ class Endpoint:
             Function to allocate the recvied object. The function should
             take the number of bytes to allocate as input and return a new
             buffer of that size as output.
+
+        Example
+        -------
+        >>> await pickle.loads(ep.recv_obj())
         """
         nbytes = bytearray(struct.calcsize("Q"))
         await self.recv(nbytes, tag=tag)

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -674,6 +674,48 @@ class Endpoint:
                 % (n, self._finished_recv_count)
             )
 
+    async def send_obj(self, obj, tag=None):
+        """Send `obj` to connected peer that calls `recv_obj()`.
+
+        The message include size information of the object.
+
+        Parameters
+        ----------
+        obj: exposing the buffer protocol or array/cuda interface
+            The object to send.
+        tag: hashable, optional
+            Set a tag that the receiver must match.
+        """
+
+        nbytes = get_buffer_nbytes(
+            buffer=obj, check_min_size=None, cuda_support=self._cuda_support
+        )
+        await self.send(struct.pack("Q", nbytes), tag=tag)
+        await self.send(obj, tag=tag)
+
+    async def recv_obj(self, tag=None, allocator=bytearray):
+        """Receive from connected peer that calls `send_obj()`.
+
+        As opposed to `recv()`, this function returns the received object.
+
+        Parameters
+        ----------
+        tag: hashable, optional
+            Set a tag that must match the received message. Notice, currently
+            UCX-Py doesn't support a "any tag" thus `tag=None` only matches a
+            send that also sets `tag=None`.
+        allocator: callabale, optional
+            Function to allocate the recvied object. The function should
+            take the number of bytes to allocate as input and return a new
+            buffer of that size as output.
+        """
+        nbytes = bytearray(struct.calcsize("Q"))
+        await self.recv(nbytes, tag=tag)
+        (nbytes,) = struct.unpack("Q", nbytes)
+        ret = allocator(nbytes)
+        await self.recv(ret, nbytes=nbytes, tag=tag)
+        return ret
+
 
 # The following functions initialize and use a single ApplicationContext instance
 

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -702,6 +702,7 @@ class Endpoint:
         """Receive from connected peer that calls `send_obj()`.
 
         As opposed to `recv()`, this function returns the received object.
+        Data is received into a buffer allocated by `allocator`.
 
         The transfer includes an extra message containing the size of `obj`,
         which increses the overhead slightly.

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -678,7 +678,7 @@ class Endpoint:
         """Send `obj` to connected peer that calls `recv_obj()`.
 
         The transfer includes an extra message containing the size of `obj`,
-        which increses the overhead slightly.
+        which increases the overhead slightly.
 
         Parameters
         ----------
@@ -713,7 +713,7 @@ class Endpoint:
             UCX-Py doesn't support a "any tag" thus `tag=None` only matches a
             send that also sets `tag=None`.
         allocator: callabale, optional
-            Function to allocate the recvied object. The function should
+            Function to allocate the received object. The function should
             take the number of bytes to allocate as input and return a new
             buffer of that size as output.
 


### PR DESCRIPTION
This PR implements `send_obj()` and `recv_obj()`, which are convenient functions that exchange size information.

```python
async def recv_obj(self, tag=None, allocator=bytearray):
    """Receive from connected peer that calls `send_obj()`.

    As opposed to `recv()`, this function returns the received object.

    The transfer includes an extra message containing the size of `obj`,
    which increses the overhead slightly.

    Parameters
    ----------
    tag: hashable, optional
        Set a tag that must match the received message. Notice, currently
        UCX-Py doesn't support a "any tag" thus `tag=None` only matches a
        send that also sets `tag=None`.
    allocator: callabale, optional
        Function to allocate the recvied object. The function should
        take the number of bytes to allocate as input and return a new
        buffer of that size as output.

    Example
    -------
    >>> await pickle.loads(ep.recv_obj())
    """
```