### PR TITLE
Update documentation for UCX 1.9

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -31,7 +31,7 @@ Without GPU support:
     conda create -n ucx -c conda-forge -c rapidsai \
       ucx-proc=*=cpu ucx ucx-py python=3.7
 
-Note: These use UCX's ``v1.8.x`` branch.
+Note: These use UCX's ``v1.9.x`` branch.
 
 Source
 ------
@@ -72,12 +72,11 @@ UCX
     conda activate ucx
     git clone https://github.com/openucx/ucx
     cd ucx
-    git checkout v1.8.x
-    # apply UCX IB registration cache patches, improves overall
+    git checkout v1.9.0
+    # apply UCX IB registration cache patch, improves overall
     # CUDA IB performance when using a memory pool
-    curl -LO https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/add-page-alignment.patch
-    curl -LO https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/ib_registration_cache.patch
-    git apply ib_registration_cache.patch && git apply add-page-alignment.patch
+    curl -LO https://raw.githubusercontent.com/rapidsai/ucx-split-feedstock/master/recipe/cuda-alloc-rcache.patch
+    git apply cuda-alloc-rcache.patch
     ./autogen.sh
     mkdir build
     cd build
@@ -88,7 +87,7 @@ UCX
     make -j install
 
 .. note::
-    If you're running on a machine without CUDA then you _must NOT_ apply the patches.
+    If you're running on a machine without CUDA then you _must NOT_ apply the IB patch above.
 
 UCX + OFED
 ~~~~~~~~~~

--- a/docs/source/send-recv.rst
+++ b/docs/source/send-recv.rst
@@ -66,7 +66,7 @@ So what happens with ``create_endpoint`` ?  Unlike Sockets, UCX employs a tag-ma
 #. Exchange endpoint info such as tags
 #. Use the info to create an endpoint
 
-Again, an ``Endpoint`` sends and receives with `unique tags <http://openucx.github.io/ucx/api/v1.8/html/group___u_c_t___t_a_g.html>`_.
+Again, an ``Endpoint`` sends and receives with `unique tags <http://openucx.github.io/ucx/api/v1.9/html/group___u_c_t___t_a_g.html>`_.
 
 .. code-block:: python
 
@@ -99,7 +99,7 @@ Most users will not care about these details but developers and interested netwo
     [1594319287.523172] [dgx12:5904] UCXPY  DEBUG Endpoint.abort(): 0x7f5e6e7bd0d8
     [1594319287.523331] [dgx12:5904] UCXPY  DEBUG Future cancelling: [Recv shutdown] ep: 0x7f5e6e7bd0d8, tag: 0xe79506f1d24b4997
 
-We can see from the above that when the ``Endpoint`` is created, 4 tags are generated:  ``msg-tag-send``, ``msg-tag-recv``, ``ctrl-tag-send``, and ``ctrl-tag-recv``.  This data is transmitted to the server via a `stream <http://openucx.github.io/ucx/api/v1.8/html/group___u_c_p___c_o_m_m.html#ga9022ff0ebb56cac81f6ba81bb28f71b3>`_ communication in an `exchange peer info <https://github.com/rapidsai/ucx-py/blob/6e1c1d201a382c689ca098c848cbfdc8237e1eba/ucp/core.py#L38-L89>`_ convenience function.
+We can see from the above that when the ``Endpoint`` is created, 4 tags are generated:  ``msg-tag-send``, ``msg-tag-recv``, ``ctrl-tag-send``, and ``ctrl-tag-recv``.  This data is transmitted to the server via a `stream <http://openucx.github.io/ucx/api/v1.9/html/group___u_c_p___c_o_m_m.html#ga9022ff0ebb56cac81f6ba81bb28f71b3>`_ communication in an `exchange peer info <https://github.com/rapidsai/ucx-py/blob/6e1c1d201a382c689ca098c848cbfdc8237e1eba/ucp/core.py#L38-L89>`_ convenience function.
 
 Next, the client sends data on the ``msg-tag-send`` tag.  Two messages are sent, the size of the data ``8 bytes`` and data itself.  The server receives the data and immediately echos the data back.  The client then receives two messages the size of the data and the data itself.  Lastly, the client closes down.  When the client closes, it sends a `control message <https://github.com/rapidsai/ucx-py/blob/6e1c1d201a382c689ca098c848cbfdc8237e1eba/ucp/core.py#L524-L534>`_ to the server's ``Endpoint`` instructing it to `also close <https://github.com/rapidsai/ucx-py/blob/6e1c1d201a382c689ca098c848cbfdc8237e1eba/ucp/core.py#L112-L140>`_
 


### PR DESCRIPTION
Requires https://github.com/rapidsai/ucx-split-feedstock/pull/44 , should wait until that's merged.