### PR TITLE
Add fence/flush/worker address APIs

### DIFF
--- a/tests/test_rma.py
+++ b/tests/test_rma.py
@@ -19,9 +19,11 @@ async def test_flush(blocking_progress_mode):
     await ucp.flush()
     ucp.reset()
 
+
 @pytest.mark.parametrize("blocking_progress_mode", [True, False])
 def test_worker_address(blocking_progress_mode):
     ucp.init(blocking_progress_mode=blocking_progress_mode)
 
     addr = ucp.get_worker_address()
+    assert addr is not None
     ucp.reset()

--- a/tests/test_rma.py
+++ b/tests/test_rma.py
@@ -1,0 +1,27 @@
+import pytest
+
+import ucp
+
+
+@pytest.mark.parametrize("blocking_progress_mode", [True, False])
+def test_fence(blocking_progress_mode):
+    ucp.init(blocking_progress_mode=blocking_progress_mode)
+#   this should always succeed
+    ucp.fence()
+    ucp.reset()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocking_progress_mode", [True, False])
+async def test_flush(blocking_progress_mode):
+    ucp.init(blocking_progress_mode=blocking_progress_mode)
+
+    await ucp.flush()
+    ucp.reset()
+
+@pytest.mark.parametrize("blocking_progress_mode", [True, False])
+def test_worker_address(blocking_progress_mode):
+    ucp.init(blocking_progress_mode=blocking_progress_mode)
+
+    addr = ucp.get_worker_address()
+    ucp.reset()

--- a/tests/test_rma.py
+++ b/tests/test_rma.py
@@ -1,6 +1,50 @@
+import numpy as np
 import pytest
+import asyncio
 
 import ucp
+
+
+def handle_exception(loop, context):
+    msg = context.get("exception", context["message"])
+    print(msg)
+
+
+# Let's make sure that UCX gets time to cancel
+# progress tasks before closing the event loop.
+@pytest.yield_fixture()
+def event_loop(scope="function"):
+    loop = asyncio.new_event_loop()
+    loop.set_exception_handler(handle_exception)
+    ucp.reset()
+    yield loop
+    ucp.reset()
+    loop.run_until_complete(asyncio.sleep(0))
+    loop.close()
+
+
+def make_echo_server(create_empty_data):
+    """
+    Returns an echo server that calls the function `create_empty_data(nbytes)`
+    to create the data container.`
+    """
+
+    async def echo_server(ep):
+        """
+        Basic echo server for sized messages.
+        We expect the other endpoint to follow the pattern::
+        # size of the real message (in bytes)
+        >>> await ep.send(msg_size, np.uint64().nbytes)
+        >>> await ep.send(msg, msg_size)       # send the real message
+        >>> await ep.recv(responds, msg_size)  # receive the echo
+        """
+        msg_size = np.empty(1, dtype=np.uint64)
+        await ep.recv(msg_size)
+        msg = create_empty_data(msg_size[0])
+        await ep.recv(msg)
+        await ep.send(msg)
+
+    return echo_server
 
 
 @pytest.mark.parametrize("blocking_progress_mode", [True, False])
@@ -27,3 +71,20 @@ def test_worker_address(blocking_progress_mode):
     addr = ucp.get_worker_address()
     assert addr is not None
     ucp.reset()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocking_progress_mode", [True, False])
+async def test_send_recv_addr(blocking_progress_mode):
+    ucp.init(blocking_progress_mode=blocking_progress_mode)
+
+    msg = ucp.get_worker_address()
+    msg_size = np.array([len(bytes(msg))], dtype=np.uint64)
+    listener = ucp.create_listener(make_echo_server(lambda n: bytearray(n)))
+    client = await ucp.create_endpoint(ucp.get_address("wlp7s0"), listener.port)
+
+    await client.send(msg_size)
+    await client.send(msg)
+    resp = bytearray(msg_size[0])
+    await client.recv(resp)
+    assert resp == bytes(msg)

--- a/tests/test_rma.py
+++ b/tests/test_rma.py
@@ -1,6 +1,7 @@
+import asyncio
+
 import numpy as np
 import pytest
-import asyncio
 
 import ucp
 

--- a/tests/test_rma.py
+++ b/tests/test_rma.py
@@ -81,7 +81,7 @@ async def test_send_recv_addr(blocking_progress_mode):
     msg = ucp.get_worker_address()
     msg_size = np.array([len(bytes(msg))], dtype=np.uint64)
     listener = ucp.create_listener(make_echo_server(lambda n: bytearray(n)))
