### PR TITLE
Cleanup `ucx_config_to_dict`

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -101,8 +101,8 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
         raise IOError("open_memstream() returned NULL")
     cdef dict ret = {}
     ucp_config_print(config, text_fd, NULL, UCS_CONFIG_PRINT_CONFIG)
-    fflush(text_fd)
     try:
+        fflush(text_fd)
         py_text = text.decode()
         for line in py_text.splitlines():
             k, v = line.split("=")

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -95,7 +95,7 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
     """Returns a dict of a UCX config"""
     cdef char *text
     cdef size_t text_len
-    cdef unicode py_text
+    cdef unicode py_text, line
     cdef FILE *text_fd = open_memstream(&text, &text_len)
     if text_fd == NULL:
         raise IOError("open_memstream() returned NULL")

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -102,7 +102,8 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
     cdef dict ret = {}
     ucp_config_print(config, text_fd, NULL, UCS_CONFIG_PRINT_CONFIG)
     try:
-        fflush(text_fd)
+        if fflush(text_fd) != 0:
+            raise IOError("fflush() failed on memory stream")
         py_text = text.decode()
         for line in py_text.splitlines():
             k, v = line.split("=")

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -11,7 +11,7 @@ from posix.stdio cimport open_memstream
 
 from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
 from libc.stdint cimport uintptr_t
-from libc.stdio cimport FILE, fclose, fflush
+from libc.stdio cimport FILE, clearerr, fclose, fflush
 from libc.stdlib cimport free
 from libc.string cimport memset
 
@@ -103,6 +103,7 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
     ucp_config_print(config, text_fd, NULL, UCS_CONFIG_PRINT_CONFIG)
     try:
         if fflush(text_fd) != 0:
+            clearerr(text_fd)
             raise IOError("fflush() failed on memory stream")
         py_text = text.decode()
         for line in py_text.splitlines():

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -97,7 +97,7 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
     cdef size_t text_len
     cdef unicode py_text
     cdef FILE *text_fd = open_memstream(&text, &text_len)
-    if(text_fd == NULL):
+    if text_fd == NULL:
         raise IOError("open_memstream() returned NULL")
     cdef dict ret = {}
     ucp_config_print(config, text_fd, NULL, UCS_CONFIG_PRINT_CONFIG)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -111,8 +111,11 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
             k = k[4:]  # Strip "UCX_" prefix
             ret[k] = v
     finally:
-        fclose(text_fd)
-        free(text)
+        if fclose(text_fd) != 0:
+            free(text)
+            raise IOError("fclose() failed to close memory stream")
+        else:
+            free(text)
     return ret
 
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -108,7 +108,7 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
         py_text = text.decode()
         for line in py_text.splitlines():
             k, v = line.split("=")
-            k = k[len("UCX_"):]
+            k = k[4:]  # Strip "UCX_" prefix
             ret[k] = v
     finally:
         fclose(text_fd)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -95,7 +95,7 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
     """Returns a dict of a UCX config"""
     cdef char *text
     cdef size_t text_len
-    cdef unicode py_text, line
+    cdef unicode py_text, line, k, v
     cdef FILE *text_fd = open_memstream(&text, &text_len)
     if text_fd == NULL:
         raise IOError("open_memstream() returned NULL")


### PR DESCRIPTION
* Drop unneeded parentheses from `if` statement
* Type `line`, which was not typed before
* Type `k` and `v`, which were not typed before
* Handle an error from `fflush` if raised
* Simplify slicing of `k`
* Handle an error from `fclose` if raised