### PR TITLE
DOC: Fix UCX_TLS environment variable for Infiniband

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ export UCX_SOCKADDR_TLS_PRIORITY=sockcm
 export UCXPY_IFNAME="eth0"
 
 # InfiniBand using "ib0" and CUDA support
-export UCX_TLS=sockcm,cuda_copy,cuda_ipc
+export UCX_TLS=ib,sockcm,cuda_copy,cuda_ipc
 export UCX_SOCKADDR_TLS_PRIORITY=sockcm
 export UCXPY_IFNAME="ib0"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ export UCX_SOCKADDR_TLS_PRIORITY=sockcm
 export UCXPY_IFNAME="eth0"
 
 # InfiniBand using "ib0" and CUDA support
-export UCX_TLS=ib,sockcm,cuda_copy,cuda_ipc
+export UCX_TLS=rc,sockcm,cuda_copy,cuda_ipc
 export UCX_SOCKADDR_TLS_PRIORITY=sockcm
 export UCXPY_IFNAME="ib0"
 


### PR DESCRIPTION
The suggested configuration doesn't really work for intra-node communication, only inter-node communications are possible, since it uses CUDA_IPC.
```
$ UCX_TLS=sockcm,cuda_copy,cuda_ipc ucx_info -eptw -u tra -D net
[1605294229.512128] [r-vmb-ppc-jenkins:12834:0]    ucp_context.c:1108 UCX  ERROR no usable transports/devices (asked sockcm,cuda_copy,cuda_ipc on all devices)
<Failed to create UCP context>
```
User has to specify `ib` to `UCX_TLS` environment variable to use Infiniband