-    client = await ucp.create_endpoint(ucp.get_address("wlp7s0"), listener.port)
+    client = await ucp.create_endpoint(ucp.get_address(), listener.port)
 
     await client.send(msg_size)
     await client.send(msg)

--- a/tests/test_rma.py
+++ b/tests/test_rma.py
@@ -6,7 +6,7 @@ import ucp
 @pytest.mark.parametrize("blocking_progress_mode", [True, False])
 def test_fence(blocking_progress_mode):
     ucp.init(blocking_progress_mode=blocking_progress_mode)
-#   this should always succeed
+    # this should always succeed
     ucp.fence()
     ucp.reset()
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -10,8 +10,8 @@ import weakref
 
 from posix.stdio cimport open_memstream
 
-from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
 from cpython.buffer cimport PyBUF_WRITABLE, PyBUF_ND, PyBUF_FORMAT
+from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
 from libc.stdint cimport uintptr_t
 from libc.stdio cimport FILE, fclose, fflush
 from libc.stdlib cimport free
@@ -460,8 +460,10 @@ cdef class UCXAddress(UCXObject):
         buffer.strides = NULL
         buffer.suboffsets = NULL
         buffer.internal = NULL
+
     def __releasebuffer__(self, Py_buffer *buffer):
         pass
+
 
 def _ucx_endpoint_finalizer(uintptr_t handle_as_int, worker, inflight_msgs):
     assert worker.initialized

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -424,7 +424,7 @@ cdef class UCXAddress(UCXObject):
 
     def __init__(self, UCXWorker worker):
         cdef ucs_status_t status
-        cdef ucp_worker_h ucp_worker = <ucp_worker_h><uintptr_t>worker.handle
+        cdef ucp_worker_h ucp_worker = worker._handle
         cdef size_t length
 
         status = ucp_worker_get_address(ucp_worker, &self._handle, &length)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -543,7 +543,11 @@ cdef class UCXEndpoint(UCXObject):
         assert self.initialized
         return int(<uintptr_t>self._handle)
 
-    def flush(self, cb_func, cb_args, cb_kwargs=dict()):
+    def flush(self, cb_func, cb_args=None, cb_kwargs=None):
+        if cb_args is None:
+            cb_args = ()
+        if cb_kwargs is None:
+            cb_kwargs = {}
         cdef ucs_status_ptr_t req
         cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -387,9 +387,8 @@ cdef class UCXWorker(UCXObject):
         assert_ucs_status(status)
         return UCXEndpoint(self, <uintptr_t>ucp_ep)
 
-    def fence(self):
-        cdef ucs_status_t status
-        status = ucp_worker_fence(self._handle)
+    cpdef ucs_status_t fence(self) except *:
+        cdef ucs_status_t status = ucp_worker_fence(self._handle)
         assert_ucs_status(status)
         return status
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -433,7 +433,7 @@ cdef class UCXAddress(UCXObject):
         self.add_handle_finalizer(
             _ucx_address_finalizer,
             int(<uintptr_t>self._handle),
-        worker
+            worker
         )
         worker.add_child(self)
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -406,9 +406,9 @@ cdef class UCXWorker(UCXObject):
         return UCXAddress(self)
 
 
-def _ucx_address_finalizer(uintptr_t handle_as_int, UCXWorker worker):
+def _ucx_address_finalizer(uintptr_t handle_as_int, uintptr_t worker_as_int):
     cdef ucp_address_t *address = <ucp_address_t *>handle_as_int
-    cdef ucp_worker_h ucp_worker = <ucp_worker_h><uintptr_t>worker.handle
+    cdef ucp_worker_h ucp_worker = <ucp_worker_h>worker_as_int
     ucp_worker_release_address(ucp_worker, address)
 
 
@@ -430,7 +430,7 @@ cdef class UCXAddress(UCXObject):
         self.add_handle_finalizer(
             _ucx_address_finalizer,
             int(<uintptr_t>self._handle),
-            worker
+            int(<uintptr_t>worker._handle)
         )
         worker.add_child(self)
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -433,7 +433,7 @@ cdef class UCXAddress(UCXObject):
         self.add_handle_finalizer(
             _ucx_address_finalizer,
             int(<uintptr_t>self._handle),
-	    worker
+        worker
         )
         worker.add_child(self)
 
