### PR TITLE
Some cleanup of topological distance

### DIFF
--- a/ucp/_libs/topological_distance.pxd
+++ b/ucp/_libs/topological_distance.pxd
@@ -10,3 +10,10 @@ from .topological_distance_dep cimport *
 cdef class TopologicalDistance:
     cdef:
         hwloc_topology_t topo
+
+    cpdef get_cuda_distances_from_pci_info(self, int domain, int bus,
+                                           int device,
+                                           str device_type=*)
+
+    cpdef get_cuda_distances_from_device_index(self, cuda_device_index,
+                                               str device_type=*)

--- a/ucp/_libs/topological_distance.pxd
+++ b/ucp/_libs/topological_distance.pxd
@@ -1,0 +1,12 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+
+# cython: language_level=3
+
+
+from .topological_distance_dep cimport *
+
+
+cdef class TopologicalDistance:
+    cdef:
+        hwloc_topology_t topo

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -27,8 +27,9 @@ cdef class TopologicalDistance:
         cdef hwloc_topology_t topo = self.topo
         hwloc_topology_destroy(topo)
 
-    def get_cuda_distances_from_pci_info(self, int domain, int bus, int device,
-                                         str device_type="openfabrics"):
+    cpdef get_cuda_distances_from_pci_info(self, int domain, int bus,
+                                           int device,
+                                           str device_type="openfabrics"):
         """ Find network or openfabrics devices closest to CUDA device at
         domain:bus:device address.
 

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -27,8 +27,8 @@ cdef class TopologicalDistance:
         cdef hwloc_topology_t topo = self.topo
         hwloc_topology_destroy(topo)
 
-    def get_cuda_distances_from_pci_info(self, domain, bus, device,
-                                         device_type="openfabrics"):
+    def get_cuda_distances_from_pci_info(self, int domain, int bus, int device,
+                                         str device_type="openfabrics"):
         """ Find network or openfabrics devices closest to CUDA device at
         domain:bus:device address.
 
@@ -102,7 +102,7 @@ cdef class TopologicalDistance:
         return ret
 
     def get_cuda_distances_from_device_index(self, cuda_device_index,
-                                             device_type="openfabrics"):
+                                             str device_type="openfabrics"):
         """ Find network or openfabrics devices closest to CUDA device of given index.
 
         Parameters

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -92,6 +92,7 @@ cdef class TopologicalDistance:
         cdef topological_distance_and_name_t *dist_name
         dist_name = get_topological_distance_and_name(dev_dist, dev_count)
 
+        cdef int i
         ret = [{"distance": dist_name[i].distance,
                "name": dist_name[i].name.decode("utf-8")}
                for i in range(dev_count)]

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -21,10 +21,10 @@ cdef class TopologicalDistance:
         (e.g., InfiniBand, aka. 'mlx5' or 'ib') interfaces closest to a NVIDIA GPU.
 
         """
-        self.topo = <hwloc_topology_t> initialize_topology()
+        self.topo = initialize_topology()
 
     def __dealloc__(self):
-        cdef hwloc_topology_t topo = <hwloc_topology_t> self.topo
+        cdef hwloc_topology_t topo = self.topo
         hwloc_topology_destroy(topo)
 
     def get_cuda_distances_from_pci_info(self, domain, bus, device,
@@ -80,8 +80,8 @@ cdef class TopologicalDistance:
             raise RuntimeError("Unknown device type: %s" % device_type)
 
         cdef hwloc_obj_t cuda_pcidev
-        cuda_pcidev = <hwloc_obj_t> get_cuda_pcidev_from_pci_info(
-            <hwloc_topology_t> self.topo, domain, bus, device
+        cuda_pcidev = get_cuda_pcidev_from_pci_info(
+            self.topo, domain, bus, device
         )
 
         cdef topological_distance_objs_t *dev_dist
@@ -90,12 +90,10 @@ cdef class TopologicalDistance:
                                      hwloc_osdev_type)
 
         cdef topological_distance_and_name_t *dist_name
-        dist_name = <topological_distance_and_name_t *> (
-            get_topological_distance_and_name(dev_dist, dev_count)
-        )
+        dist_name = get_topological_distance_and_name(dev_dist, dev_count)
 
-        ret = [{"distance": <int>(&dist_name[i]).distance,
-               "name": (<char *>(&dist_name[i]).name).decode("utf-8")}
+        ret = [{"distance": (&dist_name[i]).distance,
+               "name": ((&dist_name[i]).name).decode("utf-8")}
                for i in range(dev_count)]
 
         free(dev_dist)

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -92,8 +92,8 @@ cdef class TopologicalDistance:
         cdef topological_distance_and_name_t *dist_name
         dist_name = get_topological_distance_and_name(dev_dist, dev_count)
 
-        ret = [{"distance": (&dist_name[i]).distance,
-               "name": ((&dist_name[i]).name).decode("utf-8")}
+        ret = [{"distance": dist_name[i].distance,
+               "name": dist_name[i].name.decode("utf-8")}
                for i in range(dev_count)]
 
         free(dev_dist)

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -8,9 +8,6 @@ from .topological_distance_dep cimport *
 
 
 cdef class TopologicalDistance:
-    cdef:
-        hwloc_topology_t topo
-
     def __init__(self):
         """ Find topological distance between devices
 

--- a/ucp/_libs/topological_distance.pyx
+++ b/ucp/_libs/topological_distance.pyx
@@ -103,8 +103,8 @@ cdef class TopologicalDistance:
 
         return ret
 
-    def get_cuda_distances_from_device_index(self, cuda_device_index,
-                                             str device_type="openfabrics"):
+    cpdef get_cuda_distances_from_device_index(self, cuda_device_index,
+                                               str device_type="openfabrics"):
         """ Find network or openfabrics devices closest to CUDA device of given index.
 
         Parameters


### PR DESCRIPTION
Adds a `.pxd` file for `topological_distance`. Types methods arguments and variables in methods. Drops some casts where the type was unchanged.