### PR TITLE
Cleanup `UCXEndpoint.info`

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -457,7 +457,7 @@ cdef class UCXEndpoint(UCXObject):
         cdef size_t text_len
         cdef unicode py_text
         cdef FILE *text_fd = open_memstream(&text, &text_len)
-        if(text_fd == NULL):
+        if text_fd == NULL:
             raise IOError("open_memstream() returned NULL")
         ucp_ep_print_info(self._handle, text_fd)
         fflush(text_fd)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -461,7 +461,8 @@ cdef class UCXEndpoint(UCXObject):
             raise IOError("open_memstream() returned NULL")
         ucp_ep_print_info(self._handle, text_fd)
         try:
-            fflush(text_fd)
+            if fflush(text_fd) != 0:
+                raise IOError("fflush() failed on memory stream")
             py_text = text.decode()
         finally:
             fclose(text_fd)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -11,7 +11,7 @@ from posix.stdio cimport open_memstream
 
 from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
 from libc.stdint cimport uintptr_t
-from libc.stdio cimport FILE, fclose, fflush
+from libc.stdio cimport FILE, clearerr, fclose, fflush
 from libc.stdlib cimport free
 from libc.string cimport memset
 
@@ -462,6 +462,7 @@ cdef class UCXEndpoint(UCXObject):
         ucp_ep_print_info(self._handle, text_fd)
         try:
             if fflush(text_fd) != 0:
+                clearerr(text_fd)
                 raise IOError("fflush() failed on memory stream")
             py_text = text.decode()
         finally:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -460,8 +460,8 @@ cdef class UCXEndpoint(UCXObject):
         if text_fd == NULL:
             raise IOError("open_memstream() returned NULL")
         ucp_ep_print_info(self._handle, text_fd)
-        fflush(text_fd)
         try:
+            fflush(text_fd)
             py_text = text.decode()
         finally:
             fclose(text_fd)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -466,8 +466,11 @@ cdef class UCXEndpoint(UCXObject):
                 raise IOError("fflush() failed on memory stream")
             py_text = text.decode()
         finally:
-            fclose(text_fd)
-            free(text)
+            if fclose(text_fd) != 0:
+                free(text)
+                raise IOError("fclose() failed to close memory stream")
+            else:
+                free(text)
         return py_text
 
     @property


### PR DESCRIPTION
* Drop unneeded parentheses from `if` statement
* Handle an error from `fflush` if raised
* Handle an error from `fclose` if raised