@@ -523,7 +523,6 @@ cdef class UCXEndpoint(UCXObject):
         return _handle_status(
             status, 0, cb_func, cb_args, cb_kwargs, 'flush', self._inflight_msgs
         )
-
 
 
 cdef void _listener_callback(ucp_conn_request_h conn_request, void *args):

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -415,16 +415,18 @@ def _ucx_address_finalizer(uintptr_t handle_as_int, UCXWorker worker):
 cdef class UCXAddress(UCXObject):
     """Python representation of ucp_address_t"""
     cdef ucp_address_t *_handle
-    cdef size_t _length
+    cdef Py_ssize_t _length
     cdef worker
 
     def __init__(self, UCXWorker worker):
         cdef ucs_status_t status
         cdef ucp_worker_h ucp_worker = <ucp_worker_h><uintptr_t>worker.handle
+        cdef size_t length
 
-        status = ucp_worker_get_address(ucp_worker, &self._handle, &self._length)
+        status = ucp_worker_get_address(ucp_worker, &self._handle, &length)
         assert_ucs_status(status)
         self.worker = worker
+        self._length = <Py_ssize_t>length
         self.add_handle_finalizer(
             _ucx_address_finalizer,
             int(<uintptr_t>self._handle),
@@ -454,7 +456,7 @@ cdef class UCXAddress(UCXObject):
             buffer.format = NULL
         buffer.ndim = 1
         if (flags & PyBUF_ND) == PyBUF_ND:
-            buffer.shape = <Py_ssize_t *>&self._length
+            buffer.shape = &self._length
         else:
             buffer.shape = NULL
         buffer.strides = NULL

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -436,22 +436,25 @@ cdef class UCXAddress(UCXObject):
 
     @property
     def address(self):
+        assert self.initialized
         return <uintptr_t>self._handle
 
     @property
     def length(self):
+        assert self.initialized
         return int(self._length)
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
+        assert self.initialized
         if (flags & PyBUF_WRITABLE) == PyBUF_WRITABLE:
             raise BufferError("Requested writable view on readonly data")
         buffer.buf = <void*>self._handle
         buffer.obj = self
         buffer.len = self._length
         buffer.readonly = True
-        buffer.itemsize = self._length
+        buffer.itemsize = 1
         if (flags & PyBUF_FORMAT) == PyBUF_FORMAT:
-            buffer.format = b"p"
+            buffer.format = b"B"
         else:
             buffer.format = NULL
         buffer.ndim = 1

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -1,4 +1,5 @@
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020       UT-Battelle, LLC. All rights reserved.
 # See file LICENSE for terms.
 # cython: language_level=3
 
@@ -64,6 +65,9 @@ cdef extern from "ucp/api/ucp.h":
         pass
 
     ctypedef struct ucp_config_t:
+        pass
+
+    ctypedef struct ucp_address_t:
         pass
 
     ctypedef void(* ucp_request_init_callback_t)(void *request)
@@ -215,7 +219,18 @@ cdef extern from "ucp/api/ucp.h":
 
     ucs_status_t ucp_config_modify(ucp_config_t *config, const char *name,
                                    const char *value)
-
+    ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
+                                        ucp_address_t **address,
+                                        size_t *len)
+    void ucp_worker_release_address(ucp_worker_h worker,
+                                    ucp_address_t *address)
+    ucs_status_t ucp_worker_fence(ucp_worker_h worker)
+    ucs_status_ptr_t ucp_worker_flush_nb(ucp_worker_h worker,
+		                                 unsigned flags,
+		                                 ucp_send_callback_t cb)
+    ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep,
+                                     unsigned flags,
+                                     ucp_send_callback_t cb)
 
 cdef extern from "sys/epoll.h":
 

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -226,8 +226,8 @@ cdef extern from "ucp/api/ucp.h":
                                     ucp_address_t *address)
     ucs_status_t ucp_worker_fence(ucp_worker_h worker)
     ucs_status_ptr_t ucp_worker_flush_nb(ucp_worker_h worker,
-		                                 unsigned flags,
-		                                 ucp_send_callback_t cb)
+                                         unsigned flags,
+                                         ucp_send_callback_t cb)
     ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep,
                                      unsigned flags,
                                      ucp_send_callback_t cb)

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -85,13 +85,9 @@ def stream_recv(
     )
 
 
