### PR TITLE
Fix-up CI requirements

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,7 +53,7 @@ conda install "cudatoolkit=$CUDA_REL" \
 
 # needed for asynccontextmanager in py36
 conda install -c conda-forge "async_generator" "autoconf" "automake" "libtool" \
-                              "cython>=0.29.14,<3.0.0a0" \
+                              "make" "cython>=0.29.14,<3.0.0a0" \
                               "pytest" "pkg-config" "pytest-asyncio" \
                               "pynvml" "libhwloc" "psutil"
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -52,7 +52,7 @@ conda install "cudatoolkit=$CUDA_REL" \
               -c rapidsai-nightly
 
 # needed for asynccontextmanager in py36
-conda install -c conda-forge "async_generator" "automake" "libtool" \
+conda install -c conda-forge "async_generator" "libtool" \
                               "automake" "autoconf" "cython>=0.29.14,<3.0.0a0" \
                               "pytest" "pkg-config" "pytest-asyncio" \
                               "pynvml" "libhwloc" "psutil"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -46,12 +46,12 @@ nvidia-smi
 logger "Activate conda env..."
 source activate gdf
 conda install "cudatoolkit=$CUDA_REL" \
-              "cupy>=6.5.0" \
-              "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
-              "dask>=2.8.1" "distributed>=2.8.1" \
               "cython>=0.29.14,<3.0.0a0" \
               "libhwloc" "ucx" "ucx-proc=*=gpu" \
               "numpy>=1.16" \
+              "cupy>=6.5.0" \
+              "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
+              "dask>=2.8.1" "distributed>=2.8.1" \
               "pytest" "pytest-asyncio" \
               "pynvml" "psutil"
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -49,12 +49,11 @@ conda install "cudatoolkit=$CUDA_REL" \
               "cupy>=6.5.0" "numpy>=1.16" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
               "dask>=2.8.1" "distributed>=2.8.1" \
-              "ucx" "ucx-proc=*=gpu" \
-              -c rapidsai-nightly
+              "ucx" "ucx-proc=*=gpu"
 
-conda install -c conda-forge "cython>=0.29.14,<3.0.0a0" \
-                             "pytest" "pytest-asyncio" \
-                             "pynvml" "libhwloc" "psutil"
+conda install "cython>=0.29.14,<3.0.0a0" \
+              "pytest" "pytest-asyncio" \
+              "pynvml" "libhwloc" "psutil"
 
 # Install the master version of dask and distributed
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -49,10 +49,10 @@ conda install "cudatoolkit=$CUDA_REL" \
               "cupy>=6.5.0" "numpy>=1.16" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
               "dask>=2.8.1" "distributed>=2.8.1" \
-              "ucx" "ucx-proc=*=gpu" \
               "cython>=0.29.14,<3.0.0a0" \
+              "libhwloc" "ucx" "ucx-proc=*=gpu" \
               "pytest" "pytest-asyncio" \
-              "pynvml" "libhwloc" "psutil"
+              "pynvml" "psutil"
 
 # Install the master version of dask and distributed
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -49,9 +49,8 @@ conda install "cudatoolkit=$CUDA_REL" \
               "cupy>=6.5.0" "numpy>=1.16" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
               "dask>=2.8.1" "distributed>=2.8.1" \
-              "ucx" "ucx-proc=*=gpu"
-
-conda install "cython>=0.29.14,<3.0.0a0" \
+              "ucx" "ucx-proc=*=gpu" \
+              "cython>=0.29.14,<3.0.0a0" \
               "pytest" "pytest-asyncio" \
               "pynvml" "libhwloc" "psutil"
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,10 +53,9 @@ conda install "cudatoolkit=$CUDA_REL" \
               -c rapidsai-nightly
 
 # needed for asynccontextmanager in py36
-conda install -c conda-forge "async_generator" "autoconf" "automake" "libtool" \
-                              "make" "cython>=0.29.14,<3.0.0a0" \
-                              "pytest" "pkg-config" "pytest-asyncio" \
-                              "pynvml" "libhwloc" "psutil"
+conda install -c conda-forge "async_generator" "cython>=0.29.14,<3.0.0a0" \
+                             "pytest" "pytest-asyncio" \
+                             "pynvml" "libhwloc" "psutil"
 
 # Install the master version of dask and distributed
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -45,15 +45,9 @@ nvidia-smi
 
 logger "Activate conda env..."
 source activate gdf
-conda install "cudatoolkit=$CUDA_REL" \
-              "cython>=0.29.14,<3.0.0a0" \
-              "libhwloc" "ucx" "ucx-proc=*=gpu" \
-              "numpy>=1.16" \
-              "pytest" "pytest-asyncio" \
-              "cupy>=6.5.0" \
+conda install "cudatoolkit=${CUDA_REL}" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
-              "dask>=2.8.1" "distributed>=2.8.1" \
-              "pynvml" "psutil"
+              "rapids-build-env=${MINOR_VERSION}"
 
 # Install the master version of dask and distributed
 logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -52,8 +52,7 @@ conda install "cudatoolkit=$CUDA_REL" \
               "ucx" "ucx-proc=*=gpu" \
               -c rapidsai-nightly
 
