### PR TITLE
Fix "assignment makes pointer from integer without a cast" warnings

### DIFF
--- a/ucp/_libs/ucx_memory_handle.pyx
+++ b/ucp/_libs/ucx_memory_handle.pyx
@@ -11,7 +11,7 @@ from .ucx_api_dep cimport *
 
 def _ucx_mem_handle_finalizer(uintptr_t handle_as_int, UCXContext ctx):
     assert ctx.initialized
-    cdef ucp_mem_h handle = <ucp_mem_h>handle_as_int
+    cdef ucp_mem_h handle = <ucp_mem_h><void *>handle_as_int
     cdef ucs_status_t status
     status = ucp_mem_unmap(ctx._handle, handle)
     assert_ucs_status(status)

--- a/ucp/_libs/ucx_rkey.pyx
+++ b/ucp/_libs/ucx_rkey.pyx
@@ -12,7 +12,6 @@ from .ucx_api_dep cimport *
 def _ucx_remote_mem_finalizer_post_flush(req, exception, UCXRkey rkey):
     assert exception is None
     ucp_rkey_destroy(rkey._handle)
-    ucp_rkey_destroy(rkey_handle)
 
 
 def _ucx_rkey_finalizer(rkey, ep):

--- a/ucp/_libs/ucx_rkey.pyx
+++ b/ucp/_libs/ucx_rkey.pyx
@@ -11,7 +11,7 @@ from .ucx_api_dep cimport *
 
 def _ucx_remote_mem_finalizer_post_flush(req, exception, UCXRkey rkey):
     assert exception is None
-    cdef ucp_rkey_h rkey_handle = <ucp_rkey_h><void *>rkey._handle
+    ucp_rkey_destroy(rkey._handle)
     ucp_rkey_destroy(rkey_handle)
 
 

--- a/ucp/_libs/ucx_rkey.pyx
+++ b/ucp/_libs/ucx_rkey.pyx
@@ -11,7 +11,7 @@ from .ucx_api_dep cimport *
 
 def _ucx_remote_mem_finalizer_post_flush(req, exception, UCXRkey rkey):
     assert exception is None
-    cdef ucp_rkey_h rkey_handle = <ucp_rkey_h><uintptr_t>rkey._handle
+    cdef ucp_rkey_h rkey_handle = <ucp_rkey_h><void *>rkey._handle
     ucp_rkey_destroy(rkey_handle)
 
 


### PR DESCRIPTION
Fixes a couple of build warnings:

```cpp
  ucp/_libs/ucx_api.c: In function ‘__pyx_pf_3ucp_5_libs_7ucx_api_18_ucx_mem_handle_finalizer’:
  ucp/_libs/ucx_api.c:16449:18: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
     __pyx_v_handle = __pyx_v_handle_as_int;
                    ^
  ucp/_libs/ucx_api.c: In function ‘__pyx_pf_3ucp_5_libs_7ucx_api_22_ucx_remote_mem_finalizer_post_flush’:
  ucp/_libs/ucx_api.c:20611:23: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
     __pyx_v_rkey_handle = ((uintptr_t)__pyx_v_rkey->_handle);
                         ^
```