### PR TITLE
Clean up send/recv tags

### DIFF
--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -3,13 +3,14 @@
 # See file LICENSE for terms.
 # cython: language_level=3
 
-from libc.string cimport memset
-from libc.stdint cimport *
-from libc.stdlib cimport malloc, free
-from libc.stdio cimport FILE, stdin, stdout, stderr, printf, fflush, fclose
 from posix.stdio cimport open_memstream
 from posix.unistd cimport close
-from cpython.ref cimport PyObject, Py_INCREF, Py_DECREF
+
+from cpython.ref cimport Py_DECREF, Py_INCREF, PyObject
+from libc.stdint cimport *
+from libc.stdio cimport FILE, fclose, fflush, printf, stderr, stdin, stdout
+from libc.stdlib cimport free, malloc
+from libc.string cimport memset
 
 
 cdef extern from "src/c_util.h":

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -488,7 +488,6 @@ class Endpoint:
         self._shutting_down_peer = False  # Told peer to shutdown
         self._close_after_n_recv = None
         self._tags = tags
-        assert tags is not None
 
     @property
     def uid(self):

--- a/ucp/endpoint_reuse.py
+++ b/ucp/endpoint_reuse.py
@@ -53,7 +53,7 @@ class EndpointReuse:
         for ep in existing_endpoints:
             if not ep.ep.closed():
                 ep.refcount += 1
-                my_ep_ids.append(ep.ep._msg_tag_recv)
+                my_ep_ids.append(ep.ep._tags["msg_recv"])
 
         await ep_new.send_obj(pickle.dumps((my_ep_ids, tag)))
         reuse_ep_id = pickle.loads(await ep_new.recv_obj())
@@ -70,8 +70,8 @@ class EndpointReuse:
             await ep_new.close()
         else:
             reuse_ep = EPHandle(ep_new)
-            assert ep_new._msg_tag_send not in cls.existing_endpoints
-            cls.existing_endpoints[ep_new._msg_tag_send] = reuse_ep
+            assert ep_new._tags["msg_send"] not in cls.existing_endpoints
+            cls.existing_endpoints[ep_new._tags["msg_send"]] = reuse_ep
         return cls(reuse_ep, tag)
 
     @classmethod
@@ -86,13 +86,13 @@ class EndpointReuse:
 
             if existing_ep:
                 existing_ep.refcount += 1
-                await ep_new.send_obj(pickle.dumps(existing_ep.ep._msg_tag_recv))
+                await ep_new.send_obj(pickle.dumps(existing_ep.ep._tags["msg_recv"]))
                 await ep_new.close()
             else:
                 await ep_new.send_obj(pickle.dumps(None))
                 existing_ep = EPHandle(ep_new)
-                assert ep_new._msg_tag_send not in cls.existing_endpoints
-                cls.existing_endpoints[ep_new._msg_tag_send] = existing_ep
+                assert ep_new._tags["msg_send"] not in cls.existing_endpoints
+                cls.existing_endpoints[ep_new._tags["msg_send"]] = existing_ep
 
             await cb_coroutine(cls(existing_ep, tag))
 


### PR DESCRIPTION
Now using a `dict` for the endpoint tags.

This PR is part **1** of an effort to merge https://github.com/rapidsai/ucx-py/pull/648 in a divide-and-conquer approach.