### PR TITLE
Type `send`, `recv` arguments and `port`

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -682,6 +682,8 @@ cdef UCXRequest _handle_status(
 cdef void _send_callback(void *request, ucs_status_t status):
     cdef UCXRequest req
     cdef str msg
+    cdef tuple cb_args
+    cdef dict cb_kwargs
     with log_errors():
         req = UCXRequest(<uintptr_t><void*> request)
         req.info["status"] = "finished"
@@ -703,9 +705,11 @@ cdef void _send_callback(void *request, ucs_status_t status):
             cb_func = req.info["cb_func"]
             if cb_func is not None:
                 cb_args = req.info["cb_args"]
-                cb_args = cb_args if cb_args else tuple()
+                if cb_args is None:
+                    cb_args = ()
                 cb_kwargs = req.info["cb_kwargs"]
-                cb_kwargs = cb_kwargs if cb_kwargs else dict()
+                if cb_kwargs is None:
+                    cb_kwargs = {}
                 cb_func(req, exception, *cb_args, **cb_kwargs)
         finally:
             req.close()
@@ -783,6 +787,8 @@ cdef void _tag_recv_callback(
 ):
     cdef UCXRequest req
     cdef str msg
+    cdef tuple cb_args
+    cdef dict cb_kwargs
     with log_errors():
         req = UCXRequest(<uintptr_t><void*> request)
         req.info["status"] = "finished"
@@ -809,9 +815,11 @@ cdef void _tag_recv_callback(
             cb_func = req.info["cb_func"]
             if cb_func is not None:
                 cb_args = req.info["cb_args"]
-                cb_args = cb_args if cb_args else tuple()
+                if cb_args is None:
+                    cb_args = ()
                 cb_kwargs = req.info["cb_kwargs"]
-                cb_kwargs = cb_kwargs if cb_kwargs else dict()
+                if cb_kwargs is None:
+                    cb_kwargs = {}
                 cb_func(req, exception, *cb_args, **cb_kwargs)
         finally:
             req.close()
@@ -966,6 +974,8 @@ cdef void _stream_recv_callback(
 ):
     cdef UCXRequest req
     cdef str msg
+    cdef tuple cb_args
+    cdef dict cb_kwargs
     with log_errors():
         req = UCXRequest(<uintptr_t><void*> request)
         req.info["status"] = "finished"
@@ -992,9 +1002,11 @@ cdef void _stream_recv_callback(
             cb_func = req.info["cb_func"]
             if cb_func is not None:
                 cb_args = req.info["cb_args"]
-                cb_args = cb_args if cb_args else tuple()
+                if cb_args is None:
+                    cb_args = ()
                 cb_kwargs = req.info["cb_kwargs"]
-                cb_kwargs = cb_kwargs if cb_kwargs else dict()
+                if cb_kwargs is None:
+                    cb_kwargs = {}
                 cb_func(req, exception, *cb_args, **cb_kwargs)
         finally:
             req.close()

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -524,9 +524,9 @@ cdef class UCXListener(UCXObject):
         dict cb_kwargs=None
     ):
         if cb_args is None:
-            cb_args = tuple()
+            cb_args = ()
         if cb_kwargs is None:
-            cb_kwargs = dict()
+            cb_kwargs = {}
         cdef ucp_listener_params_t params
         cdef ucp_listener_conn_callback_t _listener_cb = (
             <ucp_listener_conn_callback_t>_listener_callback
@@ -759,9 +759,9 @@ def tag_send_nb(
         Descriptive name of the operation
     """
     if cb_args is None:
-        cb_args = tuple()
+        cb_args = ()
     if cb_kwargs is None:
-        cb_kwargs = dict()
+        cb_kwargs = {}
     if name is None:
         name = "tag_send_nb"
     cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
@@ -873,9 +873,9 @@ def tag_recv_nb(
         when the `worker` closes.
     """
     if cb_args is None:
-        cb_args = tuple()
+        cb_args = ()
     if cb_kwargs is None:
-        cb_kwargs = dict()
+        cb_kwargs = {}
     if name is None:
         name = "tag_recv_nb"
     if buffer.readonly:
@@ -942,9 +942,9 @@ def stream_send_nb(
         Descriptive name of the operation
     """
     if cb_args is None:
-        cb_args = tuple()
+        cb_args = ()
     if cb_kwargs is None:
-        cb_kwargs = dict()
+        cb_kwargs = {}
     if name is None:
         name = "stream_send_nb"
     cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
@@ -1038,9 +1038,9 @@ def stream_recv_nb(
         Descriptive name of the operation
     """
     if cb_args is None:
-        cb_args = tuple()
+        cb_args = ()
     if cb_kwargs is None:
-        cb_kwargs = dict()
+        cb_kwargs = {}
     if name is None:
         name = "stream_recv_nb"
     if buffer.readonly:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -520,9 +520,13 @@ cdef class UCXListener(UCXObject):
         UCXWorker worker,
         uint16_t port,
         cb_func,
-        tuple cb_args=tuple(),
-        dict cb_kwargs=dict()
+        tuple cb_args=None,
+        dict cb_kwargs=None
     ):
+        if cb_args is None:
+            cb_args = tuple()
+        if cb_kwargs is None:
+            cb_kwargs = dict()
         cdef ucp_listener_params_t params
         cdef ucp_listener_conn_callback_t _listener_cb = (
             <ucp_listener_conn_callback_t>_listener_callback
@@ -713,9 +717,9 @@ def tag_send_nb(
     size_t nbytes,
     ucp_tag_t tag,
     cb_func,
-    tuple cb_args=tuple(),
-    dict cb_kwargs=dict(),
-    str name="tag_send_nb"
+    tuple cb_args=None,
+    dict cb_kwargs=None,
+    str name=None
 ):
     """ This routine sends a message to a destination endpoint
 
@@ -754,6 +758,12 @@ def tag_send_nb(
     name: str, optional
         Descriptive name of the operation
     """
+    if cb_args is None:
+        cb_args = tuple()
+    if cb_kwargs is None:
+        cb_kwargs = dict()
+    if name is None:
+        name = "tag_send_nb"
     cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
     cdef ucs_status_ptr_t status = ucp_tag_send_nb(
         ep._handle,
@@ -814,9 +824,9 @@ def tag_recv_nb(
     ucp_tag_t tag,
     cb_func,
     ucp_tag_t tag_mask=-1,
-    tuple cb_args=tuple(),
-    dict cb_kwargs=dict(),
-    str name="tag_recv_nb",
+    tuple cb_args=None,
+    dict cb_kwargs=None,
+    str name=None,
     UCXEndpoint ep=None
 ):
     """ This routine receives a message on a worker
@@ -862,6 +872,12 @@ def tag_recv_nb(
         guarantee that the message is cancelled when `ep` closes as opposed to
         when the `worker` closes.
     """
+    if cb_args is None:
+        cb_args = tuple()
+    if cb_kwargs is None:
+        cb_kwargs = dict()
+    if name is None:
+        name = "tag_recv_nb"
     if buffer.readonly:
         raise ValueError("writing to readonly buffer!")
     cdef ucp_tag_recv_callback_t _tag_recv_cb = (
@@ -887,9 +903,9 @@ def stream_send_nb(
     Array buffer,
     size_t nbytes,
     cb_func,
-    tuple cb_args=tuple(),
-    dict cb_kwargs=dict(),
-    str name="stream_send_nb"
+    tuple cb_args=None,
+    dict cb_kwargs=None,
+    str name=None
 ):
     """ This routine sends data to a destination endpoint
 
@@ -925,6 +941,12 @@ def stream_send_nb(
     name: str, optional
         Descriptive name of the operation
     """
+    if cb_args is None:
+        cb_args = tuple()
+    if cb_kwargs is None:
+        cb_kwargs = dict()
+    if name is None:
+        name = "stream_send_nb"
     cdef ucp_send_callback_t _send_cb = <ucp_send_callback_t>_send_callback
     cdef ucs_status_ptr_t status = ucp_stream_send_nb(
         ep._handle,
@@ -983,9 +1005,9 @@ def stream_recv_nb(
     Array buffer,
     size_t nbytes,
     cb_func,
-    tuple cb_args=tuple(),
-    dict cb_kwargs=dict(),
-    str name="stream_recv_nb"
+    tuple cb_args=None,
+    dict cb_kwargs=None,
+    str name=None
 ):
     """ This routine receives data on the endpoint.
 
@@ -1015,6 +1037,12 @@ def stream_recv_nb(
     name: str, optional
         Descriptive name of the operation
     """
+    if cb_args is None:
+        cb_args = tuple()
+    if cb_kwargs is None:
+        cb_kwargs = dict()
+    if name is None:
+        name = "stream_recv_nb"
     if buffer.readonly:
         raise ValueError("writing to readonly buffer!")
     cdef size_t length

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -520,8 +520,8 @@ cdef class UCXListener(UCXObject):
         UCXWorker worker,
         uint16_t port,
         cb_func,
-        cb_args=tuple(),
-        cb_kwargs=dict()
+        tuple cb_args=tuple(),
+        dict cb_kwargs=dict()
     ):
         cdef ucp_listener_params_t params
         cdef ucp_listener_conn_callback_t _listener_cb = (
@@ -713,8 +713,8 @@ def tag_send_nb(
     size_t nbytes,
     ucp_tag_t tag,
     cb_func,
-    cb_args=tuple(),
-    cb_kwargs=dict(),
+    tuple cb_args=tuple(),
+    dict cb_kwargs=dict(),
     name="tag_send_nb"
 ):
     """ This routine sends a message to a destination endpoint
@@ -814,8 +814,8 @@ def tag_recv_nb(
     ucp_tag_t tag,
     cb_func,
     ucp_tag_t tag_mask=-1,
-    cb_args=tuple(),
-    cb_kwargs=dict(),
+    tuple cb_args=tuple(),
+    dict cb_kwargs=dict(),
     name="tag_recv_nb",
     UCXEndpoint ep=None
 ):
@@ -887,8 +887,8 @@ def stream_send_nb(
     Array buffer,
     size_t nbytes,
     cb_func,
-    cb_args=tuple(),
-    cb_kwargs=dict(),
+    tuple cb_args=tuple(),
+    dict cb_kwargs=dict(),
     name="stream_send_nb"
 ):
     """ This routine sends data to a destination endpoint
@@ -983,8 +983,8 @@ def stream_recv_nb(
     Array buffer,
     size_t nbytes,
     cb_func,
-    cb_args=tuple(),
-    cb_kwargs=dict(),
+    tuple cb_args=tuple(),
+    dict cb_kwargs=dict(),
     name="stream_recv_nb"
 ):
     """ This routine receives data on the endpoint.

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -10,7 +10,7 @@ import weakref
 from posix.stdio cimport open_memstream
 
 from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
-from libc.stdint cimport uintptr_t
+from libc.stdint cimport uint16_t, uintptr_t
 from libc.stdio cimport FILE, clearerr, fclose, fflush
 from libc.stdlib cimport free
 from libc.string cimport memset
@@ -376,7 +376,7 @@ cdef class UCXWorker(UCXObject):
         # which will handle the request cleanup.
         ucp_request_cancel(self._handle, req._handle)
 
-    def ep_create(self, str ip_address, port, bint endpoint_error_handling):
+    def ep_create(self, str ip_address, uint16_t port, bint endpoint_error_handling):
         assert self.initialized
         cdef ucp_ep_params_t params
         ip_address = socket.gethostbyname(ip_address)
@@ -513,12 +513,12 @@ cdef class UCXListener(UCXObject):
         dict cb_data
 
     cdef public:
-        int port
+        uint16_t port
 
     def __init__(
         self,
         UCXWorker worker,
-        port,
+        uint16_t port,
         cb_func,
         cb_args=tuple(),
         cb_kwargs=dict()

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -715,7 +715,7 @@ def tag_send_nb(
     cb_func,
     tuple cb_args=tuple(),
     dict cb_kwargs=dict(),
-    name="tag_send_nb"
+    str name="tag_send_nb"
 ):
     """ This routine sends a message to a destination endpoint
 
@@ -816,7 +816,7 @@ def tag_recv_nb(
     ucp_tag_t tag_mask=-1,
     tuple cb_args=tuple(),
     dict cb_kwargs=dict(),
-    name="tag_recv_nb",
+    str name="tag_recv_nb",
     UCXEndpoint ep=None
 ):
     """ This routine receives a message on a worker
@@ -889,7 +889,7 @@ def stream_send_nb(
     cb_func,
     tuple cb_args=tuple(),
     dict cb_kwargs=dict(),
-    name="stream_send_nb"
+    str name="stream_send_nb"
 ):
     """ This routine sends data to a destination endpoint
 
@@ -985,7 +985,7 @@ def stream_recv_nb(
     cb_func,
     tuple cb_args=tuple(),
     dict cb_kwargs=dict(),
-    name="stream_recv_nb"
+    str name="stream_recv_nb"
 ):
     """ This routine receives data on the endpoint.
 


### PR DESCRIPTION
* Type `cb_args` and `cb_kwargs` as `tuple` and `dict` respectively
* Type `name` as `str`
* Fix `port` typing to `uint16_t` as UCX and hwloc type it
* Use `None` for default arguments