### PR TITLE
Support `ucp_listener_query` to find listener's IP/port

### DIFF
--- a/ucp/_libs/src/c_util.c
+++ b/ucp/_libs/src/c_util.c
@@ -87,3 +87,25 @@ int c_util_get_ucp_ep_conn_params(ucp_ep_params_t *param,
 void c_util_get_ucp_ep_params_free(ucp_ep_params_t *param) {
     free((void*) param->sockaddr.addr);
 }
+
+void c_util_sockaddr_get_ip_port_str(const struct sockaddr_storage *sock_addr,
+                                     char *ip_str, char *port_str,
+                                     size_t max_str_size)
+{
+    struct sockaddr_in  addr_in;
+    struct sockaddr_in6 addr_in6;
+
+    switch (sock_addr->ss_family) {
+    case AF_INET:
+        memcpy(&addr_in, sock_addr, sizeof(struct sockaddr_in));
+        inet_ntop(AF_INET, &addr_in.sin_addr, ip_str, max_str_size);
+        snprintf(port_str, max_str_size, "%d", ntohs(addr_in.sin_port));
+    case AF_INET6:
+        memcpy(&addr_in6, sock_addr, sizeof(struct sockaddr_in6));
+        inet_ntop(AF_INET6, &addr_in6.sin6_addr, ip_str, max_str_size);
+        snprintf(port_str, max_str_size, "%d", ntohs(addr_in6.sin6_port));
+    default:
+        ip_str = "Invalid address family";
+        port_str = "Invalid address family";
+    }
+}

--- a/ucp/_libs/src/c_util.h
+++ b/ucp/_libs/src/c_util.h
@@ -11,6 +11,8 @@ int c_util_set_sockaddr(ucs_sock_addr_t *sockaddr, const char *ip_address, uint1
 
 void c_util_sockaddr_free(ucs_sock_addr_t *sockaddr);
 
-void c_util_sockaddr_get_ip_str(const struct sockaddr_storage *sock_addr,
-                                char *ip_str, char *port_str,
-                                size_t max_str_size);
+void c_util_sockaddr_get_ip_port_str(
+    const struct sockaddr_storage *sock_addr,
+    char *ip_str, char *port_str,
+    size_t max_str_size
+);

--- a/ucp/_libs/src/c_util.h
+++ b/ucp/_libs/src/c_util.h
@@ -25,3 +25,7 @@ int c_util_get_ucp_ep_conn_params(ucp_ep_params_t *param,
                                   ucp_err_handler_cb_t err_cb);
 
 void c_util_get_ucp_ep_params_free(ucp_ep_params_t *param);
+
+void c_util_sockaddr_get_ip_str(const struct sockaddr_storage *sock_addr,
+                                char *ip_str, char *port_str,
+                                size_t max_str_size);

--- a/ucp/_libs/tests/test_listener.py
+++ b/ucp/_libs/tests/test_listener.py
@@ -1,0 +1,18 @@
+from ucp._libs.ucx_api import UCXContext, UCXListener, UCXWorker
+
+
+def test_listener_ip_port():
+    def _listener_handler(conn_request, callback_func):
+        pass
+
+    context = UCXContext({})
+    worker = UCXWorker(context)
+
+    listener = UCXListener(
+        worker=worker, port=0, cb_func=_listener_handler, cb_args=(lambda: None,)
+    )
+
+    assert isinstance(listener.ip, str) and listener.ip
+    assert (
+        isinstance(listener.port, int) and listener.port >= 0 and listener.port <= 65535
+    )

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -683,10 +683,6 @@ cdef class UCXListener(UCXObject):
         if c_util_set_sockaddr(&params.sockaddr, NULL, port):
             raise MemoryError("Failed allocation of sockaddr")
 
-        DEF MAX_STR_LEN = 50
-        cdef char ip_str[MAX_STR_LEN]
-        cdef char port_str[MAX_STR_LEN]
-
         cdef ucs_status_t status = ucp_listener_create(
             worker._handle, &params, &self._handle
         )
@@ -699,6 +695,9 @@ cdef class UCXListener(UCXObject):
             ucp_listener_destroy(self._handle)
         assert_ucs_status(status)
 
+        DEF MAX_STR_LEN = 50
+        cdef char ip_str[MAX_STR_LEN]
+        cdef char port_str[MAX_STR_LEN]
         c_util_sockaddr_get_ip_port_str(&attr.sockaddr,
                                         ip_str,
                                         port_str,

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -674,8 +674,8 @@ cdef class UCXListener(UCXObject):
         c_util_get_ucp_listener_params_free(&params)
         assert_ucs_status(status)
 
-        attr.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR;
-        status = ucp_listener_query(self._handle, &attr);
+        attr.field_mask = UCP_LISTENER_ATTR_FIELD_SOCKADDR
+        status = ucp_listener_query(self._handle, &attr)
         if status != UCS_OK:
             ucp_listener_destroy(self._handle)
         assert_ucs_status(status)

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -13,6 +13,11 @@ from libc.stdlib cimport free, malloc
 from libc.string cimport memset
 
 
+cdef extern from "sys/socket.h":
+    ctypedef struct sockaddr_storage_t:
+        pass
+
+
 cdef extern from "src/c_util.h":
     ctypedef struct ucp_listener_params_t:
         pass
@@ -48,6 +53,11 @@ cdef extern from "src/c_util.h":
                                       ucp_conn_request_h conn_request,
                                       ucp_err_handler_cb_t err_cb)
     void c_util_get_ucp_ep_params_free(ucp_ep_params_t *param)
+
+    void c_util_sockaddr_get_ip_port_str(const sockaddr_storage_t *sock_addr,
+                                         char *ip_str,
+                                         char *port_str,
+                                         size_t max_size)
 
 
 cdef extern from "ucp/api/ucp.h":
@@ -136,9 +146,16 @@ cdef extern from "ucp/api/ucp.h":
 
     ctypedef ucp_listener* ucp_listener_h
 
+    int UCP_LISTENER_ATTR_FIELD_SOCKADDR
+    ctypedef struct ucp_listener_attr_t:
+        uint64_t field_mask
+        sockaddr_storage_t sockaddr
+
     ucs_status_t ucp_listener_create(ucp_worker_h worker,
                                      const ucp_listener_params_t *params,
                                      ucp_listener_h *listener_p)
+    ucs_status_t ucp_listener_query(ucp_listener_h listener,
+                                    ucp_listener_attr_t *attr)
 
     ucs_status_t ucp_ep_create(ucp_worker_h worker,
                                const ucp_ep_params_t *params,

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -328,7 +328,7 @@ class ApplicationContext:
         ucx_ep = self.worker.ep_create(ip_address, port, endpoint_error_handling)
         self.worker.progress()
 
-        # We create the Endpoint in four steps:
+        # We create the Endpoint in three steps:
         #  1) Generate unique IDs to use as tags
         #  2) Exchange endpoint info such as tags
         #  3) Use the info to create an endpoint

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -11,9 +11,6 @@ import struct
 import weakref
 from functools import partial
 from os import close as close_fd
-from random import randint
-
-import psutil
 
 from . import comm
 from ._libs import ucx_api

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -284,23 +284,8 @@ class ApplicationContext:
             The new listener. When this object is deleted, the listening stops
         """
         self.continuous_ucx_progress()
-        if port in (None, 0):
-            # Get a random port number and check if it's not used yet. Doing this
-            # without relying on `socket` allows preventing UCX errors such as
-            # "none of the available transports can listen for connections", due
-            # to the socket still being in TIME_WAIT state.
-            try:
-                with open("/proc/sys/net/ipv4/ip_local_port_range") as f:
-                    start_port, end_port = [int(i) for i in next(f).split()]
-            except FileNotFoundError:
-                start_port, end_port = (32768, 60000)
-
-            used_ports = set(conn.laddr[1] for conn in psutil.net_connections())
-            while True:
-                port = randint(start_port, end_port)
-
-                if port not in used_ports:
-                    break
+        if port is None:
+            port = 0
 
         logger.info("create_listener() - Start listening on port %d" % port)
         ret = Listener(

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -462,8 +462,13 @@ class Listener:
         return not self._b.initialized
 
     @property
+    def ip(self):
+        """The listening network IP address"""
+        return self._b.ip
+
+    @property
     def port(self):
-        """The network point listening on"""
+        """The listening network port"""
         return self._b.port
 
     def close(self):


### PR DESCRIPTION
This will allow us to pass the responsibility of assigning a listener port to UCX when one isn't specified by the user, rather than doing so in UCX-Py.