### PR TITLE
Use `getattr` instead of `hasattr`

### DIFF
--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
 # cython: language_level=3

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -70,8 +70,9 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         shape = [int(s) for s in iface["shape"]]
         nbytes = reduce(operator.mul, shape, 1) * itemsize
         # Check that data is contiguous
-        if len(shape) > 0 and iface.get("strides") is not None:
-            strides = [int(s) for s in iface['strides']]
+        strides = iface.get("strides")
+        if len(shape) > 0 and strides is not None:
+            strides = [int(s) for s in strides]
             if len(strides) != len(shape):
                 msg = "The length of shape and strides must be equal"
                 raise ValueError(msg)

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -68,7 +68,7 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         itemsize = int(numpy.dtype(iface["typestr"]).itemsize)
         # Making sure that the elements in shape is integers
         shape = [int(s) for s in iface["shape"]]
-        nbytes = reduce(operator.mul, shape, 1) * itemsize
+        nbytes = reduce(operator.mul, shape, itemsize)
         # Check that data is contiguous
         strides = iface.get("strides")
         if len(shape) > 0 and strides is not None:

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -20,11 +20,9 @@ def get_buffer_data(buffer, check_writable=False):
     is read only and check_writable=True is set.
     """
 
-    iface = None
-    if hasattr(buffer, "__cuda_array_interface__"):
-        iface = buffer.__cuda_array_interface__
-    elif hasattr(buffer, "__array_interface__"):
-        iface = buffer.__array_interface__
+    iface = getattr(buffer, "__array_interface__", None)
+    if iface is None:
+        iface = getattr(buffer, "__cuda_array_interface__", None)
 
     if iface is not None:
         data_ptr, data_readonly = iface["data"]
@@ -53,10 +51,10 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
     if `check_min_size` is greater than the size of the buffer
     """
 
-    iface = None
-    if hasattr(buffer, "__cuda_array_interface__"):
-        iface = buffer.__cuda_array_interface__
-        if not cuda_support:
+    iface = getattr(buffer, "__array_interface__", None)
+    if iface is None:
+        iface = getattr(buffer, "__cuda_array_interface__", None)
+        if not cuda_support and iface is not None:
             msg = "UCX is not configured with CUDA support, please add " \
                   "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment" \
                   "variable and that the ucx-proc=*=gpu package is " \
@@ -64,8 +62,6 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
                   "https://ucx-py.readthedocs.io/en/latest/install.html for " \
                   "more information."
             raise ValueError(msg)
-    elif hasattr(buffer, "__array_interface__"):
-        iface = buffer.__array_interface__
 
     if iface is not None:
         import numpy

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -1,6 +1,9 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
+
 # cython: language_level=3
+
+
 import asyncio
 import operator
 from functools import reduce

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -27,7 +27,7 @@ def get_buffer_data(buffer, check_writable=False):
         iface = buffer.__array_interface__
 
     if iface is not None:
-        data_ptr, data_readonly = iface['data']
+        data_ptr, data_readonly = iface["data"]
     else:
         mview = memoryview(buffer)
         data_ptr = int(<uintptr_t>PyMemoryView_GET_BUFFER(mview).buf)
@@ -69,13 +69,13 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
 
     if iface is not None:
         import numpy
-        itemsize = int(numpy.dtype(iface['typestr']).itemsize)
+        itemsize = int(numpy.dtype(iface["typestr"]).itemsize)
         # Making sure that the elements in shape is integers
-        shape = [int(s) for s in iface['shape']]
+        shape = [int(s) for s in iface["shape"]]
         nbytes = reduce(operator.mul, shape, 1) * itemsize
         # Check that data is contiguous
         if len(shape) > 0 and iface.get("strides", None) is not None:
-            strides = [int(s) for s in iface['strides']]
+            strides = [int(s) for s in iface["strides"]]
             if len(strides) != len(shape):
                 msg = "The length of shape and strides must be equal"
                 raise ValueError(msg)

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -16,6 +16,7 @@ def get_buffer_data(buffer, check_writable=False):
     Returns data pointer of the buffer. Raising ValueError if the buffer
     is read only and check_writable=True is set.
     """
+
     iface = None
     if hasattr(buffer, "__cuda_array_interface__"):
         iface = buffer.__cuda_array_interface__

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -74,8 +74,8 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
         shape = [int(s) for s in iface["shape"]]
         nbytes = reduce(operator.mul, shape, 1) * itemsize
         # Check that data is contiguous
-        if len(shape) > 0 and iface.get("strides", None) is not None:
-            strides = [int(s) for s in iface["strides"]]
+        if len(shape) > 0 and iface.get("strides") is not None:
+            strides = [int(s) for s in iface['strides']]
             if len(strides) != len(shape):
                 msg = "The length of shape and strides must be equal"
                 raise ValueError(msg)
@@ -84,7 +84,7 @@ def get_buffer_nbytes(buffer, check_min_size, cuda_support):
                 if s != strides[i]:
                     raise ValueError("Array must be contiguous")
                 s *= shape[i]
-        if iface.get("mask", None) is not None:
+        if iface.get("mask") is not None:
             raise NotImplementedError("mask attribute not supported")
     else:
         mview = memoryview(buffer)


### PR DESCRIPTION
Calling `hasattr` is just as expensive as calling `getattr` and slightly more expensive than direct attribute access. As a result calling `hasattr` and then perform attribute access, we are effectively paying the cost of attribute access twice.

<details>
<summary><code>hasattr</code> vs. <code>getattr</code> vs. direct access</summary>

```python
In [1]: import numpy                                                            

In [2]: a = numpy.arange(110).reshape(10, 11)                                   

In [3]: %timeit hasattr(a, "__array_interface__")                               
1.17 µs ± 3.73 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: %timeit getattr(a, "__array_interface__", None)                         
1.17 µs ± 5.61 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [5]: %timeit a.__array_interface__                                           
1.11 µs ± 2.27 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

</details>

When we look at the overall runtime of `get_buffer_data` and `get_buffer_nbytes`, we can see that attribute access makes a significant contribution to runtime of these functions overall.

<details>
<summary>Runtime <b>before</b> of <code>get_buffer_data</code> and <code>get_buffer_nbytes</code></summary>

```python
In [1]: import numpy 
   ...:  
   ...: from ucp._libs.utils import get_buffer_data, get_buffer_nbytes          

In [2]: a = numpy.arange(110).reshape(10, 11)                                   

In [3]: %timeit get_buffer_data(a)                                              
2.48 µs ± 12.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [4]: %timeit get_buffer_nbytes(a, check_min_size=None, cuda_support=True)    
3.67 µs ± 17.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

</details>

So we can simply switch to `getattr` and add a default case of `None` to check for. Overall this is a pretty minor change to the code here. Though the result in terms of `get_buffer_data` and `get_buffer_nbytes` is quite notable, making both ~2x faster.

<details>
<summary>Runtime <b>after</b> of <code>get_buffer_data</code> and <code>get_buffer_nbytes</code></summary>

```python
In [1]: import numpy 
   ...:  
   ...: from ucp._libs.utils import get_buffer_data, get_buffer_nbytes          

In [2]: a = numpy.arange(110).reshape(10, 11)                                   

In [3]: %timeit get_buffer_data(a)                                              
1.16 µs ± 12.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: %timeit get_buffer_nbytes(a, check_min_size=None, cuda_support=True)    
2.13 µs ± 20.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

</details>

cc @pentschev @madsbk @quasiben