### PR TITLE
Make `ucx_py_request`'s `uid` `unsigned`

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -31,7 +31,7 @@ from ..utils import nvtx_annotate
 # Struct used as requests by UCX
 cdef struct ucx_py_request:
     bint finished  # Used by downstream projects such as cuML
-    int uid
+    unsigned int uid
     PyObject *info
 
 


### PR DESCRIPTION
As other UID variables are `unsigned`, make sure this one is `unsigned` as well.

xref: https://github.com/rapidsai/ucx-py/pull/618