### PR TITLE
WIP: Bypass RMM initialization

### DIFF
--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -168,6 +168,7 @@ async def worker(rank, eps, args):
 
     # Initialize RMM and use pool
     import rmm
+
     rmm.reinitialize(
         pool_allocator=True, devices=dev_id, initial_pool_size=args.rmm_init_pool_size
     )

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -19,8 +19,6 @@ os.environ["RAPIDS_NO_INITIALIZE"] = "1"
 
 from dask.utils import format_bytes, format_time
 
-import cudf
-
 import ucp
 from ucp.utils import run_on_local_network
 
@@ -76,6 +74,8 @@ async def recv_bins(eps, bins):
 
 
 async def exchange_and_concat_bins(rank, eps, bins, timings=None):
+    import cudf
+
     ret = [bins[rank]]
     if timings is not None:
         t1 = clock()
@@ -98,6 +98,8 @@ async def distributed_join(args, rank, eps, left_table, right_table, timings=Non
 
 
 def generate_chunk(i_chunk, local_size, num_chunks, chunk_type, frac_match):
+    import cudf
+
     cupy.random.seed(42)
 
     if chunk_type == "build":

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -20,7 +20,6 @@ os.environ["RAPIDS_NO_INITIALIZE"] = "1"
 from dask.utils import format_bytes, format_time
 
 import cudf
-import rmm
 
 import ucp
 from ucp.utils import run_on_local_network
@@ -163,6 +162,9 @@ async def worker(rank, eps, args):
     # Setting current device and make RMM use it
     dev_id = args.devs[rank % len(args.devs)]
     cupy.cuda.runtime.setDevice(dev_id)
+
+    # Initialize RMM and use pool
+    import rmm
     rmm.reinitialize(
         pool_allocator=True, devices=dev_id, initial_pool_size=args.rmm_init_pool_size
     )

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -19,7 +19,6 @@ from dask.utils import format_bytes, format_time
 import ucp
 from ucp.utils import run_on_local_network
 
-
 os.environ["RMM_NO_INITIALIZE"] = "1"
 os.environ["RAPIDS_NO_INITIALIZE"] = "1"
 

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -14,13 +14,14 @@ from time import perf_counter as clock
 import cupy
 import numpy as np
 
-os.environ["RMM_NO_INITIALIZE"] = "1"
-os.environ["RAPIDS_NO_INITIALIZE"] = "1"
-
 from dask.utils import format_bytes, format_time
 
 import ucp
 from ucp.utils import run_on_local_network
+
+
+os.environ["RMM_NO_INITIALIZE"] = "1"
+os.environ["RAPIDS_NO_INITIALIZE"] = "1"
 
 
 async def send_df(ep, df):

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import cProfile
 import io
+import os
 import pickle
 import pstats
 import sys
@@ -12,6 +13,9 @@ from time import perf_counter as clock
 
 import cupy
 import numpy as np
+
+os.environ["RMM_NO_INITIALIZE"] = "1"
+os.environ["RAPIDS_NO_INITIALIZE"] = "1"
 
 from dask.utils import format_bytes, format_time
 

--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -28,6 +28,9 @@ from distributed.utils import format_bytes, parse_bytes
 
 import ucp
 
+os.environ["RMM_NO_INITIALIZE"] = "1"
+os.environ["RAPIDS_NO_INITIALIZE"] = "1"
+
 mp = mp.get_context("spawn")
 
 


### PR DESCRIPTION
Recently we have had some problems arise following recent changes in RMM to deprecate CNMeM ( https://github.com/rapidsai/rmm/pull/466 ) related to running workloads with UCX-Py. These are best exemplified by running the dataframe merge benchmark ( https://github.com/rapidsai/ucx-py/pull/575#issuecomment-672730196 ) and the send/recv benchmark ( https://github.com/rapidsai/ucx-py/pull/575#issuecomment-672743805 ). These appear (though have not been confirmed to be) similar to an issue we have seen with Dask-CUDA ( https://github.com/rapidsai/dask-cuda/issues/364 ).

This attempts to address them in combination with upstream changes to RMM ( https://github.com/rapidsai/rmm/pull/490 ).