### PR TITLE
Further streamline `get_buffer_data`

### DIFF
--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -25,7 +25,7 @@ cpdef uintptr_t get_buffer_data(buffer, bint check_writable=False) except *:
     cdef uintptr_t data_ptr
     cdef bint data_readonly
     if iface is not None:
-        data_ptr, data_readonly = iface["data"]
+        data_ptr, data_readonly = <tuple>iface["data"]
     else:
         mview = PyMemoryView_FromObject(buffer)
         pybuf = PyMemoryView_GET_BUFFER(mview)

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -30,7 +30,7 @@ cpdef uintptr_t get_buffer_data(buffer, bint check_writable=False) except *:
         mview = PyMemoryView_FromObject(buffer)
         pybuf = PyMemoryView_GET_BUFFER(mview)
         data_ptr = <uintptr_t>pybuf.buf
-        data_readonly = pybuf.readonly
+        data_readonly = <bint>pybuf.readonly
 
     if data_ptr == 0:
         raise NotImplementedError("zero-sized buffers isn't supported")


### PR DESCRIPTION
Streamlines the C-code generated by Cython for `get_buffer_data` to avoid unnecessary code generation.

<hr>

A short benchmark can be seen below. Makes a small, but notable improvement to the `__cuda_array_interface__` case. The `memoryview` case is [unchanged from before]( https://github.com/rapidsai/ucx-py/pull/592#issuecomment-683166572 ). The previous benchmark with CuPy can be seen [here]( https://github.com/rapidsai/ucx-py/pull/546#issuecomment-673614364 ).

```python
In [1]: import cupy
   ...: import numpy
   ...: 
   ...: from ucp._libs.utils import get_buffer_data, get_buffer_nbytes

In [2]: s = (10, 11, 12, 13)
   ...: a_c = numpy.arange(numpy.prod(s)).reshape(s)
   ...: a_g = cupy.arange(numpy.prod(s)).reshape(s)

In [3]: %timeit get_buffer_data(a_c)
548 ns ± 4.85 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: %timeit get_buffer_data(a_g)
852 ns ± 4.39 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```