### PR TITLE
Simplify license file packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include LICENSE
 include versioneer.py
 include ucp/_version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-license_files = LICENSE
-
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
     long_description=readme,
     author="NVIDIA Corporation",
     license="BSD-3-Clause",
+    license_files=["LICENSE"],
     zip_safe=False,
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
Uses the newer `license_files` key that Python tooling generally respects to package the license file more simply. Drops other ways of handling the license file to simplify things.