### PR TITLE
Include docs on building IB/RDMA support

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -98,7 +98,7 @@ As noted above, the UCX conda package no longer builds support for IB/RDMA.  To 
 If OFED drivers are not installed on the machine, you can download drivers at directly from `Mellanox <https://www.mellanox.com/products/infiniband-drivers/linux/mlnx_ofed>`_.  For versions older than 5.1 click on, *archive versions*.
 
 
-To build UCX with IB/RDMA support, include the ``--with-rdmacm``, ``--with-verbs``, and ``--with-cm`` build flags.  For example:
+To build UCX with IB/RDMA support, include the ``--with-rdmacm`` and ``--with-verbs`` build flags.  For example:
 
 ::
      ../contrib/configure-release --enable-mt

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -39,7 +39,7 @@ Source
 The following instructions assume you'll be using ucx-py on a CUDA enabled system and is in a `Conda environment <https://docs.conda.io/projects/conda/en/latest/>`_.
 
 .. note::
-    As of version 0.15, the UCX conda package will no longer build with IB/RDMA included.  This is largely due in part to compatibility issues
+    As of version 0.15, the UCX conda package build will no longer include IB/RDMA support.  This is largely due in part to compatibility issues
     between OFED versions.  However, we do provide instructions below for how to build UCX with IB/RDMA support.
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -39,8 +39,9 @@ Source
 The following instructions assume you'll be using ucx-py on a CUDA enabled system and is in a `Conda environment <https://docs.conda.io/projects/conda/en/latest/>`_.
 
 .. note::
-    As of version 0.15, the UCX conda package build will no longer include IB/RDMA support.  This is largely due in part to compatibility issues
-    between OFED versions.  However, we do provide instructions below for how to build UCX with IB/RDMA support.
+    As of version 0.15, the UCX conda package build will no longer include IB/RDMA support.  This is largely due to compatibility issues
+    between OFED versions.  We do however provide instructions below for how to build UCX with IB/RDMA support in the `UCX + OFED`_
+    section.
 
 
 Build Dependencies
@@ -102,7 +103,9 @@ If OFED drivers are not installed on the machine, you can download drivers at di
 To build UCX with IB/RDMA support, include the ``--with-rdmacm`` and ``--with-verbs`` build flags.  For example:
 
 ::
-     ../contrib/configure-release --enable-mt
+
+    ../contrib/configure-release \
+    --enable-mt \
     --prefix="$CONDA_PREFIX" \
     --with-cuda="$CUDA_HOME" \
     --enable-mt \

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -73,9 +73,9 @@ UCX
     cd ucx
     git checkout v1.8.x
     # apply UCX IB registration patches
-    curl -L https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/add-page-alignment.patch > /tmp/add-page-alignment.patch
-    curl -L https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/ib_registration_cache.patch > /tmp/ib_registration_cache.patch
-    git apply /tmp/ib_registration_cache.patch && git apply /tmp/add-page-alignment.patch
+    curl -LO https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/add-page-alignment.patch
+    curl -LO https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/ib_registration_cache.patch
+    git apply ib_registration_cache.patch && git apply add-page-alignment.patch
     ./autogen.sh
     mkdir build
     cd build

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -106,7 +106,6 @@ To build UCX with IB/RDMA support, include the ``--with-rdmacm`` and ``--with-ve
     --prefix="$CONDA_PREFIX" \
     --with-cuda="$CUDA_HOME" \
     --enable-mt \
-    --with-cm \
     --with-rdmacm \
     --with-verbs \
     CPPFLAGS="-I/$CUDA_HOME/include"

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -124,11 +124,3 @@ UCX-Py
     pip install .
     # or for develop build
     pip install -v -e .
-
-
-##
-
-
-
-(ucx) bzaitlen@dgx12:/datasets/bzaitlen/GitRepos/ucx$ git apply /tmp/ib_registration_cache.patch
-(ucx) bzaitlen@dgx12:/datasets/bzaitlen/GitRepos/ucx$ git apply /tmp/add-page-alignment.patch

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -72,7 +72,8 @@ UCX
     git clone https://github.com/openucx/ucx
     cd ucx
     git checkout v1.8.x
-    # apply UCX IB registration patches
+    # apply UCX IB registration cache patches, improves overall
+    # IB performance when using a memory pool
     curl -LO https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/add-page-alignment.patch
     curl -LO https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/ib_registration_cache.patch
     git apply ib_registration_cache.patch && git apply add-page-alignment.patch


### PR DESCRIPTION
When https://github.com/rapidsai/ucx-split-feedstock/pull/40 is merged we should have docs on how to build UCX properly for IB/RDMA support