### PR TITLE
Fix early closing of event_loop in test_shutdown

### DIFF
--- a/tests/test_rma.py
+++ b/tests/test_rma.py
@@ -13,7 +13,7 @@ def handle_exception(loop, context):
 
 # Let's make sure that UCX gets time to cancel
 # progress tasks before closing the event loop.
-@pytest.yield_fixture()
+@pytest.fixture()
 def event_loop(scope="function"):
     loop = asyncio.new_event_loop()
     loop.set_exception_handler(handle_exception)

--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -18,7 +18,7 @@ def handle_exception(loop, context):
 
 # Let's make sure that UCX gets time to cancel
 # progress tasks before closing the event loop.
-@pytest.yield_fixture()
+@pytest.fixture()
 def event_loop(scope="function"):
     loop = asyncio.new_event_loop()
     loop.set_exception_handler(handle_exception)

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -7,6 +7,24 @@ import pytest
 import ucp
 
 
+def handle_exception(loop, context):
+    msg = context.get("exception", context["message"])
+    print(msg)
+
+
+# Let's make sure that UCX gets time to cancel
+# progress tasks before closing the event loop.
+@pytest.yield_fixture()
+def event_loop(scope="function"):
+    loop = asyncio.new_event_loop()
+    loop.set_exception_handler(handle_exception)
+    ucp.reset()
+    yield loop
+    ucp.reset()
+    loop.run_until_complete(asyncio.sleep(0))
+    loop.close()
+
+
 async def shutdown(ep):
     await ep.close()
 

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -14,7 +14,7 @@ def handle_exception(loop, context):
 
 # Let's make sure that UCX gets time to cancel
 # progress tasks before closing the event loop.
-@pytest.yield_fixture()
+@pytest.fixture()
 def event_loop(scope="function"):
     loop = asyncio.new_event_loop()
     loop.set_exception_handler(handle_exception)


### PR DESCRIPTION
Fixes test file that could cause warnings such as:

```python
Task was destroyed but it is pending!
task: <Task pending name='Task-31' coro=<BlockingMode._arm_worker() running at ucp/continuous_ucx_progress.py:88>>
```

Fixes also some deprecation warnings on using `pytest.yield_fixture`.