### PR TITLE
Set UCX_SOCKADDR_CM_ENABLE=n by default

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -33,6 +33,9 @@ if not os.environ.get("UCX_RNDV_THRESH", False):
 if not os.environ.get("UCX_RNDV_SCHEME", False):
     os.environ["UCX_RNDV_SCHEME"] = "get_zcopy"
 
+if not os.environ.get("UCX_SOCKADDR_CM_ENABLE", False):
+    os.environ["UCX_SOCKADDR_CM_ENABLE"] = "n"
+
 
 # After handling of environment variable logging, add formatting to the logger
 logger = get_ucxpy_logger()


### PR DESCRIPTION
Starting with UCX 1.10 the default is `UCX_SOCKADDR_CM_ENABLE=y`, which can cause errors like those below depending on the available transports. This PR reverts that default in UCX-Py, but the user can still bypass it by explicitly setting the `UCX_SOCKADDR_CM_ENABLE=y` environment variable.

```
[1610542356.468568] [dgx13:13389:0]    ucp_context.c:1080 UCX  ERROR UCX_SOCKADDR_CM_ENABLE is set to yes but none of the available components supports SOCKADDR_CM
```