### PR TITLE
Release `config` on error

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -128,14 +128,12 @@ def get_current_options():
     Returns the current UCX options
     if UCX were to be initialized now.
     """
-    cdef dict ret
     cdef ucp_config_t *config
     config = _read_ucx_config({})
     try:
-        ret = ucx_config_to_dict(config)
+        return ucx_config_to_dict(config)
     finally:
         ucp_config_release(config)
-    return ret
 
 
 def get_ucx_version():

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -131,8 +131,10 @@ def get_current_options():
     cdef dict ret
     cdef ucp_config_t *config
     config = _read_ucx_config({})
-    ret = ucx_config_to_dict(config)
-    ucp_config_release(config)
+    try:
+        ret = ucx_config_to_dict(config)
+    finally:
+        ucp_config_release(config)
     return ret
 
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -233,14 +233,13 @@ cdef class UCXContext(UCXObject):
         cdef ucp_config_t *config = _read_ucx_config(config_dict)
         status = ucp_init(&ucp_params, config, &self._handle)
         assert_ucs_status(status)
+        self._config = ucx_config_to_dict(config)
+        ucp_config_release(config)
 
         self.add_handle_finalizer(
             _ucx_context_handle_finalizer,
             int(<uintptr_t>self._handle)
         )
-
-        self._config = ucx_config_to_dict(config)
-        ucp_config_release(config)
 
         logger.info("UCP initiated using config: ")
         cdef str k, v

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -231,10 +231,12 @@ cdef class UCXContext(UCXObject):
         )
 
         cdef ucp_config_t *config = _read_ucx_config(config_dict)
-        status = ucp_init(&ucp_params, config, &self._handle)
-        assert_ucs_status(status)
-        self._config = ucx_config_to_dict(config)
-        ucp_config_release(config)
+        try:
+            status = ucp_init(&ucp_params, config, &self._handle)
+            assert_ucs_status(status)
+            self._config = ucx_config_to_dict(config)
+        finally:
+            ucp_config_release(config)
 
         self.add_handle_finalizer(
             _ucx_context_handle_finalizer,

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -128,8 +128,8 @@ def get_current_options():
     Returns the current UCX options
     if UCX were to be initialized now.
     """
-    cdef ucp_config_t *config
     cdef dict ret
+    cdef ucp_config_t *config
     config = _read_ucx_config({})
     ret = ucx_config_to_dict(config)
     ucp_config_release(config)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -128,8 +128,10 @@ def get_current_options():
     Returns the current UCX options
     if UCX were to be initialized now.
     """
-    cdef ucp_config_t *config = _read_ucx_config({})
-    cdef dict ret = ucx_config_to_dict(config)
+    cdef ucp_config_t *config
+    cdef dict ret
+    config = _read_ucx_config({})
+    ret = ucx_config_to_dict(config)
     ucp_config_release(config)
     return ret
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -77,17 +77,21 @@ cdef ucp_config_t * _read_ucx_config(dict user_options) except *:
     # Modify the UCX configuration options based on `config_dict`
     cdef str k, v
     cdef bytes kb, vb
-    for k, v in user_options.items():
-        kb = k.encode()
-        vb = v.encode()
-        status = ucp_config_modify(config, <const char*>kb, <const char*>vb)
-        if status == UCS_ERR_NO_ELEM:
-            raise UCXConfigError(f"Option {k} doesn't exist")
-        elif status != UCS_OK:
-            status_msg = ucs_status_string(status).decode("utf-8")
-            raise UCXConfigError(
-                f"Couldn't set option {k} to {v}: {status_msg}"
-            )
+    try:
+        for k, v in user_options.items():
+            kb = k.encode()
+            vb = v.encode()
+            status = ucp_config_modify(config, <const char*>kb, <const char*>vb)
+            if status == UCS_ERR_NO_ELEM:
+                raise UCXConfigError(f"Option {k} doesn't exist")
+            elif status != UCS_OK:
+                status_msg = ucs_status_string(status).decode("utf-8")
+                raise UCXConfigError(
+                    f"Couldn't set option {k} to {v}: {status_msg}"
+                )
+    except Exception:
+        ucp_config_release(config)
+        raise
     return config
 
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -128,8 +128,7 @@ def get_current_options():
     Returns the current UCX options
     if UCX were to be initialized now.
     """
-    cdef ucp_config_t *config
-    config = _read_ucx_config({})
+    cdef ucp_config_t *config = _read_ucx_config({})
     try:
         return ucx_config_to_dict(config)
     finally:


### PR DESCRIPTION
As we are responsible for cleaning up the `config` object when we are done with it, make sure that we clean it up ourselves when an exception occurs as no one else will have the opportunity to do so then.