### PR TITLE
Gpuciscripts clean and update

### DIFF
--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2020, NVIDIA CORPORATION.
 #####################
 # cuDF Style Tester #
 #####################
 
 # Ignore errors and set path
 set +e
-PATH=/conda/bin:$PATH
+PATH=/opt/conda/bin:$PATH
 LC_ALL=C.UTF-8
 LANG=C.UTF-8
 
 # Activate common conda env
-source activate gdf
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
 # Run isort and get results/return code
 ISORT=`isort --recursive --check-only .`

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -24,6 +24,10 @@ cd $WORKSPACE
 export GIT_DESCRIBE_TAG=`git describe --abbrev=0 --tags`
 export GIT_DESCRIBE_NUMBER=`git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count`
 
+# Setup 'gpuci_conda_retry' for build retries (results in 2 total attempts)
+export GPUCI_CONDA_RETRY_MAX=1
+export GPUCI_CONDA_RETRY_SLEEP=30
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -5,14 +5,9 @@
 ######################################
 set -e
 
-# Logger function for build status output
-function gpuci_logger() {
-  echo -e "\n>>>> $@\n"
-}
-
 # Set path and build parallel level
 export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
-export PARALLEL_LEVEL=-4
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 
 # Set home to the job's workspace
 export HOME=$WORKSPACE

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2020, NVIDIA CORPORATION.
 ######################################
 # ucx-py CPU conda build script for CI #
 ######################################
 set -e
 
 # Logger function for build status output
