### PR TITLE
Fix-up CI

### DIFF
--- a/tests/test_libs_utils.py
+++ b/tests/test_libs_utils.py
@@ -46,7 +46,7 @@ def test_get_buffer_nbytes_builtins(buffer):
     with pytest.raises(ValueError):
         get_buffer_nbytes(memoryview(buffer)[::2], cuda_support=True)
 
-    # Test exceptional cases with `check_min_size`
+    # Test exceptional cases with `min_size`
     get_buffer_nbytes(buffer, min_size=nbytes, cuda_support=True)
     with pytest.raises(ValueError):
         get_buffer_nbytes(buffer, min_size=(nbytes + 1), cuda_support=True)
@@ -93,7 +93,7 @@ def test_get_buffer_nbytes_array(xp, shape, dtype, strides):
 
     if xp.__name__ == "cupy":
         with pytest.raises(ValueError):
-            get_buffer_nbytes(arr, check_min_size=None, cuda_support=False)
+            get_buffer_nbytes(arr, cuda_support=False)
 
     if arr.flags.c_contiguous:
         nbytes = get_buffer_nbytes(arr, cuda_support=True)

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -51,8 +51,8 @@ cpdef Py_ssize_t get_buffer_nbytes(buffer,
                                    Py_ssize_t min_size=-1,
                                    bint cuda_support=False) except *:
     """
-    Returns the size of the buffer in bytes. Returns ValueError
-    if `check_min_size` is greater than the size of the buffer
+    Returns the size of the buffer in bytes. Raises `ValueError`
+    if `min_size` is greater than the size of the buffer
     """
 
     cdef dict iface = getattr(buffer, "__cuda_array_interface__", None)


### PR DESCRIPTION
Rename `check_min_size` to `min_size` anywhere it was missed. Also drop `min_size` when the default value is used.