### PR TITLE
Use C attributes, methods, & minor error message cleanup

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -665,9 +665,12 @@ cdef UCXRequest _handle_status(
 ):
     if UCS_PTR_STATUS(status) == UCS_OK:
         return
-    cdef str msg = "<%s>: " % name
+    cdef str ucx_status_msg, msg
     if UCS_PTR_IS_ERR(status):
-        msg += ucs_status_string(UCS_PTR_STATUS(status)).decode("utf-8")
+        ucx_status_msg = (
+            ucs_status_string(UCS_PTR_STATUS(status)).decode("utf-8")
+        )
+        msg = "<%s>: %s" % (name, ucx_status_msg)
         raise UCXError(msg)
     cdef UCXRequest req = UCXRequest(<uintptr_t><void*> status)
     assert not req.closed()
@@ -677,8 +680,8 @@ cdef UCXRequest _handle_status(
             # The callback function has already handled the request
             received = req_info.get("received", None)
             if received is not None and received != expected_receive:
-                msg += "length mismatch: %d (got) != %d (expected)" % (
-                    received, expected_receive
+                msg = "<%s>: length mismatch: %d (got) != %d (expected)" % (
+                    name, received, expected_receive
                 )
                 raise UCXMsgTruncated(msg)
             else:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -301,7 +301,7 @@ def _ucx_worker_handle_finalizer(
         req_info = req.info
         name = req_info["name"]
         logger.debug("Future cancelling: %s" % name)
-        ucp_request_cancel(handle, <void*><uintptr_t>req.handle)
+        ucp_request_cancel(handle, <void*>req._handle)
 
     ucp_worker_destroy(handle)
 

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -169,7 +169,7 @@ cdef class UCXObject:
         # List of weak references of UCX objects that make use of this object
         self._children = []
 
-    def close(self):
+    cpdef void close(self) except *:
         """Close the object and free the underlying UCX handle.
         Does nothing if the object is already closed
         """
@@ -181,7 +181,7 @@ cdef class UCXObject:
         """Is the underlying UCX handle initialized"""
         return self._finalizer and self._finalizer.alive
 
-    def add_child(self, child):
+    cpdef void add_child(self, child) except *:
         """Add a UCX object to this object's children. The underlying UCX
         handle will be freed when this obejct is freed.
         """
@@ -253,7 +253,7 @@ cdef class UCXContext(UCXObject):
         for k, v in self._config.items():
             logger.info(f"  {k}: {v}")
 
-    def get_config(self):
+    cpdef dict get_config(self):
         return self._config
 
     @property
@@ -358,7 +358,7 @@ cdef class UCXWorker(UCXObject):
             raise IOError("epoll_ctl() returned %d" % err)
         return epoll_fd
 
-    def arm(self):
+    cpdef bint arm(self) except *:
         assert self.initialized
         cdef ucs_status_t status
         status = ucp_worker_arm(self._handle)
@@ -378,7 +378,7 @@ cdef class UCXWorker(UCXObject):
         assert self.initialized
         return int(<uintptr_t>self._handle)
 
-    def request_cancel(self, UCXRequest req):
+    cpdef void request_cancel(self, UCXRequest req) except *:
         assert self.initialized
         assert not req.closed()
 
@@ -612,7 +612,7 @@ cdef class UCXRequest:
     cpdef bint closed(self):
         return self._handle == NULL or self._uid != self._handle.uid
 
-    cpdef close(self):
+    cpdef void close(self) except *:
         """This routine releases the non-blocking request back to UCX,
         regardless of its current state. Communications operations associated with
         this request will make progress internally, however no further notifications or

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -609,7 +609,7 @@ cdef class UCXRequest:
         else:
             self._uid = self._handle.uid
 
-    def closed(self):
+    cpdef bint closed(self):
         return self._handle == NULL or self._uid != self._handle.uid
 
     def close(self):

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -612,7 +612,7 @@ cdef class UCXRequest:
     cpdef bint closed(self):
         return self._handle == NULL or self._uid != self._handle.uid
 
-    def close(self):
+    cpdef close(self):
         """This routine releases the non-blocking request back to UCX,
         regardless of its current state. Communications operations associated with
         this request will make progress internally, however no further notifications or

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -671,8 +671,7 @@ cdef UCXRequest _handle_status(
         raise UCXError(msg)
     cdef UCXRequest req = UCXRequest(<uintptr_t><void*> status)
     assert not req.closed()
-    cdef dict req_info
-    req_info = <dict>req._handle.info
+    cdef dict req_info = <dict>req._handle.info
     if req_info["status"] == "finished":
         try:
             # The callback function has already handle the request

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -674,7 +674,7 @@ cdef UCXRequest _handle_status(
     cdef dict req_info = <dict>req._handle.info
     if req_info["status"] == "finished":
         try:
-            # The callback function has already handle the request
+            # The callback function has already handled the request
             received = req_info.get("received", None)
             if received is not None and received != expected_receive:
                 msg += "length mismatch: %d (got) != %d (expected)" % (


### PR DESCRIPTION
Instead of using Python properties in Cython, directly access C level properties. This should cutdown on the overhead of these attribute access calls. Particularly in parts of the code that may be more sensitive to them. Also provide access to C implementations of a few methods, these are comparable to `virtual` methods in C++. Finally cleanup the generation of a remaining error message so that the message is only built if the error occurs. Thus bypassing construction of this message when no error happens.