### PR TITLE
Install Dask + Distributed from `main`

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -48,11 +48,11 @@ gpuci_conda_retry install "cudatoolkit=${CUDA_REL}" \
 # Install pytorch to run related tests
 gpuci_conda_retry install -c pytorch "pytorch" "torchvision"
 
-# Install the master version of dask and distributed
-gpuci_logger "pip install git+https://github.com/dask/distributed.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
-gpuci_logger "pip install git+https://github.com/dask/dask.git@master --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
+# Install the main version of dask and distributed
+gpuci_logger "pip install git+https://github.com/dask/distributed.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/distributed.git@main" --upgrade --no-deps
+gpuci_logger "pip install git+https://github.com/dask/dask.git@main --upgrade --no-deps"
+pip install "git+https://github.com/dask/dask.git@main" --upgrade --no-deps
 
 gpuci_logger "Check versions"
 python --version


### PR DESCRIPTION
These recently dropped the `master` branch and switched to `main`. So update the install steps to use `main` instead.