### PR TITLE
Fix compile warnings

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -272,8 +272,9 @@ cdef void _ib_err_cb(void *arg, ucp_ep_h ep, ucs_status_t status):
     logger.error(msg)
 
 
-cdef ucp_err_handler_cb_t _get_error_callback(str tls,
-                                              bint endpoint_error_handling):
+cdef ucp_err_handler_cb_t _get_error_callback(
+    str tls, bint endpoint_error_handling
+):
     cdef ucp_err_handler_cb_t err_cb = <ucp_err_handler_cb_t>NULL
     cdef str t
     cdef list transports

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -519,7 +519,7 @@ cdef void _listener_callback(ucp_conn_request_h conn_request, void *args):
 
 
 def _ucx_listener_handle_finalizer(uintptr_t handle):
-    ucp_listener_destroy(<ucp_listener_h> handle)
+    ucp_listener_destroy(<ucp_listener_h><void*>handle)
 
 
 cdef class UCXListener(UCXObject):

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -520,7 +520,7 @@ cdef void _listener_callback(ucp_conn_request_h conn_request, void *args):
 
 
 def _ucx_listener_handle_finalizer(uintptr_t handle):
-    ucp_listener_destroy(<ucp_listener_h><void*>handle)
+    ucp_listener_destroy(<ucp_listener_h> handle)
 
 
 cdef class UCXListener(UCXObject):

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -274,7 +274,7 @@ cdef void _ib_err_cb(void *arg, ucp_ep_h ep, ucs_status_t status):
 
 cdef ucp_err_handler_cb_t _get_error_callback(
     str tls, bint endpoint_error_handling
-):
+) except *:
     cdef ucp_err_handler_cb_t err_cb = <ucp_err_handler_cb_t>NULL
     cdef str t
     cdef list transports

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -208,6 +208,7 @@ cdef extern from "ucp/api/ucp.h":
 
     ctypedef enum ucs_config_print_flags_t:
         pass
+
     ucs_config_print_flags_t UCS_CONFIG_PRINT_CONFIG
     void ucp_config_print(const ucp_config_t *config,
                           FILE *stream,

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -126,8 +126,10 @@ cdef extern from "ucp/api/ucp.h":
                                    ucp_worker_h *worker_p)
     void ucp_worker_destroy(ucp_worker_h worker)
 
-    ctypedef struct ucp_listener_h:
+    ctypedef struct ucp_listener:
         pass
+
+    ctypedef ucp_listener* ucp_listener_h
 
     ucs_status_t ucp_listener_create(ucp_worker_h worker,
                                      const ucp_listener_params_t *params,

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -28,8 +28,7 @@ cdef extern from "src/c_util.h":
 
     ctypedef ucp_conn_request* ucp_conn_request_h
 
-    ctypedef struct ucp_err_handler_cb_t:
-        pass
+    ctypedef void(*ucp_err_handler_cb_t)(void *arg, ucp_ep_h ep, ucs_status_t status)
 
     ctypedef void(*ucp_listener_conn_callback_t)(ucp_conn_request_h request, void *arg)
 


### PR DESCRIPTION
Fixes a few issues that were causing compilation warnings. First fix typing of `ucp_listener_h` to be a pointer otherwise Cython will ignore later pointer casts, which results in C code that warns about not casting. Second fixes the typing of `ucp_listener_h`, the type of `ucp_err_handler_cb_t` wasn't correctly declared as a function pointer, which caused some unexpected C warnings about unassigned variables. This fixes that typing, which fixes the C warnings as well. Third note that `_get_error_callback` could raise Python exceptions as it works with Python objects (though this is exceedingly unlikely).