### PR TITLE
Type variables in `_read_ucx_config`

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -76,6 +76,7 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
         )
 
     # Modify the UCX configuration options based on `config_dict`
+    cdef str k, v
     for k, v in user_options.items():
         status = ucp_config_modify(config, k.encode(), v.encode())
         if status == UCS_ERR_NO_ELEM:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -72,9 +72,7 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
     status = ucp_config_read(NULL, NULL, &config)
     if status != UCS_OK:
         status_msg = ucs_status_string(status).decode("utf-8")
-        raise UCXConfigError(
-            f"Couldn't read the UCX options: {status_msg}"
-        )
+        raise UCXConfigError(f"Couldn't read the UCX options: {status_msg}")
 
     # Modify the UCX configuration options based on `config_dict`
     cdef str k, v

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -84,8 +84,9 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
             raise UCXConfigError(f"Option {k} doesn't exist")
         elif status != UCS_OK:
             status_msg = ucs_status_string(status).decode("utf-8")
-            msg = f"Couldn't set option {k} to {v}: {status_msg}"
-            raise UCXConfigError(msg)
+            raise UCXConfigError(
+                f"Couldn't set option {k} to {v}: {status_msg}"
+            )
     return config
 
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -73,8 +73,7 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
     if status != UCS_OK:
         status_msg = ucs_status_string(status).decode("utf-8")
         raise UCXConfigError(
-            "Couldn't read the UCX options: %s" %
-            status_msg
+            "Couldn't read the UCX options: %s" % status_msg
         )
 
     # Modify the UCX configuration options based on `config_dict`
@@ -85,8 +84,7 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
             raise UCXConfigError("Option %s doesn't exist" % k)
         elif status != UCS_OK:
             status_msg = ucs_status_string(status).decode("utf-8")
-            msg = "Couldn't set option %s to %s: %s" % \
-                  (k, v, status_msg)
+            msg = "Couldn't set option %s to %s: %s" % (k, v, status_msg)
             raise UCXConfigError(msg)
     return config
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -68,11 +68,13 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
     """
     cdef ucp_config_t *config
     cdef ucs_status_t status
+    cdef str status_msg
     status = ucp_config_read(NULL, NULL, &config)
     if status != UCS_OK:
+        status_msg = ucs_status_string(status).decode("utf-8")
         raise UCXConfigError(
             "Couldn't read the UCX options: %s" %
-            ucs_status_string(status).decode("utf-8")
+            status_msg
         )
 
     # Modify the UCX configuration options based on `config_dict`
@@ -82,8 +84,9 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
         if status == UCS_ERR_NO_ELEM:
             raise UCXConfigError("Option %s doesn't exist" % k)
         elif status != UCS_OK:
+            status_msg = ucs_status_string(status).decode("utf-8")
             msg = "Couldn't set option %s to %s: %s" % \
-                  (k, v, ucs_status_string(status).decode("utf-8"))
+                  (k, v, status_msg)
             raise UCXConfigError(msg)
     return config
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -73,7 +73,7 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
     if status != UCS_OK:
         status_msg = ucs_status_string(status).decode("utf-8")
         raise UCXConfigError(
-            "Couldn't read the UCX options: %s" % status_msg
+            f"Couldn't read the UCX options: {status_msg}"
         )
 
     # Modify the UCX configuration options based on `config_dict`
@@ -81,10 +81,10 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
     for k, v in user_options.items():
         status = ucp_config_modify(config, k.encode(), v.encode())
         if status == UCS_ERR_NO_ELEM:
-            raise UCXConfigError("Option %s doesn't exist" % k)
+            raise UCXConfigError(f"Option {k} doesn't exist")
         elif status != UCS_OK:
             status_msg = ucs_status_string(status).decode("utf-8")
-            msg = "Couldn't set option %s to %s: %s" % (k, v, status_msg)
+            msg = f"Couldn't set option {k} to {v}: {status_msg}"
             raise UCXConfigError(msg)
     return config
 


### PR DESCRIPTION
Types variables in `_read_ucx_config` so that Cython can use more specific Python C API operations related to those objects (namely `str`s). Also uses f-strings to clarify message formatting.