### PR TITLE
Type `UCXRequest` `info` as `dict` when used

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -289,10 +289,12 @@ def _ucx_worker_handle_finalizer(
 
     # Cancel all inflight messages
     cdef UCXRequest req
+    cdef dict req_info
     cdef str name
     for req in list(inflight_msgs):
         assert not req.closed()
-        name = req.info["name"]
+        req_info = req.info
+        name = req_info["name"]
         logger.debug("Future cancelling: %s" % name)
         ucp_request_cancel(handle, <void*><uintptr_t>req.handle)
 
@@ -424,9 +426,11 @@ def _ucx_endpoint_finalizer(uintptr_t handle_as_int, worker, set inflight_msgs):
 
     # Cancel all inflight messages
     cdef UCXRequest req
+    cdef dict req_info
     cdef str name
     for req in list(inflight_msgs):
-        name = req.info["name"]
+        req_info = req.info
+        name = req_info["name"]
         logger.debug("Future cancelling: %s" % name)
         # Notice, `request_cancel()` evoke the send/recv callback functions
         worker.request_cancel(req)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -688,7 +688,7 @@ cdef UCXRequest _handle_status(
 cdef void _send_callback(void *request, ucs_status_t status):
     cdef UCXRequest req
     cdef dict req_info
-    cdef str name, msg
+    cdef str name, ucx_status_msg, msg
     cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
@@ -706,7 +706,8 @@ cdef void _send_callback(void *request, ucs_status_t status):
         if status == UCS_ERR_CANCELED:
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
-            msg += ucs_status_string(status).decode("utf-8")
+            ucx_status_msg = ucs_status_string(status).decode("utf-8")
+            msg += ucx_status_msg
             exception = UCXError(msg)
         else:
             exception = None
@@ -798,7 +799,7 @@ cdef void _tag_recv_callback(
 ):
     cdef UCXRequest req
     cdef dict req_info
-    cdef str name, msg
+    cdef str name, ucx_status_msg, msg
     cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
@@ -816,7 +817,8 @@ cdef void _tag_recv_callback(
         if status == UCS_ERR_CANCELED:
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
-            msg += ucs_status_string(status).decode("utf-8")
+            ucx_status_msg = ucs_status_string(status).decode("utf-8")
+            msg += ucx_status_msg
             exception = UCXError(msg)
         elif info.length != req_info["expected_receive"]:
             msg += "length mismatch: %d (got) != %d (expected)" % (
@@ -992,7 +994,7 @@ cdef void _stream_recv_callback(
 ):
     cdef UCXRequest req
     cdef dict req_info
-    cdef str name, msg
+    cdef str name, ucx_status_msg, msg
     cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
@@ -1010,7 +1012,8 @@ cdef void _stream_recv_callback(
         if status == UCS_ERR_CANCELED:
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
-            msg += ucs_status_string(status).decode("utf-8")
+            ucx_status_msg = ucs_status_string(status).decode("utf-8")
+            msg += ucx_status_msg
             exception = UCXError(msg)
         elif length != req_info["expected_receive"]:
             msg += "length mismatch: %d (got) != %d (expected)" % (

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -701,6 +701,7 @@ cdef void _send_callback(void *request, ucs_status_t status):
             # This callback function was called before ucp_tag_send_nb() returned
             return
 
+        exception = None
         if status == UCS_ERR_CANCELED:
             name = req_info["name"]
             msg = "<%s>: " % name
@@ -710,8 +711,6 @@ cdef void _send_callback(void *request, ucs_status_t status):
             ucx_status_msg = ucs_status_string(status).decode("utf-8")
             msg = "<%s>: %s" % (name, ucx_status_msg)
             exception = UCXError(msg)
-        else:
-            exception = None
         try:
             inflight_msgs = req_info["inflight_msgs"]
             inflight_msgs.discard(req)
@@ -813,6 +812,7 @@ cdef void _tag_recv_callback(
             # This callback function was called before ucp_tag_recv_nb() returned
             return
 
+        exception = None
         if status == UCS_ERR_CANCELED:
             name = req_info["name"]
             msg = "<%s>: " % name
@@ -828,8 +828,6 @@ cdef void _tag_recv_callback(
                 name, info.length, req_info["expected_receive"]
             )
             exception = UCXMsgTruncated(msg)
-        else:
-            exception = None
         try:
             inflight_msgs = req_info["inflight_msgs"]
             inflight_msgs.discard(req)
@@ -1010,6 +1008,7 @@ cdef void _stream_recv_callback(
             # This callback function was called before ucp_tag_recv_nb() returned
             return
 
+        exception = None
         if status == UCS_ERR_CANCELED:
             name = req_info["name"]
             msg = "<%s>: " % name
@@ -1025,8 +1024,6 @@ cdef void _stream_recv_callback(
                 name, length, req_info["expected_receive"]
             )
             exception = UCXMsgTruncated(msg)
-        else:
-            exception = None
         try:
             inflight_msgs = req_info["inflight_msgs"]
             inflight_msgs.discard(req)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -685,6 +685,7 @@ cdef void _send_callback(void *request, ucs_status_t status):
     cdef UCXRequest req
     cdef dict req_info
     cdef str msg
+    cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
     with log_errors():
@@ -705,7 +706,8 @@ cdef void _send_callback(void *request, ucs_status_t status):
         else:
             exception = None
         try:
-            req_info["inflight_msgs"].discard(req)
+            inflight_msgs = req_info["inflight_msgs"]
+            inflight_msgs.discard(req)
             cb_func = req_info["cb_func"]
             if cb_func is not None:
                 cb_args = req_info["cb_args"]
@@ -792,6 +794,7 @@ cdef void _tag_recv_callback(
     cdef UCXRequest req
     cdef dict req_info
     cdef str msg
+    cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
     with log_errors():
@@ -817,7 +820,8 @@ cdef void _tag_recv_callback(
         else:
             exception = None
         try:
-            req_info["inflight_msgs"].discard(req)
+            inflight_msgs = req_info["inflight_msgs"]
+            inflight_msgs.discard(req)
             cb_func = req_info["cb_func"]
             if cb_func is not None:
                 cb_args = req_info["cb_args"]
@@ -983,6 +987,7 @@ cdef void _stream_recv_callback(
     cdef UCXRequest req
     cdef dict req_info
     cdef str msg
+    cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
     with log_errors():
@@ -1008,7 +1013,8 @@ cdef void _stream_recv_callback(
         else:
             exception = None
         try:
-            req_info["inflight_msgs"].discard(req)
+            inflight_msgs = req_info["inflight_msgs"]
+            inflight_msgs.discard(req)
             cb_func = req_info["cb_func"]
             if cb_func is not None:
                 cb_args = req_info["cb_args"]

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -701,11 +701,12 @@ cdef void _send_callback(void *request, ucs_status_t status):
             # This callback function was called before ucp_tag_send_nb() returned
             return
 
-        name = req_info["name"]
         if status == UCS_ERR_CANCELED:
+            name = req_info["name"]
             msg = "<%s>: " % name
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
+            name = req_info["name"]
             ucx_status_msg = ucs_status_string(status).decode("utf-8")
             msg = "<%s>: %s" % (name, ucx_status_msg)
             exception = UCXError(msg)
@@ -812,15 +813,17 @@ cdef void _tag_recv_callback(
             # This callback function was called before ucp_tag_recv_nb() returned
             return
 
-        name = req_info["name"]
         if status == UCS_ERR_CANCELED:
+            name = req_info["name"]
             msg = "<%s>: " % name
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
+            name = req_info["name"]
             ucx_status_msg = ucs_status_string(status).decode("utf-8")
             msg = "<%s>: %s" % (name, ucx_status_msg)
             exception = UCXError(msg)
         elif info.length != req_info["expected_receive"]:
+            name = req_info["name"]
             msg = "<%s>: length mismatch: %d (got) != %d (expected)" % (
                 name, info.length, req_info["expected_receive"]
             )
@@ -1007,15 +1010,17 @@ cdef void _stream_recv_callback(
             # This callback function was called before ucp_tag_recv_nb() returned
             return
 
-        name = req_info["name"]
         if status == UCS_ERR_CANCELED:
+            name = req_info["name"]
             msg = "<%s>: " % name
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
+            name = req_info["name"]
             ucx_status_msg = ucs_status_string(status).decode("utf-8")
             msg = "<%s>: %s" % (name, ucx_status_msg)
             exception = UCXError(msg)
         elif length != req_info["expected_receive"]:
+            name = req_info["name"]
             msg = "<%s>: length mismatch: %d (got) != %d (expected)" % (
                 name, length, req_info["expected_receive"]
             )

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -702,12 +702,12 @@ cdef void _send_callback(void *request, ucs_status_t status):
             return
 
         name = req_info["name"]
-        msg = "<%s>: " % name
         if status == UCS_ERR_CANCELED:
+            msg = "<%s>: " % name
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
             ucx_status_msg = ucs_status_string(status).decode("utf-8")
-            msg += ucx_status_msg
+            msg = "<%s>: %s" % (name, ucx_status_msg)
             exception = UCXError(msg)
         else:
             exception = None
@@ -813,16 +813,16 @@ cdef void _tag_recv_callback(
             return
 
         name = req_info["name"]
-        msg = "<%s>: " % name
         if status == UCS_ERR_CANCELED:
+            msg = "<%s>: " % name
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
             ucx_status_msg = ucs_status_string(status).decode("utf-8")
-            msg += ucx_status_msg
+            msg = "<%s>: %s" % (name, ucx_status_msg)
             exception = UCXError(msg)
         elif info.length != req_info["expected_receive"]:
-            msg += "length mismatch: %d (got) != %d (expected)" % (
-                info.length, req_info["expected_receive"]
+            msg = "<%s>: length mismatch: %d (got) != %d (expected)" % (
+                name, info.length, req_info["expected_receive"]
             )
             exception = UCXMsgTruncated(msg)
         else:
@@ -1008,16 +1008,16 @@ cdef void _stream_recv_callback(
             return
 
         name = req_info["name"]
-        msg = "<%s>: " % name
         if status == UCS_ERR_CANCELED:
+            msg = "<%s>: " % name
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
             ucx_status_msg = ucs_status_string(status).decode("utf-8")
-            msg += ucx_status_msg
+            msg = "<%s>: %s" % (name, ucx_status_msg)
             exception = UCXError(msg)
         elif length != req_info["expected_receive"]:
-            msg += "length mismatch: %d (got) != %d (expected)" % (
-                length, req_info["expected_receive"]
+            msg = "<%s>: length mismatch: %d (got) != %d (expected)" % (
+                name, length, req_info["expected_receive"]
             )
             exception = UCXMsgTruncated(msg)
         else:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -288,9 +288,11 @@ def _ucx_worker_handle_finalizer(
     cdef ucp_worker_h handle = <ucp_worker_h>handle_as_int
 
     # Cancel all inflight messages
+    cdef str name
     for req in list(inflight_msgs):
         assert not req.closed()
-        logger.debug("Future cancelling: %s" % req.info["name"])
+        name = req.info["name"]
+        logger.debug("Future cancelling: %s" % name)
         ucp_request_cancel(handle, <void*><uintptr_t>req.handle)
 
     ucp_worker_destroy(handle)
@@ -420,8 +422,10 @@ def _ucx_endpoint_finalizer(uintptr_t handle_as_int, worker, set inflight_msgs):
     cdef ucs_status_ptr_t status
 
     # Cancel all inflight messages
+    cdef str name
     for req in list(inflight_msgs):
-        logger.debug("Future cancelling: %s" % req.info["name"])
+        name = req.info["name"]
+        logger.debug("Future cancelling: %s" % name)
         # Notice, `request_cancel()` evoke the send/recv callback functions
         worker.request_cancel(req)
 
@@ -684,7 +688,7 @@ cdef UCXRequest _handle_status(
 cdef void _send_callback(void *request, ucs_status_t status):
     cdef UCXRequest req
     cdef dict req_info
-    cdef str msg
+    cdef str name, msg
     cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
@@ -697,7 +701,8 @@ cdef void _send_callback(void *request, ucs_status_t status):
             # This callback function was called before ucp_tag_send_nb() returned
             return
 
-        msg = "<%s>: " % req_info["name"]
+        name = req_info["name"]
+        msg = "<%s>: " % name
         if status == UCS_ERR_CANCELED:
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
@@ -793,7 +798,7 @@ cdef void _tag_recv_callback(
 ):
     cdef UCXRequest req
     cdef dict req_info
-    cdef str msg
+    cdef str name, msg
     cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
@@ -806,7 +811,8 @@ cdef void _tag_recv_callback(
             # This callback function was called before ucp_tag_recv_nb() returned
             return
 
-        msg = "<%s>: " % req_info["name"]
+        name = req_info["name"]
+        msg = "<%s>: " % name
         if status == UCS_ERR_CANCELED:
             exception = UCXCanceled(msg)
         elif status != UCS_OK:
@@ -986,7 +992,7 @@ cdef void _stream_recv_callback(
 ):
     cdef UCXRequest req
     cdef dict req_info
-    cdef str msg
+    cdef str name, msg
     cdef set inflight_msgs
     cdef tuple cb_args
     cdef dict cb_kwargs
@@ -999,7 +1005,8 @@ cdef void _stream_recv_callback(
             # This callback function was called before ucp_tag_recv_nb() returned
             return
 
-        msg = "<%s>: " % req_info["name"]
+        name = req_info["name"]
+        msg = "<%s>: " % name
         if status == UCS_ERR_CANCELED:
             exception = UCXCanceled(msg)
         elif status != UCS_OK:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -288,6 +288,7 @@ def _ucx_worker_handle_finalizer(
     cdef ucp_worker_h handle = <ucp_worker_h>handle_as_int
 
     # Cancel all inflight messages
+    cdef UCXRequest req
     cdef str name
     for req in list(inflight_msgs):
         assert not req.closed()
@@ -422,6 +423,7 @@ def _ucx_endpoint_finalizer(uintptr_t handle_as_int, worker, set inflight_msgs):
     cdef ucs_status_ptr_t status
 
     # Cancel all inflight messages
+    cdef UCXRequest req
     cdef str name
     for req in list(inflight_msgs):
         name = req.info["name"]


### PR DESCRIPTION
Make sure Cython treats `info` as a `dict` when it is used. Also type some frequently used content from `info`. This should help Cython leverage more efficient Python C APIs with these objects.