### PR TITLE
Type variables in `assert_ucs_status`

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -54,8 +54,10 @@ cdef assert_ucs_status(ucs_status_t status, str msg_context=None):
     cdef str msg, ucs_status
     if status != UCS_OK:
         ucs_status = ucs_status_string(status).decode("utf-8")
-        msg = "[%s] " % msg_context if msg_context is not None else ""
-        msg += ucs_status
+        if msg_context is not None:
+            msg = "[%s] %s" % (msg_context, ucs_status)
+        else:
+            msg = ucs_status
         raise UCXError(msg)
 
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -50,7 +50,7 @@ cdef int _ucx_py_request_counter = 0
 logger = logging.getLogger("ucx")
 
 
-cdef assert_ucs_status(ucs_status_t status, msg_context=None):
+cdef assert_ucs_status(ucs_status_t status, str msg_context=None):
     if status != UCS_OK:
         msg = "[%s] " % msg_context if msg_context is not None else ""
         msg += ucs_status_string(status).decode("utf-8")

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -51,10 +51,11 @@ logger = logging.getLogger("ucx")
 
 
 cdef assert_ucs_status(ucs_status_t status, str msg_context=None):
-    cdef str msg
+    cdef str msg, ucs_status
     if status != UCS_OK:
+        ucs_status = ucs_status_string(status).decode("utf-8")
         msg = "[%s] " % msg_context if msg_context is not None else ""
-        msg += ucs_status_string(status).decode("utf-8")
+        msg += ucs_status
         raise UCXError(msg)
 
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -55,7 +55,7 @@ cdef assert_ucs_status(ucs_status_t status, str msg_context=None):
     if status != UCS_OK:
         ucs_status = ucs_status_string(status).decode("utf-8")
         if msg_context is not None:
-            msg = "[%s] %s" % (msg_context, ucs_status)
+            msg = f"[{msg_context}] {ucs_status}"
         else:
             msg = ucs_status
         raise UCXError(msg)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -51,6 +51,7 @@ logger = logging.getLogger("ucx")
 
 
 cdef assert_ucs_status(ucs_status_t status, str msg_context=None):
+    cdef str msg
     if status != UCS_OK:
         msg = "[%s] " % msg_context if msg_context is not None else ""
         msg += ucs_status_string(status).decode("utf-8")


### PR DESCRIPTION
Types variables in `assert_ucs_status` so that Cython can use more specific Python C API operations related to those objects (namely `str`s). Also use an [f-string]( https://docs.python.org/3.8/reference/lexical_analysis.html#formatted-string-literals ) to clarify message formatting.