### PR TITLE
Memory allocation/registration and rkey management

### DIFF
--- a/ucp/_libs/tests/test_mem.py
+++ b/ucp/_libs/tests/test_mem.py
@@ -1,7 +1,8 @@
-import pytest
 import array
 import io
 import mmap
+
+import pytest
 
 import ucp._libs.ucx_api as ucx_api
 

--- a/ucp/_libs/tests/test_mem.py
+++ b/ucp/_libs/tests/test_mem.py
@@ -51,3 +51,13 @@ def test_ctx_map(buffer):
     mem = ctx.map(buffer)
     rkey = mem.pack_rkey()
     assert rkey is not None
+
+
+def test_rkey_unpack():
+    ctx = ucx_api.UCXContext({})
+    mem = ucx_api.UCXMemoryHandle.alloc(ctx, 1024)
+    packed_rkey = mem.pack_rkey()
+    worker = ucx_api.UCXWorker(ctx)
+    ep = worker.ep_create_from_worker_address(worker.get_address(), ctx)
+    rkey = ep.unpack_rkey(packed_rkey)
+    assert rkey is not None

--- a/ucp/_libs/tests/test_mem.py
+++ b/ucp/_libs/tests/test_mem.py
@@ -1,0 +1,52 @@
+import pytest
+import array
+import io
+import mmap
+
+import ucp._libs.ucx_api as ucx_api
+
+builtin_buffers = [
+    b"",
+    b"abcd",
+    array.array("i", []),
+    array.array("i", [0, 1, 2, 3]),
+    array.array("I", [0, 1, 2, 3]),
+    array.array("f", []),
+    array.array("f", [0, 1, 2, 3]),
+    array.array("d", [0, 1, 2, 3]),
+    memoryview(array.array("B", [0, 1, 2, 3, 4, 5])).cast("B", (3, 2)),
+    memoryview(b"abcd"),
+    memoryview(bytearray(b"abcd")),
+    io.BytesIO(b"abcd").getbuffer(),
+    mmap.mmap(-1, 5),
+]
+
+
+def test_alloc():
+    ctx = ucx_api.UCXContext({})
+    mem = ucx_api.UCXMemoryHandle.alloc(ctx, 1024)
+    rkey = mem.pack_rkey()
+    assert rkey is not None
+
+
+@pytest.mark.parametrize("buffer", builtin_buffers)
+def test_map(buffer):
+    ctx = ucx_api.UCXContext({})
+    mem = ucx_api.UCXMemoryHandle.map(ctx, buffer)
+    rkey = mem.pack_rkey()
+    assert rkey is not None
+
+
+def test_ctx_alloc():
+    ctx = ucx_api.UCXContext({})
+    mem = ctx.alloc(1024)
+    rkey = mem.pack_rkey()
+    assert rkey is not None
+
+
+@pytest.mark.parametrize("buffer", builtin_buffers)
+def test_ctx_map(buffer):
+    ctx = ucx_api.UCXContext({})
+    mem = ctx.map(buffer)
+    rkey = mem.pack_rkey()
+    assert rkey is not None

--- a/ucp/_libs/tests/test_mem.py
+++ b/ucp/_libs/tests/test_mem.py
@@ -4,7 +4,7 @@ import mmap
 
 import pytest
 
