### PR TITLE
Run PyTorch tests from Distributed on CI

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -57,6 +57,9 @@ conda install -c conda-forge "async_generator" "automake" "libtool" \
                               "pytest" "pkg-config" "pytest-asyncio" \
                               "pynvml" "libhwloc" "psutil"
 
+# Install pytorch to run related tests
+conda install -c pytorch "pytorch" "torchvision"
+
 # Install the master version of dask and distributed
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
@@ -133,6 +136,7 @@ else
         py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_cupy as m;print(m.__file__)"`
         py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_numba as m;print(m.__file__)"`
         py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_rmm as m;print(m.__file__)"`
+        py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_torch as m;print(m.__file__)"`
         py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_collection_cuda as m;print(m.__file__)"`
         py.test --cache-clear -vs `python -c "import distributed.comm.tests.test_ucx as m;print(m.__file__)"`
         py.test --cache-clear -vs `python -c "import distributed.tests.test_nanny as m;print(m.__file__)"`


### PR DESCRIPTION
Make sure we are running the PyTorch tests on CI so we can catch any regressions here.