### PR TITLE
Use new NVTX module

### DIFF
--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -228,10 +228,9 @@ def run_on_local_network(
 
 
 try:
-    from cudf._lib.nvtx import annotate as nvtx_annotate
+    from nvtx import annotate as nvtx_annotate
 except ImportError:
-    # NVTX annotations functionality currently exists in cuDF, if cuDF isn't
-    # installed, `annotate` yields only.
+    # If nvtx module is not installed, `annotate` yields only.
     from contextlib import contextmanager
 
     @contextmanager


### PR DESCRIPTION
This is being removed from cuDF in https://github.com/rapidsai/cudf/pull/6413, we should use its own new `nvtx` package available from `conda-forge`.