### PR TITLE
Add support for UCX AM (Active Messages)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ ext_modules = cythonize(
             extra_compile_args=extra_compile_args,
         ),
     ],
-    compile_time_env={"CY_UCP_AM_SUPPORTED": _am_supported, },
+    compile_time_env={"CY_UCP_AM_SUPPORTED": _am_supported,},
 )
 
 cmdclass = dict()

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ from setuptools.extension import Extension
 import versioneer
 
 try:
-    from Cython.Distutils.build_ext import new_build_ext as build_ext
     from Cython.Build import cythonize
+    from Cython.Distutils.build_ext import new_build_ext as build_ext
 except ImportError:
     from setuptools.command.build_ext import build_ext
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ ext_modules = cythonize(
             extra_compile_args=extra_compile_args,
         ),
     ],
-    compile_time_env={"CY_UCP_AM_SUPPORTED": _am_supported,},
+    compile_time_env={"CY_UCP_AM_SUPPORTED": _am_supported},
 )
 
 cmdclass = dict()

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,7 @@ ext_modules = cythonize(
             extra_compile_args=extra_compile_args,
         ),
     ],
-    compile_time_env={
-        "CY_UCP_AM_SUPPORTED": _am_supported,
-    },
+    compile_time_env={"CY_UCP_AM_SUPPORTED": _am_supported,},
 )
 
 cmdclass = dict()

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ ext_modules = cythonize(
             extra_compile_args=extra_compile_args,
         ),
     ],
-    compile_time_env={"CY_UCP_AM_SUPPORTED": _am_supported,},
+    compile_time_env={"CY_UCP_AM_SUPPORTED": _am_supported, },
 )
 
 cmdclass = dict()

--- a/tests/test_send_recv_am.py
+++ b/tests/test_send_recv_am.py
@@ -44,7 +44,10 @@ def simple_server(size, recv):
 @pytest.mark.parametrize("recv_wait", [True, False])
 async def test_send_recv_bytes(size, blocking_progress_mode, recv_wait):
     rndv_thresh = 8192
-    ucp.init(options={"RNDV_THRESH": str(rndv_thresh)}, blocking_progress_mode=blocking_progress_mode)
+    ucp.init(
+        options={"RNDV_THRESH": str(rndv_thresh)},
+        blocking_progress_mode=blocking_progress_mode,
+    )
 
     msg = bytearray(b"m" * size)
 

--- a/tests/test_send_recv_am.py
+++ b/tests/test_send_recv_am.py
@@ -1,0 +1,49 @@
+import asyncio
+
+import pytest
+
+import ucp
+
+msg_sizes = [2 ** i for i in range(0, 25, 4)]
+
+
+def handle_exception(loop, context):
+    msg = context.get("exception", context["message"])
+    print("handle_exception: %s" % msg)
+
+
+# Let's make sure that UCX gets time to cancel
+# progress tasks before closing the event loop.
+@pytest.fixture()
+def event_loop(scope="function"):
+    loop = asyncio.new_event_loop()
+    loop.set_exception_handler(handle_exception)
+    ucp.reset()
+    yield loop
+    ucp.reset()
+    loop.run_until_complete(asyncio.sleep(0))
+    loop.close()
+
+
+def simple_server():
+    async def server(ep):
+        pass
+    return server
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", msg_sizes)
+@pytest.mark.parametrize("blocking_progress_mode", [True, False])
+async def test_send_recv_bytes(size, blocking_progress_mode):
+    ucp.init(blocking_progress_mode=blocking_progress_mode)
+
+    msg = bytearray(b"m" * size)
+
+    listener = ucp.create_listener(simple_server())
+    num_clients = 2
+    clients = [await ucp.create_endpoint(ucp.get_address(), listener.port) for i in range(num_clients)]
+    for c in clients:
+        await c.am_send(msg)
+    for c in clients:
+        await c.close()
+    listener.close()

--- a/tests/test_send_recv_am.py
+++ b/tests/test_send_recv_am.py
@@ -28,6 +28,7 @@ def event_loop(scope="function"):
 def simple_server():
     async def server(ep):
         pass
+
     return server
 
 
@@ -41,7 +42,10 @@ async def test_send_recv_bytes(size, blocking_progress_mode):
 
     listener = ucp.create_listener(simple_server())
     num_clients = 2
-    clients = [await ucp.create_endpoint(ucp.get_address(), listener.port) for i in range(num_clients)]
+    clients = [
+        await ucp.create_endpoint(ucp.get_address(), listener.port)
+        for i in range(num_clients)
+    ]
     for c in clients:
         await c.am_send(msg)
     for c in clients:

--- a/tests/test_send_recv_am.py
+++ b/tests/test_send_recv_am.py
@@ -32,6 +32,9 @@ def simple_server(size, recv):
     return server
 
 
