### PR TITLE
Clean up of custom send/recv test, which fixes #621

### DIFF
--- a/tests/test_custom_send_recv.py
+++ b/tests/test_custom_send_recv.py
@@ -4,8 +4,7 @@ import pickle
 import numpy as np
 import pytest
 
-from distributed.comm.utils import to_frames  # noqa
-from distributed.utils import nbytes  # noqa
+from distributed.utils import nbytes
 
 import ucp
 
@@ -43,8 +42,6 @@ async def test_send_recv_cudf(event_loop, g):
     class UCX:
         def __init__(self, ep):
             self.ep = ep
-            loop = asyncio.get_event_loop()
-            self.queue = asyncio.Queue(loop=loop)
 
         async def write(self, cdf):
             header, _frames = cdf.serialize()


### PR DESCRIPTION
Removing unused functions and imports in `test_custom_send_recv.py`, which fixes a deprecation warning #621