-# needed for asynccontextmanager in py36
-conda install -c conda-forge "async_generator" "cython>=0.29.14,<3.0.0a0" \
+conda install -c conda-forge "cython>=0.29.14,<3.0.0a0" \
                              "pytest" "pytest-asyncio" \
                              "pynvml" "libhwloc" "psutil"
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -49,6 +49,7 @@ conda install "cudatoolkit=$CUDA_REL" \
               "cupy>=6.5.0" "numpy>=1.16" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
               "dask>=2.8.1" "distributed>=2.8.1" \
+              "ucx" "ucx-proc=*=gpu" \
               -c rapidsai-nightly
 
 # needed for asynccontextmanager in py36

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -46,11 +46,12 @@ nvidia-smi
 logger "Activate conda env..."
 source activate gdf
 conda install "cudatoolkit=$CUDA_REL" \
-              "cupy>=6.5.0" "numpy>=1.16" \
+              "cupy>=6.5.0" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
               "dask>=2.8.1" "distributed>=2.8.1" \
               "cython>=0.29.14,<3.0.0a0" \
               "libhwloc" "ucx" "ucx-proc=*=gpu" \
+              "numpy>=1.16" \
               "pytest" "pytest-asyncio" \
               "pynvml" "psutil"
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,7 +53,7 @@ conda install "cudatoolkit=$CUDA_REL" \
 
 # needed for asynccontextmanager in py36
 conda install -c conda-forge "async_generator" "automake" "libtool" \
-                              "cmake" "automake" "autoconf" "cython>=0.29.14,<3.0.0a0" \
+                              "automake" "autoconf" "cython>=0.29.14,<3.0.0a0" \
                               "pytest" "pkg-config" "pytest-asyncio" \
                               "pynvml" "libhwloc" "psutil"
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -70,25 +70,6 @@ $CXX --version
 conda list
 
 ################################################################################
-# BUILD - Build ucx
-################################################################################
-
-logger "Build ucx"
-git clone https://github.com/openucx/ucx
-cd ucx
-git checkout v1.8.x
-ls
-./autogen.sh
-mkdir build
-cd build
-../configure --prefix=$CONDA_PREFIX --enable-debug --with-cuda=$CUDA_HOME --enable-mt CPPFLAGS="-I//$CUDA_HOME/include"
-make -j install
-cd $WORKSPACE
-
-
-
-
-################################################################################
 # BUILD - Build ucx-py
 ################################################################################
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -49,10 +49,10 @@ conda install "cudatoolkit=$CUDA_REL" \
               "cython>=0.29.14,<3.0.0a0" \
               "libhwloc" "ucx" "ucx-proc=*=gpu" \
               "numpy>=1.16" \
+              "pytest" "pytest-asyncio" \
               "cupy>=6.5.0" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
               "dask>=2.8.1" "distributed>=2.8.1" \
-              "pytest" "pytest-asyncio" \
               "pynvml" "psutil"
 
 # Install the master version of dask and distributed

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -52,8 +52,8 @@ conda install "cudatoolkit=$CUDA_REL" \
               -c rapidsai-nightly
 
 # needed for asynccontextmanager in py36
-conda install -c conda-forge "async_generator" "libtool" \
-                              "automake" "autoconf" "cython>=0.29.14,<3.0.0a0" \
+conda install -c conda-forge "async_generator" "autoconf" "automake" "libtool" \
+                              "cython>=0.29.14,<3.0.0a0" \
                               "pytest" "pkg-config" "pytest-asyncio" \
                               "pynvml" "libhwloc" "psutil"
 

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,11 @@ install_requires = [
     "psutil",
 ]
 
+tests_require = [
+    "pytest",
+    "pytest-asyncio",
+]
+
 setup(
     name="ucx-py",
     packages=find_packages(exclude=["tests*"]),
@@ -80,6 +85,7 @@ setup(
     version=versioneer.get_version(),
     python_requires=">=3.6",
     install_requires=install_requires,
+    tests_require=tests_require,
     description="Python Bindings for the Unified Communication X library (UCX)",
     long_description=readme,
     author="NVIDIA Corporation",

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ cmdclass["build_ext"] = build_ext
 install_requires = [
     "numpy",
     "psutil",
+    "pynvml",
 ]
 
 tests_require = [


### PR DESCRIPTION
Cleans up requirements on CI.

* Use `ucx` package instead of building from source
* Drop/consolidate dependencies