-function logger() {
+function gpuci_logger() {
   echo -e "\n>>>> $@\n"
 }
 
 # Set path and build parallel level
-export PATH=/conda/bin:/usr/local/cuda/bin:$PATH
-export PARALLEL_LEVEL=4
+export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
+export PARALLEL_LEVEL=-4
 
 # Set home to the job's workspace
 export HOME=$WORKSPACE
@@ -28,17 +28,20 @@ export GIT_DESCRIBE_NUMBER=`git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count`
 # SETUP - Check environment
 ################################################################################
 
-logger "Get env..."
+gpuci_logger "Get env"
 env
 
-logger "Activate conda env..."
-source activate gdf
+gpuci_logger "Activate conda env"
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
-logger "Check versions..."
+gpuci_logger "Check versions"
 python --version
-gcc --version
-g++ --version
-conda list
+$CC --version
+$CXX --version
+conda info
+conda config --show-sources
+conda list --show-channel-urls
 
 # FIX Added to deal with Anancoda SSL verification issues during conda builds
 conda config --set ssl_verify False
@@ -47,12 +50,12 @@ conda config --set ssl_verify False
 # BUILD - Conda package builds (conda deps: ucx-py)
 ################################################################################
 
-# logger "Build conda pkg for ucx-py..."
+# logger "Build conda pkg for ucx-py"
 # source ci/cpu/ucx-py/build_ucx-py.sh
 
 ################################################################################
 # UPLOAD - Conda packages
 ################################################################################
 
-# logger "Upload conda pkgs..."
+# logger "Upload conda pkgs"
 # source ci/cpu/upload_anaconda.sh

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2020, NVIDIA CORPORATION.
 #########################################
 # ucx-py GPU build and test script for CI #
 #########################################
@@ -8,7 +8,7 @@ NUMARGS=$#
 ARGS=$*
 
 # Logger function for build status output
-function logger() {
+function gpuci_logger() {
   echo -e "\n>>>> $@\n"
 }
 
@@ -20,8 +20,8 @@ function hasArg {
 }
 
 # Set path and build parallel level
-export PATH=/conda/bin:/usr/local/cuda/bin:$PATH
-export PARALLEL_LEVEL=4
+export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
+export PARALLEL_LEVEL=-4
 export CUDA_REL=${CUDA_VERSION%.*}
 
 # Set home to the job's workspace
@@ -33,42 +33,49 @@ export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 export UCX_PATH=$CONDA_PREFIX
 
+# Setup 'gpuci_conda_retry' for build retries (results in 2 total attempts)
+export GPUCI_CONDA_RETRY_MAX=1
+export GPUCI_CONDA_RETRY_SLEEP=30
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################
 
-logger "Check environment..."
+gpuci_logger "Check environment"
 env
 
-logger "Check GPU usage..."
+gpuci_logger "Check GPU usage"
 nvidia-smi
 
-logger "Activate conda env..."
-source activate gdf
-conda install "cudatoolkit=${CUDA_REL}" \
+gpuci_logger "Activate conda env"
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
+gpuci_conda_retry install "cudatoolkit=${CUDA_REL}" \
               "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
               "rapids-build-env=${MINOR_VERSION}"
 
 # Install pytorch to run related tests
-conda install -c pytorch "pytorch" "torchvision"
+gpuci_conda_retry install -c pytorch "pytorch" "torchvision"
 
 # Install the master version of dask and distributed
-logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
+gpuci_logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
+gpuci_logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
 pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
 
-logger "Check versions..."
+gpuci_logger "Check versions"
 python --version
 $CC --version
 $CXX --version
-conda list
+conda info
+conda config --show-sources
+conda list --show-channel-urls
 
 ################################################################################
 # BUILD - Build ucx-py
 ################################################################################
 
-logger "Build ucx-py..."
+gpuci_logger "Build ucx-py"
 cd $WORKSPACE
 python setup.py build_ext --inplace
 python -m pip install -e .
@@ -78,16 +85,16 @@ python -m pip install -e .
 ################################################################################
 
 if hasArg --skip-tests; then
-    logger "Skipping Tests..."
+    gpuci_logger "Skipping Tests"
 else
-    logger "Check GPU usage..."
+    gpuci_logger "Check GPU usage"
     nvidia-smi
 
-    logger "Check NICs"
+    gpuci_logger "Check NICs"
     awk 'END{print $1}' /etc/hosts
     cat /etc/hosts
 
-    logger "Python py.test for ucx-py..."
+    gpuci_logger "Python py.test for ucx-py"
     cd $WORKSPACE
 
     # list test directory
@@ -100,12 +107,12 @@ else
     export UCX_SOCKADDR_TLS_PRIORITY=sockcm
 
     # Test with TCP/Sockets
-    logger "TEST WITH TCP ONLY..."
+    gpuci_logger "TEST WITH TCP ONLY"
     py.test --cache-clear -vs --ignore-glob tests/test_send_recv_two_workers.py tests/
 
     # Test downstream packages, which requires Python v3.7
     if [ $(python -c "import sys; print(sys.version_info[1])") -ge "7" ]; then
-        logger "TEST OF DASK/UCX..."
+        gpuci_logger "TEST OF DASK/UCX"
         py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_cupy as m;print(m.__file__)"`
         py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_numba as m;print(m.__file__)"`
         py.test --cache-clear -vs `python -c "import distributed.protocol.tests.test_rmm as m;print(m.__file__)"`
@@ -116,7 +123,7 @@ else
         py.test --cache-clear -m "slow" -vs `python -c "import distributed.comm.tests.test_ucx as m;print(m.__file__)"`
     fi
 
-    logger "Run local benchmark..."
+    gpuci_logger "Run local benchmark"
     python benchmarks/local-send-recv.py -o cupy --server-dev 0 --client-dev 0 --reuse-alloc
     python benchmarks/cudf-merge.py --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 2097152
 fi

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -7,11 +7,6 @@ set -e
 NUMARGS=$#
 ARGS=$*
 
-# Logger function for build status output
-function gpuci_logger() {
-  echo -e "\n>>>> $@\n"
-}
-
 # apt-get install libnuma libnuma-dev
 
 # Arg parsing function
@@ -21,7 +16,7 @@ function hasArg {
 
 # Set path and build parallel level
 export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
-export PARALLEL_LEVEL=-4
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 export CUDA_REL=${CUDA_VERSION%.*}
 
 # Set home to the job's workspace

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -33,10 +33,6 @@ export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 export UCX_PATH=$CONDA_PREFIX
 
-# Setup 'gpuci_conda_retry' for build retries (results in 2 total attempts)
-export GPUCI_CONDA_RETRY_MAX=1
-export GPUCI_CONDA_RETRY_SLEEP=30
-
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/ci/local/README.md
+++ b/ci/local/README.md
@@ -30,7 +30,8 @@ For a full list of available gpuCI docker images, visit our [DockerHub](https://
 Style Check:
 ```bash
 $ bash ci/local/build.sh -r ~/rapids/ucx-py -s
-$ source activate gdf    #Activate gpuCI conda environment
+$ . /opt/conda/etc/profile.d/conda.sh
+$ conda activate rapids   #Activate gpuCI conda environment
 $ cd rapids
 $ flake8 python
 ```


### PR DESCRIPTION
In CI folder the following changes have been made:

- Remove logger function and replace all logger calls with gpuci_logger

- Removed all ellipses ... from logger messages

- Prepend /opt to the conda path in PATH variable

- Replace conda with gpuci_conda_retry for build and install calls  (Did not replace conda activate with gpuci_conda_retry) 

- Replace source activate <env> with the following:
. /opt/conda/etc/profile.d/conda.sh
conda activate rapids

- Replace conda list with more verbose information:
conda info
conda config --show-sources
conda list --show-channel-urls

- Update Copyright year in the top of scripts to include 2020 if applicable

- Set PARALLEL_LEVEL to ${PARALLEL_LEVEL:-4}

- Set gpuci_conda_retry flags in cpu/build.sh
Setup 'gpuci_conda_retry' for build retries (results in 2 total attempts)
export GPUCI_CONDA_RETRY_MAX=1
export GPUCI_CONDA_RETRY_SLEEP=30

- Replace calls to gcc and g++ with $CC and $CXX respectively