+@pytest.mark.skipif(
+    not ucp.core.is_am_supported(), reason="AM only supported in UCX >= 1.11"
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("size", msg_sizes)
 @pytest.mark.parametrize("blocking_progress_mode", [True, False])

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -372,114 +372,115 @@ def _ucx_worker_handle_finalizer(
     ucp_worker_destroy(handle)
 
 
-cdef void _am_recv_completed_callback(
-    void *request,
-    ucs_status_t status,
-    size_t length,
-    void *user_data
-):
-    logger.debug(
-        "_am_recv_completed_callback status %d len %d buf %s" % (
-            status, length, hex(int(<uintptr_t>user_data))
-        )
-    )
-
-    assert user_data != NULL
-
-    if status != UCS_OK:
-        status_msg = ucs_status_string(status).decode("utf-8")
-        logger.info("AM RNDV receive failed with %d: %s" % (status, status_msg))
-
-    logger.debug("am rndv completed: buf %s" % (hex(int(<uintptr_t>user_data))))
-
-    ucp_request_free(request)
-
-
-cdef ucs_status_t _am_recv_callback(
-    void *arg,
-    const void *header,
-    size_t header_length,
-    void *data,
-    size_t length,
-    const ucp_am_recv_param_t *param
-):
-    cdef UCXWorker worker = <UCXWorker>arg
-    cdef dict am_recv_pool = worker._am_recv_pool
-    cdef dict am_recv_wait = worker._am_recv_wait
-    assert worker.initialized
-    assert param.recv_attr & UCP_AM_RECV_ATTR_FIELD_REPLY_EP
-    assert Feature.AM in worker._context._feature_flags
-
-    cdef ucp_ep_h ep = param.reply_ep
-    cdef unsigned long ep_as_int = int(<uintptr_t>ep)
-    if ep_as_int not in am_recv_pool:
-        am_recv_pool[ep_as_int] = list()
-
-    is_rndv = param.recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV
-
-    cdef bytearray buf = bytearray(length)
-    cdef char[:] buf_view = buf
-    cdef void *buf_ptr = <void *><uintptr_t>&buf_view[0]
-
-    cdef ucp_request_param_t request_param
-    cdef ucs_status_ptr_t status
-    cdef str ucx_status_msg, msg
-    cdef UCXRequest req
-    if is_rndv:
-        request_param.op_attr_mask = (
-            UCP_OP_ATTR_FIELD_CALLBACK |
-            UCP_OP_ATTR_FIELD_USER_DATA |
-            UCP_OP_ATTR_FLAG_NO_IMM_CMPL
-        )
-        request_param.cb.recv_am = (
-            <ucp_am_recv_data_nbx_callback_t>_am_recv_completed_callback
-        )
-        request_param.user_data = <void *>buf
-        status = ucp_am_recv_data_nbx(
-            worker._handle, data, buf_ptr, length, &request_param
-        )
-
-        logger.debug("am rndv: ep %s len %s" % (hex(int(ep_as_int)), length))
-
-        if UCS_PTR_IS_ERR(status):
-            ucx_status_msg = (
-                ucs_status_string(UCS_PTR_STATUS(status)).decode("utf-8")
+IF CY_UCP_AM_SUPPORTED:
+    cdef void _am_recv_completed_callback(
+        void *request,
+        ucs_status_t status,
+        size_t length,
+        void *user_data
+    ):
+        logger.debug(
+            "_am_recv_completed_callback status %d len %d buf %s" % (
+                status, length, hex(int(<uintptr_t>user_data))
             )
-            msg = "<_am_recv_callback>: %s" % (ucx_status_msg)
-            logger.info("_am_recv_callback error: %s" % msg)
-            am_recv_pool[ep_as_int].append(UCXError(msg))
-            return UCS_PTR_STATUS(status)
+        )
 
-        return UCS_OK
+        assert user_data != NULL
 
-    else:
-        logger.debug("am eager copying %d bytes with ep %s" % (
-            length,
-            hex(ep_as_int)
-        ))
-        memcpy(buf_ptr, data, length)
-        if (
-            am_recv_wait is not None and
-            ep_as_int in am_recv_wait and
-            len(am_recv_wait[ep_as_int]) > 0
-        ):
-            exception = None
+        if status != UCS_OK:
+            status_msg = ucs_status_string(status).decode("utf-8")
+            logger.info("AM RNDV receive failed with %d: %s" % (status, status_msg))
 
-            recv_wait = am_recv_wait[ep_as_int].pop(0)
-            cb_func = recv_wait["cb_func"]
-            cb_args = recv_wait["cb_args"]
-            cb_kwargs = recv_wait["cb_kwargs"]
+        logger.debug("am rndv completed: buf %s" % (hex(int(<uintptr_t>user_data))))
 
-            logger.debug("am eager awaiting in ep %s cb_func %s" % (
-                hex(ep_as_int),
-                cb_func
-            ))
+        ucp_request_free(request)
 
-            cb_func(buf, exception, *cb_args, **cb_kwargs)
+
+    cdef ucs_status_t _am_recv_callback(
+        void *arg,
+        const void *header,
+        size_t header_length,
+        void *data,
+        size_t length,
+        const ucp_am_recv_param_t *param
+    ):
+        cdef UCXWorker worker = <UCXWorker>arg
+        cdef dict am_recv_pool = worker._am_recv_pool
+        cdef dict am_recv_wait = worker._am_recv_wait
+        assert worker.initialized
+        assert param.recv_attr & UCP_AM_RECV_ATTR_FIELD_REPLY_EP
+        assert Feature.AM in worker._context._feature_flags
+
+        cdef ucp_ep_h ep = param.reply_ep
+        cdef unsigned long ep_as_int = int(<uintptr_t>ep)
+        if ep_as_int not in am_recv_pool:
+            am_recv_pool[ep_as_int] = list()
+
+        is_rndv = param.recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV
+
+        cdef bytearray buf = bytearray(length)
+        cdef char[:] buf_view = buf
+        cdef void *buf_ptr = <void *><uintptr_t>&buf_view[0]
+
+        cdef ucp_request_param_t request_param
+        cdef ucs_status_ptr_t status
+        cdef str ucx_status_msg, msg
+        cdef UCXRequest req
+        if is_rndv:
+            request_param.op_attr_mask = (
+                UCP_OP_ATTR_FIELD_CALLBACK |
+                UCP_OP_ATTR_FIELD_USER_DATA |
+                UCP_OP_ATTR_FLAG_NO_IMM_CMPL
+            )
+            request_param.cb.recv_am = (
+                <ucp_am_recv_data_nbx_callback_t>_am_recv_completed_callback
+            )
+            request_param.user_data = <void *>buf
+            status = ucp_am_recv_data_nbx(
+                worker._handle, data, buf_ptr, length, &request_param
+            )
+
+            logger.debug("am rndv: ep %s len %s" % (hex(int(ep_as_int)), length))
+
+            if UCS_PTR_IS_ERR(status):
+                ucx_status_msg = (
+                    ucs_status_string(UCS_PTR_STATUS(status)).decode("utf-8")
+                )
+                msg = "<_am_recv_callback>: %s" % (ucx_status_msg)
+                logger.info("_am_recv_callback error: %s" % msg)
+                am_recv_pool[ep_as_int].append(UCXError(msg))
+                return UCS_PTR_STATUS(status)
+
+            return UCS_OK
+
         else:
-            logger.debug("am eager pushing to pool in ep %s" % (hex(ep_as_int)))
-            am_recv_pool[ep_as_int].append(buf)
-        return UCS_OK
+            logger.debug("am eager copying %d bytes with ep %s" % (
+                length,
+                hex(ep_as_int)
+            ))
+            memcpy(buf_ptr, data, length)
+            if (
+                am_recv_wait is not None and
+                ep_as_int in am_recv_wait and
+                len(am_recv_wait[ep_as_int]) > 0
+            ):
+                exception = None
+
+                recv_wait = am_recv_wait[ep_as_int].pop(0)
+                cb_func = recv_wait["cb_func"]
+                cb_args = recv_wait["cb_args"]
+                cb_kwargs = recv_wait["cb_kwargs"]
+
+                logger.debug("am eager awaiting in ep %s cb_func %s" % (
+                    hex(ep_as_int),
+                    cb_func
+                ))
+
+                cb_func(buf, exception, *cb_args, **cb_kwargs)
+            else:
+                logger.debug("am eager pushing to pool in ep %s" % (hex(ep_as_int)))
+                am_recv_pool[ep_as_int].append(buf)
+            return UCS_OK
 
 
 cdef class UCXWorker(UCXObject):
@@ -488,14 +489,18 @@ cdef class UCXWorker(UCXObject):
         ucp_worker_h _handle
         UCXContext _context
         set _inflight_msgs
-        dict _am_recv_pool
-        dict _am_recv_wait
+        IF CY_UCP_AM_SUPPORTED:
+            dict _am_recv_pool
+            dict _am_recv_wait
 
     def __init__(self, UCXContext context):
         cdef ucp_params_t ucp_params
         cdef ucp_worker_params_t worker_params
         cdef ucs_status_t status
-        cdef ucp_am_handler_param_t am_handler_param
+
+        IF CY_UCP_AM_SUPPORTED:
+            cdef ucp_am_handler_param_t am_handler_param
+
         assert context.initialized
         self._context = context
         memset(&worker_params, 0, sizeof(worker_params))
@@ -505,19 +510,20 @@ cdef class UCXWorker(UCXObject):
         assert_ucs_status(status)
         self._inflight_msgs = set()
 
-        cdef int AM_MSG_ID = 0
-        if Feature.AM in context._feature_flags:
-            self._am_recv_pool = dict()
-            self._am_recv_wait = dict()
-            am_handler_param.field_mask = (
-                UCP_AM_HANDLER_PARAM_FIELD_ID |
-                UCP_AM_HANDLER_PARAM_FIELD_CB |
-                UCP_AM_HANDLER_PARAM_FIELD_ARG
-            )
-            am_handler_param.id = AM_MSG_ID
-            am_handler_param.cb = _am_recv_callback
-            am_handler_param.arg = <void *>self
-            status = ucp_worker_set_am_recv_handler(self._handle, &am_handler_param)
+        IF CY_UCP_AM_SUPPORTED:
+            cdef int AM_MSG_ID = 0
+            if Feature.AM in context._feature_flags:
+                self._am_recv_pool = dict()
+                self._am_recv_wait = dict()
+                am_handler_param.field_mask = (
+                    UCP_AM_HANDLER_PARAM_FIELD_ID |
+                    UCP_AM_HANDLER_PARAM_FIELD_CB |
+                    UCP_AM_HANDLER_PARAM_FIELD_ARG
+                )
+                am_handler_param.id = AM_MSG_ID
+                am_handler_param.cb = _am_recv_callback
+                am_handler_param.arg = <void *>self
+                status = ucp_worker_set_am_recv_handler(self._handle, &am_handler_param)
 
         self.add_handle_finalizer(
             _ucx_worker_handle_finalizer,
@@ -1572,209 +1578,210 @@ def stream_recv_nb(
     )
 
 
-cdef void _send_nbx_callback(void *request, ucs_status_t status, void *user_data):
-    cdef UCXRequest req
-    cdef dict req_info
-    cdef str name, ucx_status_msg, msg
-    cdef set inflight_msgs
-    cdef tuple cb_args
-    cdef dict cb_kwargs
-    with log_errors():
-        req = UCXRequest(<uintptr_t><void*> request)
-        assert not req.closed()
-        req_info = <dict>req._handle.info
-        req_info["status"] = "finished"
+IF CY_UCP_AM_SUPPORTED:
+    cdef void _send_nbx_callback(void *request, ucs_status_t status, void *user_data):
+        cdef UCXRequest req
+        cdef dict req_info
+        cdef str name, ucx_status_msg, msg
+        cdef set inflight_msgs
+        cdef tuple cb_args
+        cdef dict cb_kwargs
+        with log_errors():
+            req = UCXRequest(<uintptr_t><void*> request)
+            assert not req.closed()
+            req_info = <dict>req._handle.info
+            req_info["status"] = "finished"
 
-        if "cb_func" not in req_info:
-            # This callback function was called before ucp_tag_send_nb() returned
-            return
+            if "cb_func" not in req_info:
+                # This callback function was called before ucp_tag_send_nb() returned
+                return
 
-        exception = None
-        if status == UCS_ERR_CANCELED:
-            name = req_info["name"]
-            msg = "<%s>: " % name
-            exception = UCXCanceled(msg)
-        elif status != UCS_OK:
-            name = req_info["name"]
-            ucx_status_msg = ucs_status_string(status).decode("utf-8")
-            msg = "<%s>: %s" % (name, ucx_status_msg)
-            exception = UCXError(msg)
-        try:
-            inflight_msgs = req_info["inflight_msgs"]
-            inflight_msgs.discard(req)
-            cb_func = req_info["cb_func"]
-            if cb_func is not None:
-                cb_args = req_info["cb_args"]
-                if cb_args is None:
-                    cb_args = ()
-                cb_kwargs = req_info["cb_kwargs"]
-                if cb_kwargs is None:
-                    cb_kwargs = {}
-                cb_func(req, exception, *cb_args, **cb_kwargs)
-        finally:
-            req.close()
-
-
-def am_send_nbx(
-    UCXEndpoint ep,
-    Array buffer,
-    size_t nbytes,
-    cb_func,
-    tuple cb_args=None,
-    dict cb_kwargs=None,
-    str name=None
-):
-    """ This routine sends a message to a destination endpoint
-
-    Each message is associated with a tag value that is used for message matching
-    on the receiver. The routine is non-blocking and therefore returns immediately,
-    however the actual send operation may be delayed. The send operation is
-    considered completed when it is safe to reuse the source buffer. If the send
-    operation is completed immediately the routine return None and the call-back
-    function **is not invoked**. If the operation is not completed immediately
-    and no exception raised then the UCP library will schedule to invoke the call-back
-    whenever the send operation will be completed. In other words, the completion
-    of a message can be signaled by the return code or the call-back.
-
-    Note
-    ----
-    The user should not modify any part of the buffer after this operation is called,
-    until the operation completes.
-
-    Parameters
-    ----------
-    ep: UCXEndpoint
-        The destination endpoint
-    buffer: Array
-        An ``Array`` wrapping a user-provided array-like object
-    nbytes: int
-        Size of the buffer to use. Must be equal or less than the size of buffer
-    cb_func: callable
-        The call-back function, which must accept `request` and `exception` as the
-        first two arguments.
-    cb_args: tuple, optional
-        Extra arguments to the call-back function
-    cb_kwargs: dict, optional
-        Extra keyword arguments to the call-back function
-    name: str, optional
-        Descriptive name of the operation
-    """
-    if cb_args is None:
-        cb_args = ()
-    if cb_kwargs is None:
-        cb_kwargs = {}
-    if name is None:
-        name = "am_send_nb"
-    if Feature.AM not in ep.worker._context._feature_flags:
-        raise ValueError("UCXContext must be created with `Feature.AM`")
-    if buffer.cuda and not ep.worker._context.cuda_support:
-        raise ValueError(
-            "UCX is not configured with CUDA support, please add "
-            "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment"
-            "variable and that the ucx-proc=*=gpu package is "
-            "installed. See "
-            "https://ucx-py.readthedocs.io/en/latest/install.html for "
-            "more information."
-        )
-    if not buffer._contiguous():
-        raise ValueError("Array must be C or F contiguous")
-
-    cdef ucp_request_param_t params
-    params.op_attr_mask = (
-        UCP_OP_ATTR_FIELD_CALLBACK |
-        UCP_OP_ATTR_FIELD_USER_DATA |
-        UCP_OP_ATTR_FIELD_FLAGS
-    )
-    params.cb.send = <ucp_send_nbx_callback_t>_send_nbx_callback
-    params.flags = UCP_AM_SEND_FLAG_REPLY
-    params.user_data = <void*>buffer.ptr
-
-    cdef ucs_status_ptr_t status = ucp_am_send_nbx(
-        ep._handle,
-        0,
-        NULL,
-        0,
-        <void*>buffer.ptr,
-        nbytes,
-        &params,
-    )
-    return _handle_status(
-        status, nbytes, cb_func, cb_args, cb_kwargs, name, ep._inflight_msgs
-    )
+            exception = None
+            if status == UCS_ERR_CANCELED:
+                name = req_info["name"]
+                msg = "<%s>: " % name
+                exception = UCXCanceled(msg)
+            elif status != UCS_OK:
+                name = req_info["name"]
+                ucx_status_msg = ucs_status_string(status).decode("utf-8")
+                msg = "<%s>: %s" % (name, ucx_status_msg)
+                exception = UCXError(msg)
+            try:
+                inflight_msgs = req_info["inflight_msgs"]
+                inflight_msgs.discard(req)
+                cb_func = req_info["cb_func"]
+                if cb_func is not None:
+                    cb_args = req_info["cb_args"]
+                    if cb_args is None:
+                        cb_args = ()
+                    cb_kwargs = req_info["cb_kwargs"]
+                    if cb_kwargs is None:
+                        cb_kwargs = {}
+                    cb_func(req, exception, *cb_args, **cb_kwargs)
+            finally:
+                req.close()
 
 
-def am_recv_nb(
-    UCXEndpoint ep,
-    cb_func,
-    tuple cb_args=None,
-    dict cb_kwargs=None,
-    str name=None,
-):
-    """ This routine receives a message on a worker with the active message API.
-
-    The routine is a non-blocking and therefore returns immediately. The receive
-    operation is considered completed when the message is delivered to the buffer.
-    If there is a pending received buffer for the endpoint, the call will return
-    immediately with `True`. Otherwise, in order to notify the application about
-    completion of the receive operation the UCP library will invoke the call-back
-    function when the received message is in the receive buffer and ready for
-    application access. If the receive operation cannot be stated the routine
-    raise an exception.
-
-    Note
-    ----
-    This routine cannot return None. It always returns `True`, a request handle or
-    raises an exception.
-
-    Parameters
-    ----------
-    worker: UCXWorker
-        The worker that is used for the receive operation
-    ep: UCXEndpoint
-        The endpoint that is used for the receive operation. Received active
-        messages are always targeted at a specific endpoint, therefore it
-        s imperative to specify the correct one here.
-    cb_func: callable
-        The call-back function, which must accept `request` and `exception` as the
-        first two arguments.
-    cb_args: tuple, optional
-        Extra arguments to the call-back function
-    cb_kwargs: dict, optional
-        Extra keyword arguments to the call-back function
-    name: str, optional
-        Descriptive name of the operation
-    """
-    worker = ep.worker
-
-    if cb_args is None:
-        cb_args = ()
-    if cb_kwargs is None:
-        cb_kwargs = {}
-    if name is None:
-        name = "am_recv_nb"
-    if Feature.AM not in worker._context._feature_flags:
-        raise ValueError("UCXContext must be created with `Feature.AM`")
-    cdef bint cuda_support
-
-    am_recv_pool = worker._am_recv_pool
-    ep_as_int = int(<uintptr_t>ep._handle)
-    if (
-        am_recv_pool is not None and
-        ep_as_int in am_recv_pool and
-        len(am_recv_pool[ep_as_int]) > 0
+    def am_send_nbx(
+        UCXEndpoint ep,
+        Array buffer,
+        size_t nbytes,
+        cb_func,
+        tuple cb_args=None,
+        dict cb_kwargs=None,
+        str name=None
     ):
-        recv_obj = am_recv_pool[ep_as_int].pop(0)
-        exception = recv_obj if issubclass(type(recv_obj), (Exception, )) else None
-        cb_func(recv_obj, exception, *cb_args, **cb_kwargs)
-        logger.debug("AM recv ready: ep %s" % (hex(ep_as_int), ))
-    else:
-        if ep_as_int not in worker._am_recv_wait:
-            worker._am_recv_wait[ep_as_int] = list()
-        worker._am_recv_wait[ep_as_int].append(
-            {
-                "cb_func": cb_func,
-                "cb_args": cb_args,
-                "cb_kwargs": cb_kwargs
-            }
+        """ This routine sends a message to a destination endpoint
+
+        Each message is associated with a tag value that is used for message matching
+        on the receiver. The routine is non-blocking and therefore returns immediately,
+        however the actual send operation may be delayed. The send operation is
+        considered completed when it is safe to reuse the source buffer. If the send
+        operation is completed immediately the routine return None and the call-back
+        function **is not invoked**. If the operation is not completed immediately
+        and no exception raised then the UCP library will schedule to invoke the call-back
+        whenever the send operation will be completed. In other words, the completion
+        of a message can be signaled by the return code or the call-back.
+
+        Note
+        ----
+        The user should not modify any part of the buffer after this operation is called,
+        until the operation completes.
+
+        Parameters
+        ----------
+        ep: UCXEndpoint
+            The destination endpoint
+        buffer: Array
+            An ``Array`` wrapping a user-provided array-like object
+        nbytes: int
+            Size of the buffer to use. Must be equal or less than the size of buffer
+        cb_func: callable
+            The call-back function, which must accept `request` and `exception` as the
+            first two arguments.
+        cb_args: tuple, optional
+            Extra arguments to the call-back function
+        cb_kwargs: dict, optional
+            Extra keyword arguments to the call-back function
+        name: str, optional
+            Descriptive name of the operation
+        """
+        if cb_args is None:
+            cb_args = ()
+        if cb_kwargs is None:
+            cb_kwargs = {}
+        if name is None:
+            name = "am_send_nb"
+        if Feature.AM not in ep.worker._context._feature_flags:
+            raise ValueError("UCXContext must be created with `Feature.AM`")
+        if buffer.cuda and not ep.worker._context.cuda_support:
+            raise ValueError(
+                "UCX is not configured with CUDA support, please add "
+                "`cuda_copy` and/or `cuda_ipc` to the UCX_TLS environment"
+                "variable and that the ucx-proc=*=gpu package is "
+                "installed. See "
+                "https://ucx-py.readthedocs.io/en/latest/install.html for "
+                "more information."
+            )
+        if not buffer._contiguous():
+            raise ValueError("Array must be C or F contiguous")
+
+        cdef ucp_request_param_t params
+        params.op_attr_mask = (
+            UCP_OP_ATTR_FIELD_CALLBACK |
+            UCP_OP_ATTR_FIELD_USER_DATA |
+            UCP_OP_ATTR_FIELD_FLAGS
         )
-        logger.debug("AM recv waiting: ep %s" % (hex(ep_as_int), ))
+        params.cb.send = <ucp_send_nbx_callback_t>_send_nbx_callback
+        params.flags = UCP_AM_SEND_FLAG_REPLY
+        params.user_data = <void*>buffer.ptr
+
+        cdef ucs_status_ptr_t status = ucp_am_send_nbx(
+            ep._handle,
+            0,
+            NULL,
+            0,
+            <void*>buffer.ptr,
+            nbytes,
+            &params,
+        )
+        return _handle_status(
+            status, nbytes, cb_func, cb_args, cb_kwargs, name, ep._inflight_msgs
+        )
+
+
+    def am_recv_nb(
+        UCXEndpoint ep,
+        cb_func,
+        tuple cb_args=None,
+        dict cb_kwargs=None,
+        str name=None,
+    ):
+        """ This routine receives a message on a worker with the active message API.
+
+        The routine is a non-blocking and therefore returns immediately. The receive
+        operation is considered completed when the message is delivered to the buffer.
+        If there is a pending received buffer for the endpoint, the call will return
+        immediately with `True`. Otherwise, in order to notify the application about
+        completion of the receive operation the UCP library will invoke the call-back
+        function when the received message is in the receive buffer and ready for
+        application access. If the receive operation cannot be stated the routine
+        raise an exception.
+
+        Note
+        ----
+        This routine cannot return None. It always returns `True`, a request handle or
+        raises an exception.
+
+        Parameters
+        ----------
+        worker: UCXWorker
+            The worker that is used for the receive operation
+        ep: UCXEndpoint
+            The endpoint that is used for the receive operation. Received active
+            messages are always targeted at a specific endpoint, therefore it
+            s imperative to specify the correct one here.
+        cb_func: callable
+            The call-back function, which must accept `request` and `exception` as the
+            first two arguments.
+        cb_args: tuple, optional
+            Extra arguments to the call-back function
+        cb_kwargs: dict, optional
+            Extra keyword arguments to the call-back function
+        name: str, optional
+            Descriptive name of the operation
+        """
+        worker = ep.worker
+
+        if cb_args is None:
+            cb_args = ()
+        if cb_kwargs is None:
+            cb_kwargs = {}
+        if name is None:
+            name = "am_recv_nb"
+        if Feature.AM not in worker._context._feature_flags:
+            raise ValueError("UCXContext must be created with `Feature.AM`")
+        cdef bint cuda_support
+
+        am_recv_pool = worker._am_recv_pool
+        ep_as_int = int(<uintptr_t>ep._handle)
+        if (
+            am_recv_pool is not None and
+            ep_as_int in am_recv_pool and
+            len(am_recv_pool[ep_as_int]) > 0
+        ):
+            recv_obj = am_recv_pool[ep_as_int].pop(0)
+            exception = recv_obj if issubclass(type(recv_obj), (Exception, )) else None
+            cb_func(recv_obj, exception, *cb_args, **cb_kwargs)
+            logger.debug("AM recv ready: ep %s" % (hex(ep_as_int), ))
+        else:
+            if ep_as_int not in worker._am_recv_wait:
+                worker._am_recv_wait[ep_as_int] = list()
+            worker._am_recv_wait[ep_as_int].append(
+                {
+                    "cb_func": cb_func,
+                    "cb_args": cb_args,
+                    "cb_kwargs": cb_kwargs
+                }
+            )
+            logger.debug("AM recv waiting: ep %s" % (hex(ep_as_int), ))

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -402,7 +402,6 @@ IF CY_UCP_AM_SUPPORTED:
 
         def _push_result(buf, exception, recv_type):
             if (
-                am_recv_wait is not None and
                 ep_as_int in am_recv_wait and
                 len(am_recv_wait[ep_as_int]) > 0
             ):
@@ -1720,7 +1719,6 @@ def am_recv_nb(
         am_recv_pool = worker._am_recv_pool
         ep_as_int = int(<uintptr_t>ep._handle)
         if (
-            am_recv_pool is not None and
             ep_as_int in am_recv_pool and
             len(am_recv_pool[ep_as_int]) > 0
         ):

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -1606,50 +1606,52 @@ IF CY_UCP_AM_SUPPORTED:
             finally:
                 req.close()
 
-    def am_send_nbx(
-        UCXEndpoint ep,
-        Array buffer,
-        size_t nbytes,
-        cb_func,
-        tuple cb_args=None,
-        dict cb_kwargs=None,
-        str name=None
-    ):
-        """ This routine sends a message to an endpoint using the active message API
 
-        Each message is sent to an endpoint that is the message's sole recipient.
-        The routine is non-blocking and therefore returns immediately, however the
-        actual send operation may be delayed. The send operation is considered
-        completed when it is safe to reuse the source buffer. If the send operation
-        is completed immediately the routine returns None and the call-back function
-        **is not invoked**. If the operation is not completed immediately and no
-        exception raised then the UCP library will schedule to invoke the call-back
-        whenever the send operation will be completed. In other words, the completion
-        of a message can be signaled by the return code or the call-back.
+def am_send_nbx(
+    UCXEndpoint ep,
+    Array buffer,
+    size_t nbytes,
+    cb_func,
+    tuple cb_args=None,
+    dict cb_kwargs=None,
+    str name=None
+):
+    """ This routine sends a message to an endpoint using the active message API
 
-        Note
-        ----
-        The user should not modify any part of the buffer after this operation is
-        called, until the operation completes.
+    Each message is sent to an endpoint that is the message's sole recipient.
+    The routine is non-blocking and therefore returns immediately, however the
+    actual send operation may be delayed. The send operation is considered
+    completed when it is safe to reuse the source buffer. If the send operation
+    is completed immediately the routine returns None and the call-back function
+    **is not invoked**. If the operation is not completed immediately and no
+    exception raised then the UCP library will schedule to invoke the call-back
+    whenever the send operation will be completed. In other words, the completion
+    of a message can be signaled by the return code or the call-back.
 
-        Parameters
-        ----------
-        ep: UCXEndpoint
-            The destination endpoint
-        buffer: Array
-            An ``Array`` wrapping a user-provided array-like object
-        nbytes: int
-            Size of the buffer to use. Must be equal or less than the size of buffer
-        cb_func: callable
-            The call-back function, which must accept `request` and `exception` as the
-            first two arguments.
-        cb_args: tuple, optional
-            Extra arguments to the call-back function
-        cb_kwargs: dict, optional
-            Extra keyword arguments to the call-back function
-        name: str, optional
-            Descriptive name of the operation
-        """
+    Note
+    ----
+    The user should not modify any part of the buffer after this operation is
+    called, until the operation completes.
+
+    Parameters
+    ----------
+    ep: UCXEndpoint
+        The destination endpoint
+    buffer: Array
+        An ``Array`` wrapping a user-provided array-like object
+    nbytes: int
+        Size of the buffer to use. Must be equal or less than the size of buffer
+    cb_func: callable
+        The call-back function, which must accept `request` and `exception` as the
+        first two arguments.
+    cb_args: tuple, optional
+        Extra arguments to the call-back function
+    cb_kwargs: dict, optional
+        Extra keyword arguments to the call-back function
+    name: str, optional
+        Descriptive name of the operation
+    """
+    IF CY_UCP_AM_SUPPORTED:
         if cb_args is None:
             cb_args = ()
         if cb_kwargs is None:
@@ -1692,34 +1694,39 @@ IF CY_UCP_AM_SUPPORTED:
         return _handle_status(
             status, nbytes, cb_func, cb_args, cb_kwargs, name, ep._inflight_msgs
         )
+    ELSE:
+        raise RuntimeError("UCX-Py needs to be built against and running with "
+                           "UCX >= 1.11 to support am_send_nbx.")
 
-    def am_recv_nb(
-        UCXEndpoint ep,
-        cb_func,
-        tuple cb_args=None,
-        dict cb_kwargs=None,
-        str name=None,
-    ):
-        """ This routine receives a message on a worker with the active message API.
 
-        TODO
+def am_recv_nb(
+    UCXEndpoint ep,
+    cb_func,
+    tuple cb_args=None,
+    dict cb_kwargs=None,
+    str name=None,
+):
+    """ This routine receives a message on a worker with the active message API.
 
-        Parameters
-        ----------
-        ep: UCXEndpoint
-            The endpoint that is used for the receive operation. Received active
-            messages are always targeted at a specific endpoint, therefore it is
-            imperative to specify the correct one here.
-        cb_func: callable
-            The call-back function, which must accept `request` and `exception` as the
-            first two arguments.
-        cb_args: tuple, optional
-            Extra arguments to the call-back function
-        cb_kwargs: dict, optional
-            Extra keyword arguments to the call-back function
-        name: str, optional
-            Descriptive name of the operation
-        """
+    TODO
+
+    Parameters
+    ----------
+    ep: UCXEndpoint
+        The endpoint that is used for the receive operation. Received active
+        messages are always targeted at a specific endpoint, therefore it is
+        imperative to specify the correct one here.
+    cb_func: callable
+        The call-back function, which must accept `request` and `exception` as the
+        first two arguments.
+    cb_args: tuple, optional
+        Extra arguments to the call-back function
+    cb_kwargs: dict, optional
+        Extra keyword arguments to the call-back function
+    name: str, optional
+        Descriptive name of the operation
+    """
+    IF CY_UCP_AM_SUPPORTED:
         worker = ep.worker
 
         if cb_args is None:
@@ -1754,3 +1761,6 @@ IF CY_UCP_AM_SUPPORTED:
                 }
             )
             logger.debug("AM recv waiting: ep %s" % (hex(ep_as_int), ))
+    ELSE:
+        raise RuntimeError("UCX-Py needs to be built against and running with "
+                           "UCX >= 1.11 to support am_recv_nb.")

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -477,6 +477,7 @@ cdef class UCXWorker(UCXObject):
 
         cdef int AM_MSG_ID = 0
         if Feature.AM in context._feature_flags:
+            self._am_msgs = {}
             am_handler_param.field_mask = (
                 UCP_AM_HANDLER_PARAM_FIELD_ID |
                 UCP_AM_HANDLER_PARAM_FIELD_CB |

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -1723,7 +1723,7 @@ def am_recv_nb(
             len(am_recv_pool[ep_as_int]) > 0
         ):
             recv_obj = am_recv_pool[ep_as_int].pop(0)
-            exception = recv_obj if issubclass(type(recv_obj), (Exception, )) else None
+            exception = recv_obj if isinstance(type(recv_obj), (Exception, )) else None
             cb_func(recv_obj, exception, *cb_args, **cb_kwargs)
             logger.debug("AM recv ready: ep %s" % (hex(ep_as_int), ))
         else:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -484,7 +484,10 @@ cdef ucs_status_t _am_recv_callback(
 
             cb_func(req, exception, *cb_args, **cb_kwargs)
         else:
-            logger.debug("am eager copying %d bytes with ep %s" % (hex(ep_as_int), ))
+            logger.debug("am eager copying %d bytes with ep %s" % (
+                length,
+                hex(ep_as_int)
+            ))
             memcpy(buf_ptr, data, length)
             am_msgs[ep_as_int].append(buf)
         return UCS_OK
@@ -1794,9 +1797,8 @@ def am_recv_nb(
         recv_obj = am_msgs[ep_as_int].pop(0)
         req = None
         exception = recv_obj if issubclass(type(recv_obj), (Exception, )) else None
-        logger.debug("AM recv ready: ep %s exception %s" % (hex(ep_as_int), exception))
         cb_func(req, exception, *cb_args, **cb_kwargs)
-        logger.debug("AM recv ready: ep %s buf %s" % (hex(ep_as_int), recv_obj))
+        logger.debug("AM recv ready: ep %s" % (hex(ep_as_int), ))
         return
     else:
         if ep_as_int not in worker._am_recv_wait:

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -429,9 +429,13 @@ cdef ucs_status_t _am_recv_callback(
             UCP_OP_ATTR_FIELD_USER_DATA |
             UCP_OP_ATTR_FLAG_NO_IMM_CMPL
         )
-        request_param.cb.recv_am = <ucp_am_recv_data_nbx_callback_t>_am_recv_completed_callback
+        request_param.cb.recv_am = (
+            <ucp_am_recv_data_nbx_callback_t>_am_recv_completed_callback
+        )
         request_param.user_data = <void *>buf
-        status = ucp_am_recv_data_nbx(worker._handle, data, buf_ptr, length, &request_param)
+        status = ucp_am_recv_data_nbx(
+            worker._handle, data, buf_ptr, length, &request_param
+        )
 
         if UCS_PTR_IS_ERR(status):
             ucx_status_msg = (

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -1615,17 +1615,17 @@ IF CY_UCP_AM_SUPPORTED:
         dict cb_kwargs=None,
         str name=None
     ):
-        """ This routine sends a message to a destination endpoint
+        """ This routine sends a message to an endpoint using the active message API
 
-        Each message is associated with a tag value that is used for message matching
-        on the receiver. The routine is non-blocking and therefore returns immediately,
-        however the actual send operation may be delayed. The send operation is
-        considered completed when it is safe to reuse the source buffer. If the send
-        operation is completed immediately the routine return None and the call-back
-        function **is not invoked**. If the operation is not completed immediately
-        and no exception raised then the UCP library will schedule to invoke the
-        call-back whenever the send operation will be completed. In other words, the
-        completion of a message can be signaled by the return code or the call-back.
+        Each message is sent to an endpoint that is the message's sole recipient.
+        The routine is non-blocking and therefore returns immediately, however the
+        actual send operation may be delayed. The send operation is considered
+        completed when it is safe to reuse the source buffer. If the send operation
+        is completed immediately the routine returns None and the call-back function
+        **is not invoked**. If the operation is not completed immediately and no
+        exception raised then the UCP library will schedule to invoke the call-back
+        whenever the send operation will be completed. In other words, the completion
+        of a message can be signaled by the return code or the call-back.
 
         Note
         ----
@@ -1702,28 +1702,14 @@ IF CY_UCP_AM_SUPPORTED:
     ):
         """ This routine receives a message on a worker with the active message API.
 
-        The routine is a non-blocking and therefore returns immediately. The receive
-        operation is considered completed when the message is delivered to the buffer.
-        If there is a pending received buffer for the endpoint, the call will return
-        immediately with `True`. Otherwise, in order to notify the application about
-        completion of the receive operation the UCP library will invoke the call-back
-        function when the received message is in the receive buffer and ready for
-        application access. If the receive operation cannot be stated the routine
-        raise an exception.
-
-        Note
-        ----
-        This routine cannot return None. It always returns `True`, a request handle or
-        raises an exception.
+        TODO
 
         Parameters
         ----------
-        worker: UCXWorker
-            The worker that is used for the receive operation
         ep: UCXEndpoint
             The endpoint that is used for the receive operation. Received active
-            messages are always targeted at a specific endpoint, therefore it
-            s imperative to specify the correct one here.
+            messages are always targeted at a specific endpoint, therefore it is
+            imperative to specify the correct one here.
         cb_func: callable
             The call-back function, which must accept `request` and `exception` as the
             first two arguments.

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -373,28 +373,6 @@ def _ucx_worker_handle_finalizer(
 
 
 IF CY_UCP_AM_SUPPORTED:
-    cdef void _am_recv_completed_callback(
-        void *request,
-        ucs_status_t status,
-        size_t length,
-        void *user_data
-    ):
-        logger.debug(
-            "_am_recv_completed_callback status %d len %d buf %s" % (
-                status, length, hex(int(<uintptr_t>user_data))
-            )
-        )
-
-        assert user_data != NULL
-
-        if status != UCS_OK:
-            status_msg = ucs_status_string(status).decode("utf-8")
-            logger.info("AM RNDV receive failed with %d: %s" % (status, status_msg))
-
-        logger.debug("am rndv completed: buf %s" % (hex(int(<uintptr_t>user_data))))
-
-        ucp_request_free(request)
-
     cdef ucs_status_t _am_recv_callback(
         void *arg,
         const void *header,

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -395,7 +395,6 @@ IF CY_UCP_AM_SUPPORTED:
 
         ucp_request_free(request)
 
-
     cdef ucs_status_t _am_recv_callback(
         void *arg,
         const void *header,
@@ -442,7 +441,10 @@ IF CY_UCP_AM_SUPPORTED:
 
                 cb_func(buf, exception, *cb_args, **cb_kwargs)
             else:
-                logger.debug("am %s pushing to pool in ep %s" % (recv_type, hex(ep_as_int)))
+                logger.debug("am %s pushing to pool in ep %s" % (
+                    recv_type,
+                    hex(ep_as_int)
+                ))
                 if exception is not None:
                     am_recv_pool[ep_as_int].append(exception)
                 else:
@@ -1604,7 +1606,6 @@ IF CY_UCP_AM_SUPPORTED:
             finally:
                 req.close()
 
-
     def am_send_nbx(
         UCXEndpoint ep,
         Array buffer,
@@ -1622,14 +1623,14 @@ IF CY_UCP_AM_SUPPORTED:
         considered completed when it is safe to reuse the source buffer. If the send
         operation is completed immediately the routine return None and the call-back
         function **is not invoked**. If the operation is not completed immediately
-        and no exception raised then the UCP library will schedule to invoke the call-back
-        whenever the send operation will be completed. In other words, the completion
-        of a message can be signaled by the return code or the call-back.
+        and no exception raised then the UCP library will schedule to invoke the
+        call-back whenever the send operation will be completed. In other words, the
+        completion of a message can be signaled by the return code or the call-back.
 
         Note
         ----
-        The user should not modify any part of the buffer after this operation is called,
-        until the operation completes.
+        The user should not modify any part of the buffer after this operation is
+        called, until the operation completes.
 
         Parameters
         ----------
@@ -1691,7 +1692,6 @@ IF CY_UCP_AM_SUPPORTED:
         return _handle_status(
             status, nbytes, cb_func, cb_args, cb_kwargs, name, ep._inflight_msgs
         )
-
 
     def am_recv_nb(
         UCXEndpoint ep,

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -35,6 +35,17 @@ cdef extern from "src/c_util.h":
                                          size_t max_size)
 
 
+cdef extern from "ucs/memory/memory_type.h":
+    cdef enum ucs_memory_type_t:
+        UCS_MEMORY_TYPE_HOST
+        UCS_MEMORY_TYPE_CUDA
+        UCS_MEMORY_TYPE_CUDA_MANAGED
+        UCS_MEMORY_TYPE_ROCM
+        UCS_MEMORY_TYPE_ROCM_MANAGED
+        UCS_MEMORY_TYPE_LAST
+        UCS_MEMORY_TYPE_UNKNOWN = UCS_MEMORY_TYPE_LAST
+
+
 cdef extern from "ucp/api/ucp.h":
     ctypedef struct ucp_context:
         pass
@@ -292,6 +303,97 @@ cdef extern from "ucp/api/ucp.h":
     ucs_status_ptr_t ucp_ep_flush_nb(ucp_ep_h ep,
                                      unsigned flags,
                                      ucp_send_callback_t cb)
+
+    unsigned UCP_AM_SEND_FLAG_REPLY
+    unsigned UCP_AM_SEND_FLAG_EAGER
+    unsigned UCP_AM_SEND_FLAG_RNDV
+
+    unsigned UCP_AM_RECV_ATTR_FIELD_REPLY_EP
+    unsigned UCP_AM_RECV_ATTR_FIELD_TOTAL_LENGTH
+    unsigned UCP_AM_RECV_ATTR_FIELD_FRAG_OFFSET
+    unsigned UCP_AM_RECV_ATTR_FIELD_MSG_CONTEXT
+    unsigned UCP_AM_RECV_ATTR_FLAG_DATA
+    unsigned UCP_AM_RECV_ATTR_FLAG_RNDV
+    unsigned UCP_AM_RECV_ATTR_FLAG_FIRST
+    unsigned UCP_AM_RECV_ATTR_FLAG_ONLY
+
+    unsigned UCP_AM_HANDLER_PARAM_FIELD_ID
+    unsigned UCP_AM_HANDLER_PARAM_FIELD_FLAGS
+    unsigned UCP_AM_HANDLER_PARAM_FIELD_CB
+    unsigned UCP_AM_HANDLER_PARAM_FIELD_ARG
+
+    ctypedef ucs_status_t(*ucp_am_recv_data_nbx_callback_t)(void *request,
+                                                            ucs_status_t status,
+                                                            size_t length, void *used_data)
+
+    ctypedef union _ucp_request_param_cb_t:
+        ucp_send_nbx_callback_t send
+        # ucp_tag_recv_nbx_callback_t recv
+        # ucp_stream_recv_nbx_callback_t recv_stream
+        ucp_am_recv_data_nbx_callback_t recv_am
+
+    ctypedef union _ucp_request_param_recv_info_t:
+        size_t *length
+        # ucp_tag_recv_info_t *tag_info
+
+    ctypedef void (*ucp_send_nbx_callback_t)(void *request, ucs_status_t status,
+                                             void *user_data)  # noqa
+
+    ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
+                                     const void *header, size_t header_length,
+                                     const void *buffer, size_t count,
+                                     const ucp_request_param_t *param)
+
+    ucs_status_ptr_t ucp_am_recv_data_nbx(ucp_worker_h worker, void *data_desc,
+                                          void *buffer, size_t count,
+                                          const ucp_request_param_t *param)
+
+    int UCP_OP_ATTR_FIELD_REQUEST
+    int UCP_OP_ATTR_FIELD_CALLBACK
+    int UCP_OP_ATTR_FIELD_USER_DATA
+    int UCP_OP_ATTR_FIELD_DATATYPE
+    int UCP_OP_ATTR_FIELD_FLAGS
+    int UCP_OP_ATTR_FIELD_REPLY_BUFFER
+    int UCP_OP_ATTR_FIELD_MEMORY_TYPE
+    int UCP_OP_ATTR_FIELD_RECV_INFO
+
+    int UCP_OP_ATTR_FLAG_NO_IMM_CMPL
+    int UCP_OP_ATTR_FLAG_FAST_CMPL
+    int UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL
+
+    ctypedef struct ucp_request_param_t:
+        uint32_t op_attr_mask
+        uint32_t flags
+        void *request
+        _ucp_request_param_cb_t cb
+        ucp_datatype_t datatype
+        void *user_data
+        void *reply_buffer
+        ucs_memory_type_t memory_type
+        _ucp_request_param_recv_info_t recv_info
+
+
+    ctypedef struct ucp_am_recv_param_t:
+        uint64_t recv_attr
+        ucp_ep_h reply_ep
+        size_t total_length
+        size_t frag_offset
+        void **msg_context
+
+    ctypedef ucs_status_t(*ucp_am_recv_callback_t)(void *arg, const void *header,
+                                                   size_t header_length,
+                                                   void *data, size_t length,
+                                                   const ucp_am_recv_param_t *param)
+
+    ctypedef struct ucp_am_handler_param_t:
+        uint64_t field_mask
+        unsigned id
+        uint32_t flags
+        ucp_am_recv_callback_t cb
+        void *arg
+
+    ucs_status_t ucp_worker_set_am_recv_handler(ucp_worker_h worker,
+                                                 const ucp_am_handler_param_t *param)
 
 cdef extern from "sys/epoll.h":
 

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -304,96 +304,94 @@ cdef extern from "ucp/api/ucp.h":
                                      unsigned flags,
                                      ucp_send_callback_t cb)
 
-    unsigned UCP_AM_SEND_FLAG_REPLY
-    unsigned UCP_AM_SEND_FLAG_EAGER
-    unsigned UCP_AM_SEND_FLAG_RNDV
+    IF CY_UCP_AM_SUPPORTED:
+        unsigned UCP_AM_SEND_FLAG_REPLY
+        unsigned UCP_AM_SEND_FLAG_EAGER
+        unsigned UCP_AM_SEND_FLAG_RNDV
 
-    unsigned UCP_AM_RECV_ATTR_FIELD_REPLY_EP
-    unsigned UCP_AM_RECV_ATTR_FIELD_TOTAL_LENGTH
-    unsigned UCP_AM_RECV_ATTR_FIELD_FRAG_OFFSET
-    unsigned UCP_AM_RECV_ATTR_FIELD_MSG_CONTEXT
-    unsigned UCP_AM_RECV_ATTR_FLAG_DATA
-    unsigned UCP_AM_RECV_ATTR_FLAG_RNDV
-    unsigned UCP_AM_RECV_ATTR_FLAG_FIRST
-    unsigned UCP_AM_RECV_ATTR_FLAG_ONLY
+        unsigned UCP_AM_RECV_ATTR_FIELD_REPLY_EP
+        unsigned UCP_AM_RECV_ATTR_FIELD_TOTAL_LENGTH
+        unsigned UCP_AM_RECV_ATTR_FIELD_FRAG_OFFSET
+        unsigned UCP_AM_RECV_ATTR_FIELD_MSG_CONTEXT
+        unsigned UCP_AM_RECV_ATTR_FLAG_DATA
+        unsigned UCP_AM_RECV_ATTR_FLAG_RNDV
+        unsigned UCP_AM_RECV_ATTR_FLAG_FIRST
+        unsigned UCP_AM_RECV_ATTR_FLAG_ONLY
 
-    unsigned UCP_AM_HANDLER_PARAM_FIELD_ID
-    unsigned UCP_AM_HANDLER_PARAM_FIELD_FLAGS
-    unsigned UCP_AM_HANDLER_PARAM_FIELD_CB
-    unsigned UCP_AM_HANDLER_PARAM_FIELD_ARG
+        unsigned UCP_AM_HANDLER_PARAM_FIELD_ID
+        unsigned UCP_AM_HANDLER_PARAM_FIELD_FLAGS
+        unsigned UCP_AM_HANDLER_PARAM_FIELD_CB
+        unsigned UCP_AM_HANDLER_PARAM_FIELD_ARG
 
-    ctypedef ucs_status_t(*ucp_am_recv_data_nbx_callback_t)(void *request,
-                                                            ucs_status_t status,
-                                                            size_t length,
-                                                            void *used_data)
+        ctypedef ucs_status_t(*ucp_am_recv_data_nbx_callback_t)(void *request,
+                                                                ucs_status_t status,
+                                                                size_t length,
+                                                                void *used_data)
 
-    ctypedef void (*ucp_send_nbx_callback_t)(void *request, ucs_status_t status,
-                                             void *user_data)  # noqa
+        ctypedef void (*ucp_send_nbx_callback_t)(void *request, ucs_status_t status,
+                                                 void *user_data)  # noqa
 
-    ctypedef union _ucp_request_param_cb_t:
-        ucp_send_nbx_callback_t send
-        # ucp_tag_recv_nbx_callback_t recv
-        # ucp_stream_recv_nbx_callback_t recv_stream
-        ucp_am_recv_data_nbx_callback_t recv_am
+        ctypedef union _ucp_request_param_cb_t:
+            ucp_send_nbx_callback_t send
+            ucp_am_recv_data_nbx_callback_t recv_am
 
-    ctypedef union _ucp_request_param_recv_info_t:
-        size_t *length
-        # ucp_tag_recv_info_t *tag_info
+        ctypedef union _ucp_request_param_recv_info_t:
+            size_t *length
 
-    ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
-                                     const void *header, size_t header_length,
-                                     const void *buffer, size_t count,
-                                     const ucp_request_param_t *param)
+        ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
+                                         const void *header, size_t header_length,
+                                         const void *buffer, size_t count,
+                                         const ucp_request_param_t *param)
 
-    ucs_status_ptr_t ucp_am_recv_data_nbx(ucp_worker_h worker, void *data_desc,
-                                          void *buffer, size_t count,
-                                          const ucp_request_param_t *param)
+        ucs_status_ptr_t ucp_am_recv_data_nbx(ucp_worker_h worker, void *data_desc,
+                                              void *buffer, size_t count,
+                                              const ucp_request_param_t *param)
 
-    int UCP_OP_ATTR_FIELD_REQUEST
-    int UCP_OP_ATTR_FIELD_CALLBACK
-    int UCP_OP_ATTR_FIELD_USER_DATA
-    int UCP_OP_ATTR_FIELD_DATATYPE
-    int UCP_OP_ATTR_FIELD_FLAGS
-    int UCP_OP_ATTR_FIELD_REPLY_BUFFER
-    int UCP_OP_ATTR_FIELD_MEMORY_TYPE
-    int UCP_OP_ATTR_FIELD_RECV_INFO
+        int UCP_OP_ATTR_FIELD_REQUEST
+        int UCP_OP_ATTR_FIELD_CALLBACK
+        int UCP_OP_ATTR_FIELD_USER_DATA
+        int UCP_OP_ATTR_FIELD_DATATYPE
+        int UCP_OP_ATTR_FIELD_FLAGS
+        int UCP_OP_ATTR_FIELD_REPLY_BUFFER
+        int UCP_OP_ATTR_FIELD_MEMORY_TYPE
+        int UCP_OP_ATTR_FIELD_RECV_INFO
 
-    int UCP_OP_ATTR_FLAG_NO_IMM_CMPL
-    int UCP_OP_ATTR_FLAG_FAST_CMPL
-    int UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL
+        int UCP_OP_ATTR_FLAG_NO_IMM_CMPL
+        int UCP_OP_ATTR_FLAG_FAST_CMPL
+        int UCP_OP_ATTR_FLAG_FORCE_IMM_CMPL
 
-    ctypedef struct ucp_request_param_t:
-        uint32_t op_attr_mask
-        uint32_t flags
-        void *request
-        _ucp_request_param_cb_t cb
-        ucp_datatype_t datatype
-        void *user_data
-        void *reply_buffer
-        ucs_memory_type_t memory_type
-        _ucp_request_param_recv_info_t recv_info
+        ctypedef struct ucp_request_param_t:
+            uint32_t op_attr_mask
+            uint32_t flags
+            void *request
+            _ucp_request_param_cb_t cb
+            ucp_datatype_t datatype
+            void *user_data
+            void *reply_buffer
+            ucs_memory_type_t memory_type
+            _ucp_request_param_recv_info_t recv_info
 
-    ctypedef struct ucp_am_recv_param_t:
-        uint64_t recv_attr
-        ucp_ep_h reply_ep
-        size_t total_length
-        size_t frag_offset
-        void **msg_context
+        ctypedef struct ucp_am_recv_param_t:
+            uint64_t recv_attr
+            ucp_ep_h reply_ep
+            size_t total_length
+            size_t frag_offset
+            void **msg_context
 
-    ctypedef ucs_status_t(*ucp_am_recv_callback_t)(void *arg, const void *header,
-                                                   size_t header_length,
-                                                   void *data, size_t length,
-                                                   const ucp_am_recv_param_t *param)
+        ctypedef ucs_status_t(*ucp_am_recv_callback_t)(void *arg, const void *header,
+                                                       size_t header_length,
+                                                       void *data, size_t length,
+                                                       const ucp_am_recv_param_t *param)
 
-    ctypedef struct ucp_am_handler_param_t:
-        uint64_t field_mask
-        unsigned id
-        uint32_t flags
-        ucp_am_recv_callback_t cb
-        void *arg
+        ctypedef struct ucp_am_handler_param_t:
+            uint64_t field_mask
+            unsigned id
+            uint32_t flags
+            ucp_am_recv_callback_t cb
+            void *arg
 
-    ucs_status_t ucp_worker_set_am_recv_handler(ucp_worker_h worker,
-                                                const ucp_am_handler_param_t *param)
+        ucs_status_t ucp_worker_set_am_recv_handler(ucp_worker_h worker,
+                                                    const ucp_am_handler_param_t *param)
 
 cdef extern from "sys/epoll.h":
 

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -324,7 +324,11 @@ cdef extern from "ucp/api/ucp.h":
 
     ctypedef ucs_status_t(*ucp_am_recv_data_nbx_callback_t)(void *request,
                                                             ucs_status_t status,
-                                                            size_t length, void *used_data)
+                                                            size_t length,
+                                                            void *used_data)
+
+    ctypedef void (*ucp_send_nbx_callback_t)(void *request, ucs_status_t status,
+                                             void *user_data)  # noqa
 
     ctypedef union _ucp_request_param_cb_t:
         ucp_send_nbx_callback_t send
@@ -335,9 +339,6 @@ cdef extern from "ucp/api/ucp.h":
     ctypedef union _ucp_request_param_recv_info_t:
         size_t *length
         # ucp_tag_recv_info_t *tag_info
-
-    ctypedef void (*ucp_send_nbx_callback_t)(void *request, ucs_status_t status,
-                                             void *user_data)  # noqa
 
     ucs_status_ptr_t ucp_am_send_nbx(ucp_ep_h ep, unsigned id,
                                      const void *header, size_t header_length,
@@ -372,7 +373,6 @@ cdef extern from "ucp/api/ucp.h":
         ucs_memory_type_t memory_type
         _ucp_request_param_recv_info_t recv_info
 
-
     ctypedef struct ucp_am_recv_param_t:
         uint64_t recv_attr
         ucp_ep_h reply_ep
@@ -393,7 +393,7 @@ cdef extern from "ucp/api/ucp.h":
         void *arg
 
     ucs_status_t ucp_worker_set_am_recv_handler(ucp_worker_h worker,
-                                                 const ucp_am_handler_param_t *param)
+                                                const ucp_am_handler_param_t *param)
 
 cdef extern from "sys/epoll.h":
 

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -101,21 +101,14 @@ def tag_recv(
 
 
 def am_recv(
-    ep: ucx_api.UCXEndpoint,
-    name="am_recv",
-    event_loop=None,
+    ep: ucx_api.UCXEndpoint, name="am_recv", event_loop=None,
 ) -> asyncio.Future:
 
     event_loop = event_loop if event_loop else asyncio.get_event_loop()
     ret = event_loop.create_future()
     # All the comm functions takes the call-back function and its arguments
     cb_args = (event_loop, ret)
-    ucx_api.am_recv_nb(
-        ep,
-        cb_func=_am_cb_func,
-        cb_args=cb_args,
-        name=name
-    )
+    ucx_api.am_recv_nb(ep, cb_func=_am_cb_func, cb_args=cb_args, name=name)
     return ret
 
 

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -54,9 +54,7 @@ def am_send(
     event_loop=None,
 ) -> asyncio.Future:
 
-    return _call_ucx_api(
-        event_loop, ucx_api.am_send_nbx, ep, buffer, nbytes, name=name
-    )
+    return _call_ucx_api(event_loop, ucx_api.am_send_nbx, ep, buffer, nbytes, name=name)
 
 
 def stream_send(

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -91,6 +91,24 @@ def tag_recv(
     )
 
 
+def am_recv(
+    ep: ucx_api.UCXEndpoint,
+    buffer: arr.Array,
+    nbytes: int,
+    name="am_recv",
+    event_loop=None,
+) -> asyncio.Future:
+
+    return _call_ucx_api(
+        event_loop,
+        ucx_api.am_recv_nb,
+        ep,
+        buffer,
+        nbytes,
+        name=name,
+    )
+
+
 def stream_recv(
     ep: ucx_api.UCXEndpoint,
     buffer: arr.Array,

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -46,6 +46,19 @@ def tag_send(
     )
 
 
+def am_send(
+    ep: ucx_api.UCXEndpoint,
+    buffer: arr.Array,
+    nbytes: int,
+    name="am_send",
+    event_loop=None,
+) -> asyncio.Future:
+
+    return _call_ucx_api(
+        event_loop, ucx_api.am_send_nbx, ep, buffer, nbytes, name=name
+    )
+
+
 def stream_send(
     ep: ucx_api.UCXEndpoint,
     buffer: arr.Array,

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -139,7 +139,7 @@ class CtrlMsg:
         msg = bytearray(CtrlMsg.nbytes)
         msg_arr = Array(msg)
         shutdown_fut = comm.tag_recv(
-            ep._ep, msg_arr, msg_arr.nbytes, ep._tags["ctrl_recv"], name=log,
+            ep._ep, msg_arr, msg_arr.nbytes, ep._tags["ctrl_recv"], name=log
         )
 
         shutdown_fut.add_done_callback(
@@ -534,11 +534,7 @@ class Endpoint:
             logger.debug(log)
             try:
                 await comm.tag_send(
-                    self._ep,
-                    msg_arr,
-                    msg_arr.nbytes,
-                    self._tags["ctrl_send"],
-                    name=log,
+                    self._ep, msg_arr, msg_arr.nbytes, self._tags["ctrl_send"], name=log
                 )
             # The peer might already be shutting down thus we can ignore any send errors
             except UCXError as e:
@@ -602,7 +598,7 @@ class Endpoint:
         if not isinstance(buffer, Array):
             buffer = Array(buffer)
         nbytes = buffer.nbytes
-        log = "[Send #%03d] ep: %s, tag: %s, nbytes: %d, type: %s" % (
+        log = "[AM Send #%03d] ep: %s, tag: %s, nbytes: %d, type: %s" % (
             self._send_count,
             hex(self.uid),
             hex(self._tags["msg_send"]),
@@ -662,7 +658,7 @@ class Endpoint:
         """
         if self.closed():
             raise UCXCloseError("Endpoint closed")
-        log = "[Recv AM #%03d] ep: %s" % (self._recv_count, hex(self.uid),)
+        log = "[AM Recv #%03d] ep: %s" % (self._recv_count, hex(self.uid))
         logger.debug(log)
         self._recv_count += 1
         ret = await comm.am_recv(self._ep, name=log)

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -656,10 +656,7 @@ class Endpoint:
         """
         if self.closed():
             raise UCXCloseError("Endpoint closed")
-        log = "[Recv AM #%03d] ep: %s" % (
-            self._recv_count,
-            hex(self.uid),
-        )
+        log = "[Recv AM #%03d] ep: %s" % (self._recv_count, hex(self.uid),)
         logger.debug(log)
         self._recv_count += 1
         ret = await comm.am_recv(self._ep, name=log)

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -35,6 +35,12 @@ def _get_ctx():
     return _ctx
 
 
+def is_am_supported():
+    return all(
+        hasattr(ucx_api, attr) for attr in ["am_send_nbx", "am_recv_nb"]
+    ) and get_ucx_version() >= (1, 11, 0)
+
+
 async def exchange_peer_info(
     endpoint, msg_tag, ctrl_tag, guarantee_msg_order, listener
 ):

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -651,29 +651,18 @@ class Endpoint:
         return ret
 
     @nvtx_annotate("UCXPY_AM_RECV", color="red", domain="ucxpy")
-    async def am_recv(self, buffer):
-        """Receive from connected peer into `buffer`.
-
-        Parameters
-        ----------
-        buffer: exposing the buffer protocol or array/cuda interface
-            The buffer to receive into. Raise ValueError if buffer
-            is smaller than nbytes or read-only.
+    async def am_recv(self):
+        """Receive from connected peer.
         """
         if self.closed():
             raise UCXCloseError("Endpoint closed")
-        if not isinstance(buffer, Array):
-            buffer = Array(buffer)
-        nbytes = buffer.nbytes
-        log = "[Recv #%03d] ep: %s, nbytes: %d, type: %s" % (
+        log = "[Recv AM #%03d] ep: %s" % (
             self._recv_count,
             hex(self.uid),
-            nbytes,
-            type(buffer.obj),
         )
         logger.debug(log)
         self._recv_count += 1
-        ret = await comm.am_recv(self._ep, buffer, nbytes, name=log)
+        ret = await comm.am_recv(self._ep, name=log)
         self._finished_recv_count += 1
         if (
             self._close_after_n_recv is not None


### PR DESCRIPTION
This PR adds initial support for the Active Message UCX API. There are currently some limitations:

- Receiving rendezvous messages is not supported yet;
- Only host messages are supported.

The limitations above are intended to avoid this PR getting even longer and will be addressed in a follow-up PR.