-import ucp._libs.ucx_api as ucx_api
+from ucp._libs import ucx_api
 
 builtin_buffers = [
     b"",

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -468,8 +468,8 @@ cdef class UCXMemoryHandle(UCXObject):
     @classmethod
     def alloc(cls, ctx, size):
         """ Allocate a new pool of registered memory. This memory can be used for
-            RMA and AMO operations. This memory should not be accessed from outside these
-            operations.
+            RMA and AMO operations. This memory should not be accessed from outside
+            these operations.
 
             Parameters
             ----------

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -434,7 +434,10 @@ cdef class UCXMemoryHandle(UCXObject):
         cdef ucp_mem_map_params_t params
         cdef ucs_status_t status
 
-        params.field_mask = UCP_MEM_MAP_PARAM_FIELD_FLAGS | UCP_MEM_MAP_PARAM_FIELD_LENGTH
+        params.field_mask = (
+            UCP_MEM_MAP_PARAM_FIELD_FLAGS |
+            UCP_MEM_MAP_PARAM_FIELD_LENGTH
+        )
         params.length = <size_t>size
         params.flags = UCP_MEM_MAP_NONBLOCK | UCP_MEM_MAP_ALLOCATE
 
@@ -447,7 +450,10 @@ cdef class UCXMemoryHandle(UCXObject):
 
         buff = Array(mem)
 
-        params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS | UCP_MEM_MAP_PARAM_FIELD_LENGTH
+        params.field_mask = (
+            UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+            UCP_MEM_MAP_PARAM_FIELD_LENGTH
+        )
         params.address = <void*>buff.ptr
         params.length = buff.nbytes
 
@@ -460,13 +466,16 @@ cdef class UCXMemoryHandle(UCXObject):
     def memh(self):
         return <uintptr_t>self._memh
 
-    #Done as a separate function because some day I plan on making this loaded lazily
-    #I believe this reports the actual registered space, rather than what was requested.
+    # Done as a separate function because some day I plan on making this loaded lazily
+    # I believe this reports the actual registered space, rather than what was requested
     def _populate_metadata(self):
         cdef ucs_status_t status
         cdef ucp_mem_attr_t attr
 
-        attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS | UCP_MEM_ATTR_FIELD_LENGTH
+        attr.field_mask = (
+            UCP_MEM_ATTR_FIELD_ADDRESS |
+            UCP_MEM_ATTR_FIELD_LENGTH
+        )
         status = ucp_mem_query(self._memh, &attr)
         assert_ucs_status(status)
         self.r_address = <uintptr_t>attr.address

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -268,7 +268,13 @@ cdef class UCXContext(UCXObject):
     def __init__(
         self,
         config_dict={},
-        feature_flags=(Feature.TAG, Feature.WAKEUP, Feature.STREAM, Feature.AM, Feature.RMA)
+        feature_flags=(
+            Feature.TAG,
+            Feature.WAKEUP,
+            Feature.STREAM,
+            Feature.AM,
+            Feature.RMA
+        )
     ):
         cdef ucp_params_t ucp_params
         cdef ucp_worker_params_t worker_params

--- a/ucp/_libs/ucx_api.pyx
+++ b/ucp/_libs/ucx_api.pyx
@@ -468,7 +468,7 @@ cdef class UCXMemoryHandle(UCXObject):
     @classmethod
     def alloc(cls, ctx, size):
         """ Allocate a new pool of registered memory. This memory can be used for
-            RMA and AMO operations. This memory should no be accessed from outside these
+            RMA and AMO operations. This memory should not be accessed from outside these
             operations.
 
             Parameters

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -353,8 +353,8 @@ cdef extern from "sys/epoll.h":
 
     ctypedef struct ucp_mem_map_params_t:
         uint64_t field_mask
-        void    *address
-        size_t   length
+        void *address
+        size_t length
         unsigned flags
 
     ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *params,

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -326,3 +326,46 @@ cdef extern from "sys/epoll.h":
     int epoll_create(int size)
     int epoll_ctl(int epfd, int op, int fd, epoll_event *event)
     int epoll_wait(int epfd, epoll_event *events, int maxevents, int timeout)
+
+    ctypedef struct ucp_address_t:
+        pass
+
+    ctypedef struct ucp_rkey_h:
+        pass
+
+    int UCP_MEM_MAP_NONBLOCK
+    int UCP_MEM_MAP_ALLOCATE
+    int UCP_MEM_MAP_FIXED
+
+    ctypedef struct ucp_mem_h:
+        pass
+
+    ctypedef struct ucp_mem_attr_t:
+        uint64_t field_mask
+        void *address
+        size_t length
+
+    int UCP_MEM_MAP_PARAM_FIELD_LENGTH
+    int UCP_MEM_MAP_PARAM_FIELD_ADDRESS
+    int UCP_MEM_MAP_PARAM_FIELD_FLAGS
+    int UCP_MEM_ATTR_FIELD_ADDRESS
+    int UCP_MEM_ATTR_FIELD_LENGTH
+
+    ctypedef struct ucp_mem_map_params_t:
+        uint64_t field_mask
+        void    *address
+        size_t   length
+        unsigned flags
+
+    ucs_status_t ucp_mem_map(ucp_context_h context, const ucp_mem_map_params_t *params,
+                             ucp_mem_h *memh_p)
+    ucs_status_t ucp_mem_unmap(ucp_context_h context, ucp_mem_h memh)
+    ucs_status_t ucp_mem_query(const ucp_mem_h memh, ucp_mem_attr_t *attr)
+
+    ucs_status_t ucp_rkey_pack(ucp_context_h context, ucp_mem_h memh,
+                               void **rkey_buffer_p, size_t *size_p)
+    ucs_status_t ucp_ep_rkey_unpack(ucp_ep_h ep, const void *rkey_buffer,
+                                    ucp_rkey_h *rkey_p)
+    void ucp_rkey_buffer_release(void *rkey_buffer)
+    ucs_status_t ucp_rkey_ptr(ucp_rkey_h rkey, uint64_t raddr, void **addr_p)
+    void ucp_rkey_destroy(ucp_rkey_h rkey)


### PR DESCRIPTION
Filling out more of the low level UCX API. This one covers the mapping of existing memory/allocation of new memory registered to a UCX context and packing an Rkey that will, after a future PR adds RMA/AMO operations, allow for one sided operations against this memory.