-def flush_worker(
-        worker: ucx_api.UCXWorker, event_loop=None
-) -> asyncio.Future:
+def flush_worker(worker: ucx_api.UCXWorker, event_loop=None) -> asyncio.Future:
     return _call_ucx_api(event_loop, worker.flush)
 
 
-def flush_ep(
-        ep: ucx_api.UCXEndpoint, event_loop=None
-) -> asyncio.Future:
+def flush_ep(ep: ucx_api.UCXEndpoint, event_loop=None) -> asyncio.Future:
     return _call_ucx_api(event_loop, ep.flush)

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -88,14 +88,10 @@ def stream_recv(
 def flush_worker(
         worker: ucx_api.UCXWorker, event_loop=None
 ) -> asyncio.Future:
-    return _call_ucx_api(
-        event_loop, worker.flush
-    )
+    return _call_ucx_api(event_loop, worker.flush)
 
 
 def flush_ep(
         ep: ucx_api.UCXEndpoint, event_loop=None
 ) -> asyncio.Future:
-    return _call_ucx_api(
-        event_loop, ep.flush
-    )
+    return _call_ucx_api(event_loop, ep.flush)

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020       UT-Battelle, LLC. All rights reserved.
 # See file LICENSE for terms.
 
 import asyncio
@@ -81,4 +82,20 @@ def stream_recv(
 
     return _call_ucx_api(
         event_loop, ucx_api.stream_recv_nb, ep, buffer, nbytes, name=name
+    )
+
+
+def flush_worker(
+        worker: ucx_api.UCXWorker, event_loop=None
+) -> asyncio.Future:
+    return _call_ucx_api(
+        event_loop, worker.flush
+    )
+
+
+def flush_ep(
+        ep: ucx_api.UCXEndpoint, event_loop=None
+) -> asyncio.Future:
+    return _call_ucx_api(
+        event_loop, ep.flush
     )

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -882,6 +882,7 @@ def get_ucp_worker():
 def get_worker_address():
     return _get_ctx().get_worker_address()
 
+
 async def flush():
     """Flushes outstanding AMO and RMA operations. This ensures that the
        operations issued on this worker have completed both locally and remotely.

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020       UT-Battelle, LLC. All rights reserved.
 # See file LICENSE for terms.
 
 import array
@@ -426,6 +427,15 @@ class ApplicationContext:
         """
         return self.context.get_config()
 
+    def fence(self):
+        return self.worker.fence()
+
+    async def flush(self):
+        return await comm.flush_worker(self.worker)
+
+    def get_worker_address(self):
+        return self.worker.get_address()
+
 
 class Listener:
     """A handle to the listening service started by `create_listener()`
@@ -735,6 +745,9 @@ class Endpoint:
         await self.recv(ret, nbytes=nbytes, tag=tag)
         return ret
 
+    async def flush(self):
+        return await comm.flush_ep(self)
+
 
 # The following functions initialize and use a single ApplicationContext instance
 
@@ -864,6 +877,30 @@ def continuous_ucx_progress(event_loop=None):
 
 def get_ucp_worker():
     return _get_ctx().get_ucp_worker()
+
+
+def get_worker_address():
+    return _get_ctx().get_worker_address()
+
+async def flush():
+    """Flushes outstanding AMO and RMA operations. This ensures that the
+       operations issued on this worker have completed both locally and remotely.
+       This function does not guarantee ordering.
+    """
+    if _ctx is not None:
+        return await _get_ctx().flush()
+    else:
+        # If ctx is not initialized we still want to do the right thing by asyncio
+        return await asyncio.sleep(0)
+
+
+def fence():
+    """Ensures ordering of non-blocking communication operations on the UCP worker.
+       This function returns nothing, but will raise an error if it cannot make
+       this guarantee. This function does not ensure any operations have completed.
+    """
+    if _ctx is not None:
+        _get_ctx().fence()
 
 
 # Setting the __doc__


### PR DESCRIPTION
First patch to upstream #551 in smaller chunks with a cleaned up API. This brings in all the foundational APIs for RMA short of the changes to end point creation, which a topic I expect to be more controversial than the pure addition changes and get some testing to make sure it doesn't break anything.

In this patch it exposes:

- ucp_worker_fence as ucp.fence()
- ucp_worker_flush_nb as ucp.flush()
- ucp_ep_flush_nb as ep.flush()
- ucp_worker_get_address() as ucp.get_worker_address()
- ucp_worker_release_address() as a destructor in the UCXAddress object


With thanks to @jglaser for bug fixing.