### PR TITLE
Remove remaining `nbytes` references in send/recv calls

### DIFF
--- a/benchmarks/local-send-recv.py
+++ b/benchmarks/local-send-recv.py
@@ -71,8 +71,8 @@ def server(queue, args):
 
             assert msg_recv_list[0].nbytes == args.n_bytes
             for i in range(args.n_iter):
-                await ep.recv(msg_recv_list[i], args.n_bytes)
-                await ep.send(msg_recv_list[i], args.n_bytes)
+                await ep.recv(msg_recv_list[i])
+                await ep.send(msg_recv_list[i])
             await ep.close()
             lf.close()
 
@@ -135,8 +135,8 @@ def client(queue, port, server_address, args):
         times = []
         for i in range(args.n_iter):
             start = clock()
-            await ep.send(msg_send_list[i], args.n_bytes)
-            await ep.recv(msg_recv_list[i], args.n_bytes)
+            await ep.send(msg_send_list[i])
+            await ep.recv(msg_recv_list[i])
             stop = clock()
             times.append(stop - start)
         if args.cuda_profile:

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -83,7 +83,7 @@ Process 2 - Client
 
         # send message
         print("Send Original NumPy array")
-        await ep.send(msg, msg_size)  # send the real message
+        await ep.send(msg)  # send the real message
 
         # recv response
         print("Receive Incremented NumPy arrays")
@@ -163,7 +163,7 @@ Process 2 - Client
 
         # send message
         print("Send Original CuPy array")
-        await ep.send(msg, msg_size)  # send the real message
+        await ep.send(msg)  # send the real message
 
         # recv response
         print("Receive Incremented CuPy arrays")

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -79,7 +79,6 @@ Process 2 - Client
         host = ucp.get_address(ifname='eth0')  # ethernet device name
         ep = await ucp.create_endpoint(host, port)
         msg = np.zeros(n_bytes, dtype='u1') # create some data to send
-        msg_size = np.array([msg.nbytes], dtype=np.uint64)
 
         # send message
         print("Send Original NumPy array")
@@ -88,7 +87,7 @@ Process 2 - Client
         # recv response
         print("Receive Incremented NumPy arrays")
         resp = np.empty_like(msg)
-        await ep.recv(resp, msg_size)  # receive the echo
+        await ep.recv(resp)  # receive the echo
         await ep.close()
         np.testing.assert_array_equal(msg + 1, resp)
 
@@ -159,7 +158,6 @@ Process 2 - Client
         host = ucp.get_address(ifname='eth0')  # ethernet device name
         ep = await ucp.create_endpoint(host, port)
         msg = cp.zeros(n_bytes, dtype='u1') # create some data to send
-        msg_size = np.array([msg.nbytes], dtype=np.uint64)
 
         # send message
         print("Send Original CuPy array")
@@ -168,7 +166,7 @@ Process 2 - Client
         # recv response
         print("Receive Incremented CuPy arrays")
         resp = cp.empty_like(msg)
-        await ep.recv(resp, msg_size)  # receive the echo
+        await ep.recv(resp)  # receive the echo
         await ep.close()
         cp.testing.assert_array_equal(msg + 1, resp)
 

--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -40,9 +40,9 @@ def make_echo_server(create_empty_data):
         Basic echo server for sized messages.
         We expect the other endpoint to follow the pattern::
         # size of the real message (in bytes)
-        >>> await ep.send(msg_size, np.uint64().nbytes)
-        >>> await ep.send(msg, msg_size)       # send the real message
-        >>> await ep.recv(responds, msg_size)  # receive the echo
+        >>> await ep.send(msg_size)
+        >>> await ep.send(msg)       # send the real message
+        >>> await ep.recv(responds)  # receive the echo
         """
         msg_size = np.empty(1, dtype=np.uint64)
         await ep.recv(msg_size)


### PR DESCRIPTION
Remove remaining usage of `nbytes`. It has been removed in #605 and was the cause of issues in #630 .