### PR TITLE
Use cuDF's `assert_eq`

### DIFF
--- a/tests/test_custom_send_recv.py
+++ b/tests/test_custom_send_recv.py
@@ -118,7 +118,7 @@ async def test_send_recv_cudf(event_loop, g):
     typ = type(msg)
     res = typ.deserialize(ucx_header, cudf_buffer)
 
-    from dask.dataframe.utils import assert_eq
+    from cudf.tests.utils import assert_eq
 
     assert_eq(res, msg)
     await uu.comm.ep.close()


### PR DESCRIPTION
Previously we were using Dask's `assert_eq`, which caused some issues when testing with cuDF's new nullable support. Here we fix this by relying on cuDF's `assert_eq`, which is designed to handle cuDF objects that we are passing.

cc @pentschev @quasiben