### PR TITLE
Prevent closing event_loop too early

### DIFF
--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -161,7 +161,6 @@ def _worker_process(
 
     loop = asyncio.get_event_loop()
     ret = loop.run_until_complete(run())
-    loop.close()
     queue.put(ret)
 
 


### PR DESCRIPTION
This fixes test warnings such as:

```python
Task was destroyed but it is pending!
task: <Task pending name='Task-31' coro=<BlockingMode._arm_worker() running at ucp/continuous_ucx_progress.py:88>>
```