### PR TITLE
Simplify `get_buffer_nbytes` `min_size` check

### DIFF
--- a/tests/test_libs_utils.py
+++ b/tests/test_libs_utils.py
@@ -40,18 +40,16 @@ def test_get_buffer_data_builtins(buffer):
 @pytest.mark.parametrize("buffer", builtin_buffers)
 def test_get_buffer_nbytes_builtins(buffer):
     nbytes = memoryview(buffer).nbytes
-    result = get_buffer_nbytes(buffer, check_min_size=None, cuda_support=True)
+    result = get_buffer_nbytes(buffer, cuda_support=True)
     assert result == nbytes
 
     with pytest.raises(ValueError):
-        get_buffer_nbytes(
-            memoryview(buffer)[::2], check_min_size=None, cuda_support=True
-        )
+        get_buffer_nbytes(memoryview(buffer)[::2], cuda_support=True)
 
     # Test exceptional cases with `check_min_size`
-    get_buffer_nbytes(buffer, check_min_size=nbytes, cuda_support=True)
+    get_buffer_nbytes(buffer, min_size=nbytes, cuda_support=True)
     with pytest.raises(ValueError):
-        get_buffer_nbytes(buffer, check_min_size=(nbytes + 1), cuda_support=True)
+        get_buffer_nbytes(buffer, min_size=(nbytes + 1), cuda_support=True)
 
 
 array_params = [
@@ -94,8 +92,8 @@ def test_get_buffer_nbytes_array(xp, shape, dtype, strides):
     xp, arr, iface = create_array(xp, shape, dtype, strides)
 
     if arr.flags.c_contiguous:
-        nbytes = get_buffer_nbytes(arr, check_min_size=None, cuda_support=True)
+        nbytes = get_buffer_nbytes(arr, cuda_support=True)
         assert nbytes == arr.nbytes
     else:
         with pytest.raises(ValueError):
-            get_buffer_nbytes(arr, check_min_size=None, cuda_support=True)
+            get_buffer_nbytes(arr, cuda_support=True)

--- a/ucp/_libs/utils.pxd
+++ b/ucp/_libs/utils.pxd
@@ -8,4 +8,6 @@ from libc.stdint cimport uintptr_t
 
 
 cpdef uintptr_t get_buffer_data(buffer, bint check_writable=*) except *
-cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) except *
+cpdef Py_ssize_t get_buffer_nbytes(buffer,
+                                   Py_ssize_t min_size=*,
+                                   bint cuda_support=*) except *

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -47,7 +47,9 @@ cpdef uintptr_t get_buffer_data(buffer, bint check_writable=False) except *:
 
 @boundscheck(False)
 @wraparound(False)
-cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) except *:
+cpdef Py_ssize_t get_buffer_nbytes(buffer,
+                                   Py_ssize_t min_size=-1,
+                                   bint cuda_support=False) except *:
     """
     Returns the size of the buffer in bytes. Returns ValueError
     if `check_min_size` is greater than the size of the buffer
@@ -99,11 +101,7 @@ cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) ex
         if not PyBuffer_IsContiguous(pybuf, b"C"):
             raise ValueError("buffer must be C-contiguous")
 
-    cdef Py_ssize_t min_size
-    if check_min_size is not None:
-        min_size = check_min_size
-        if nbytes < min_size:
-            raise ValueError(
-                "the nbytes is greater than the size of the buffer!"
-            )
+    if min_size > 0 and nbytes < min_size:
+        raise ValueError("the nbytes is greater than the size of the buffer!")
+
     return nbytes

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -547,7 +547,7 @@ class Endpoint:
                 self.abort()
 
     @nvtx_annotate("UCXPY_SEND", color="green", domain="ucxpy")
-    async def send(self, buffer, nbytes=None, tag=None):
+    async def send(self, buffer, nbytes=-1, tag=None):
         """Send `buffer` to connected peer.
 
         Parameters
@@ -563,7 +563,7 @@ class Endpoint:
         if self.closed():
             raise UCXCloseError("Endpoint closed")
         nbytes = get_buffer_nbytes(
-            buffer, check_min_size=nbytes, cuda_support=self._cuda_support
+            buffer, min_size=nbytes, cuda_support=self._cuda_support
         )
         log = "[Send #%03d] ep: %s, tag: %s, nbytes: %d, type: %s" % (
             self._send_count,
@@ -583,7 +583,7 @@ class Endpoint:
         return await comm.tag_send(self._ep, buffer, nbytes, tag, name=log)
 
     @nvtx_annotate("UCXPY_RECV", color="red", domain="ucxpy")
-    async def recv(self, buffer, nbytes=None, tag=None):
+    async def recv(self, buffer, nbytes=-1, tag=None):
         """Receive from connected peer into `buffer`.
 
         Parameters
@@ -601,7 +601,7 @@ class Endpoint:
         if self.closed():
             raise UCXCloseError("Endpoint closed")
         nbytes = get_buffer_nbytes(
-            buffer, check_min_size=nbytes, cuda_support=self._cuda_support
+            buffer, min_size=nbytes, cuda_support=self._cuda_support
         )
         log = "[Recv #%03d] ep: %s, tag: %s, nbytes: %d, type: %s" % (
             self._recv_count,
@@ -694,12 +694,7 @@ class Endpoint:
         """
 
         nbytes = array.array(
-            "Q",
-            [
-                get_buffer_nbytes(
-                    buffer=obj, check_min_size=None, cuda_support=self._cuda_support
-                )
-            ],
+            "Q", [get_buffer_nbytes(buffer=obj, cuda_support=self._cuda_support)]
         )
         await self.send(nbytes, tag=tag)
         await self.send(obj, tag=tag)

--- a/ucp/endpoint_reuse.py
+++ b/ucp/endpoint_reuse.py
@@ -98,10 +98,10 @@ class EndpointReuse:
 
         return core.create_listener(_handle, port=port)
 
-    async def send(self, buffer, nbytes=None):
+    async def send(self, buffer, nbytes=-1):
         await self.handle.ep.send(buffer, nbytes=nbytes, tag=self.tag)
 
-    async def recv(self, buffer, nbytes=None):
+    async def recv(self, buffer, nbytes=-1):
         await self.handle.ep.recv(buffer, nbytes=nbytes, tag=self.tag)
 
     async def close(self):


### PR DESCRIPTION
Makes a few adjustments to `get_buffer_nbytes` signature. Namely replaces `check_min_size` with `min_size`, which is now typed as `Py_ssize_t`. If `min_size` is not positive definite, this is the same as skipping the checking. Also provides some reasonable default values to `min_size` and `cuda_support`.