### PR TITLE
[gpuCI] Auto-merge branch-0.17 to branch-0.18 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,10 +53,10 @@ conda install "cudatoolkit=${CUDA_REL}" \
 conda install -c pytorch "pytorch" "torchvision"
 
 # Install the master version of dask and distributed
-logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/distributed.git@master --upgrade --no-deps"
+pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/dask.git@master --upgrade --no-deps"
+pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
 
 logger "Check versions..."
 python --version


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.17` that creates a PR to keep `branch-0.18` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.