### PR TITLE
Handling UCS_INPROGRESS in assert_ucs_status()

### DIFF
--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -90,7 +90,7 @@ cdef get_ucx_object(Py_buffer *buffer, int flags,
 
 cdef void assert_ucs_status(ucs_status_t status, str msg_context=None) except *:
     cdef str msg, ucs_status
-    if status != UCS_OK:
+    if not (status == UCS_OK or status == UCS_INPROGRESS):
         ucs_status = ucs_status_string(status).decode("utf-8")
         if msg_context is not None:
             msg = f"[{msg_context}] {ucs_status}"


### PR DESCRIPTION
While working on the RMA branch I ran into this interesting behavior. As it stands now the `assert_ucs_status()` function will treat `UCS_INPROGRESS` as an error and raise an exception. I looked through the code and don't see how this change would affect anything outside of the RMA implicit interface, but I wanted to break this change out into it's own one liner to see if any tests have a problem with this change