### PR TITLE
Use 2 MB pool for cuDF merge

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -118,5 +118,5 @@ else
 
     logger "Run local benchmark..."
     python benchmarks/local-send-recv.py -o cupy --server-dev 0 --client-dev 0 --reuse-alloc
-    python benchmarks/cudf-merge.py --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 100
+    python benchmarks/cudf-merge.py --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 2097152
 fi


### PR DESCRIPTION
This entire computation uses a bit under 2 MB of space. So bump the pool size so that all the allocations should fit comfortably within it.

xref: https://github.com/rapidsai/ucx-py/issues/578#issuecomment-674309920

cc @quasiben