### PR TITLE
Remove default values for UCX_TCP_{TX,RX}_SEG_SIZE

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -84,8 +84,6 @@ UCX_TCP_TX_SEG_SIZE
 
 Size of send copy-out buffer when transmitting.  This environment variable controls the size of the buffer on the host when sending data over TCP.
 
-UCX-Py uses ``8M`` as the default value for both RX/TX.
-
 .. note::
     Users should take care to properly tune ``UCX_TCP_{RX/TX}_SEG_SIZE`` parameters when mixing TCP with other transports methods as well as when
     using TCP over UCX in isolation.  These variables will impact CUDA transfers when no NVLink or InfiniBand is available between UCX-Py processes.

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -33,12 +33,6 @@ if not os.environ.get("UCX_RNDV_THRESH", False):
 if not os.environ.get("UCX_RNDV_SCHEME", False):
     os.environ["UCX_RNDV_SCHEME"] = "get_zcopy"
 
-if not os.environ.get("UCX_TCP_TX_SEG_SIZE", False):
-    os.environ["UCX_TCP_TX_SEG_SIZE"] = "8M"
-
-if not os.environ.get("UCX_TCP_RX_SEG_SIZE", False):
-    os.environ["UCX_TCP_RX_SEG_SIZE"] = "8M"
-
 
 # After handling of environment variable logging, add formatting to the logger
 logger = get_ucxpy_logger()


### PR DESCRIPTION
These raise lots of warnings and only benefit the CUDA with TCP-only case, which is not very common right now. If this becomes necessary, we should consider adding them directly into the application, such as dask-cuda when both NVLink and IB are disabled.