### PR TITLE
Move `cuda_support` check into CUDA case

### DIFF
--- a/tests/test_libs_utils.py
+++ b/tests/test_libs_utils.py
@@ -93,6 +93,10 @@ def test_get_buffer_data_array(xp, shape, dtype, strides):
 def test_get_buffer_nbytes_array(xp, shape, dtype, strides):
     xp, arr, iface = create_array(xp, shape, dtype, strides)
 
+    if xp.__name__ == "cupy":
+        with pytest.raises(ValueError):
+            get_buffer_nbytes(arr, check_min_size=None, cuda_support=False)
+
     if arr.flags.c_contiguous:
         nbytes = get_buffer_nbytes(arr, check_min_size=None, cuda_support=True)
         assert nbytes == arr.nbytes

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -54,20 +54,20 @@ cpdef Py_ssize_t get_buffer_nbytes(buffer, check_min_size, bint cuda_support) ex
     """
 
     cdef dict iface = getattr(buffer, "__cuda_array_interface__", None)
-    if not cuda_support and iface is not None:
-        raise ValueError(
-            "UCX is not configured with CUDA support, please add "
-            "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment"
-            "variable and that the ucx-proc=*=gpu package is "
-            "installed. See "
-            "https://ucx-py.readthedocs.io/en/latest/install.html for "
-            "more information."
-        )
-
     cdef const Py_buffer* pybuf
     cdef tuple shape, strides
     cdef Py_ssize_t i, s, itemsize, ndim, nbytes
     if iface is not None:
+        if not cuda_support:
+            raise ValueError(
+                "UCX is not configured with CUDA support, please add "
+                "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment"
+                "variable and that the ucx-proc=*=gpu package is "
+                "installed. See "
+                "https://ucx-py.readthedocs.io/en/latest/install.html for "
+                "more information."
+            )
+
         import numpy
         itemsize = numpy.dtype(iface["typestr"]).itemsize
         # Making sure that the elements in shape is integers


### PR DESCRIPTION
As we already have a branch later for the CUDA case, defer checking whether `cuda_support` is `True` until we are within the CUDA case. This behaves the same while simplifying the code a bit.