### PR TITLE
Implement `get_itemsize`

### DIFF
--- a/ucp/_libs/utils.pxd
+++ b/ucp/_libs/utils.pxd
@@ -7,5 +7,6 @@
 from libc.stdint cimport uintptr_t
 
 
+cpdef Py_ssize_t get_itemsize(str fmt) except *
 cpdef uintptr_t get_buffer_data(buffer, bint check_writable=*) except *
 cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) except *


### PR DESCRIPTION
This provides the function `get_itemsize` to fast path identification of the `itemsize` some common `typestr`s. Anything else that cannot be easily identified is passed off to NumPy for determination.

Before:

```python
In [1]: import cupy
   ...: import numpy
   ...: 
   ...: from ucp._libs.utils import get_buffer_nbytes

In [2]: s = (10, 11, 12, 13)
   ...: a_g = cupy.arange(numpy.prod(s)).reshape(s)

In [3]: %timeit get_buffer_nbytes(a_g, check_min_size=None, cuda_support=True)
1.28 µs ± 9.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

After:

```python
In [1]: import cupy
   ...: import numpy
   ...: 
   ...: from ucp._libs.utils import get_buffer_nbytes

In [2]: s = (10, 11, 12, 13)
   ...: a_g = cupy.arange(numpy.prod(s)).reshape(s)

In [3]: %timeit get_buffer_nbytes(a_g, check_min_size=None, cuda_support=True)
1 µs ± 6.44 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```