### PR TITLE
Fix character decoding

### DIFF
--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -111,7 +111,7 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
         if fflush(text_fd) != 0:
             clearerr(text_fd)
             raise IOError("fflush() failed on memory stream")
-        py_text = text.decode("ISO-8859-1")
+        py_text = text.decode(errors="ignore")
         for line in py_text.splitlines():
             k, v = line.split("=")
             k = k[4:]  # Strip "UCX_" prefix
@@ -581,7 +581,7 @@ cdef class UCXEndpoint(UCXObject):
             if fflush(text_fd) != 0:
                 clearerr(text_fd)
                 raise IOError("fflush() failed on memory stream")
-            py_text = text.decode("ISO-8859-1")
+            py_text = text.decode(errors="ignore")
         finally:
             if fclose(text_fd) != 0:
                 free(text)

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -111,7 +111,7 @@ cdef dict ucx_config_to_dict(ucp_config_t *config):
         if fflush(text_fd) != 0:
             clearerr(text_fd)
             raise IOError("fflush() failed on memory stream")
-        py_text = text.decode()
+        py_text = text.decode("ISO-8859-1")
         for line in py_text.splitlines():
             k, v = line.split("=")
             k = k[4:]  # Strip "UCX_" prefix
@@ -581,7 +581,7 @@ cdef class UCXEndpoint(UCXObject):
             if fflush(text_fd) != 0:
                 clearerr(text_fd)
                 raise IOError("fflush() failed on memory stream")
-            py_text = text.decode()
+            py_text = text.decode("ISO-8859-1")
         finally:
             if fclose(text_fd) != 0:
                 free(text)


### PR DESCRIPTION
This resolves errors such as below:

```python
asyncio:base_events.py:1707 Task exception was never retrieved
future: <Task finished name='Task-102' coro=<_listener_handler_coroutine() done, defined at /gpfs/fs1/pentschev/miniconda3/envs/ucx-master-110-0.18.210127/lib/python3.8/site-packages/ucp/core.py:148> exception=UnicodeDecodeError('utf-8', b'#\n# UCP endpoint\n#\n#               peer: <no debug data>\n#                 lane[0]: 255:\xc0\x7f/.0 md[60]                   -> md[255]/posix   \n#                 lane[1]:  0:tcp/enp1s0f0.0 md[0]          -> md[0]/tcp      am am_bw#0 wireup\n#                 lane[2]:  1:cuda_copy/cuda.0 md[1]        -> md[1]/cuda_cpy rma_bw#0\n#\n#                tag_send: 0..<egr/short>..8185..<egr/zcopy>..8192..<rndv>..(inf)\n#            tag_send_nbr: 0..<egr/short>..8185..<egr/bcopy>..8192..<rndv>..(inf)\n#           tag_send_sync: 0..<egr/short>..8185..<egr/zcopy>..8192..<rndv>..(inf)\n#\n#                  rma_bw: mds rndv_rkey_size 9\n#\n', 88, 89, 'invalid start byte')>
Traceback (most recent call last):
  File "ucp/core.py", line 200, in _listener_handler_coroutine
    await func(ep)
  File "tests/test_multiple_nodes.py", line 21, in server_node
    await hello(ep)
  File "test_multiple_nodes.py", line 17, in hello
    assert isinstance(ep.ucx_info(), str)
  File "core.py", line 655, in ucx_info
    return self._ep.info()
  File "ucp/_libs/ucx_api.pyx", line 584, in ucp._libs.ucx_api.UCXEndpoint.info
    py_text = text.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 88: invalid start byte
``` 