### PR TITLE
Add GitHub Actions workflow for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,5 +21,6 @@ jobs:
           auto-activate-base: false
       - name: Build documentation
         run: |
+          conda activate ucx_dev
           cd docs
           make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,14 +32,16 @@ jobs:
           environment-file: latest/conda/environments/builddocs_py37.yml
           auto-activate-base: false
       - name: Build documentation
+        working-directory: latest/docs
+        run: make html
+      - name: Copy docs to gh-pages
         run: |
-          cd latest/docs
-          make html
-      - name: Commit changes to docs
-        run: |
-          COMMIT_SHA=$(echo "${COMMIT_SHA}" | cut -c 1-7)
           rm -rf gh-pages/*
           cp -r latest/docs/build/html/* gh-pages/
+      - name: Commit changes to docs
+        working-directory: gh-pages
+        run: |
+          COMMIT_SHA=$(echo "${COMMIT_SHA}" | cut -c 1-7)
           git config user.name "GitHub Actions"
           git config user.email "action@github.com"
           git add --all

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,5 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: ucx_dev
-          environment-file: ../conda/environments/builddocs_py37.yml
+          environment-file: conda/environments/builddocs_py37.yml
           auto-activate-base: false
-      - name: Build documentation
-        uses: ammaraskar/sphinx-action@0.4
-        with:
-          docs-folder: "docs/"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Commit changes to docs
         run: |
           git clone https://github.com/charlesbluca/ucx-py.git --branch gh-pages --single-branch gh-pages
-          cp -r build/html/* gh-pages/
+          cp -r docs/build/html/* gh-pages/
           cd gh-pages
           touch .nojekyll
           git config --local user.email "action@github.com"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches: ["gha-docs-build"]
+
+jobs:
+  build:
+    name: Build Sphinx documentation
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Install libnuma
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libnuma-dev
+      - name: Create docs environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: ucx_dev
+          environment-file: conda/environments/builddocs_py37.yml
+          auto-activate-base: false
+      - name: Build documentation
+        uses: ammaraskar/sphinx-action@0.4
+        with:
+          docs-folder: "docs/"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
+name: UCX-Py documentation build
+
 on:
   push:
-    branches: ["gha-docs-build"]
+    branches: ["branch-0.20"]
 
 jobs:
   build:
@@ -29,7 +31,7 @@ jobs:
           make html
       - name: Commit changes to docs
         run: |
-          git clone https://github.com/charlesbluca/ucx-py.git --branch gh-pages --single-branch gh-pages
+          git clone https://github.com/rapidsai/ucx-py.git --branch gh-pages --single-branch gh-pages
           cp -r docs/build/html/* gh-pages/
           cd gh-pages
           touch .nojekyll

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,11 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libnuma-dev
-      - name: Create docs environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: ucx_dev
-          environment-file: conda/environments/builddocs_py37.yml
-          auto-activate-base: false
+      - run: |
+          ls
+      # - name: Create docs environment
+      #   uses: conda-incubator/setup-miniconda@v2
+      #   with:
+      #     activate-environment: ucx_dev
+      #     environment-file: conda/environments/builddocs_py37.yml
+      #     auto-activate-base: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,8 @@ jobs:
           git add --all
           git commit --allow-empty -m "Update docs from ${COMMIT_SHA}"
           git push
+        env:
+          COMMIT_SHA: ${{ github.sha }}
       # - name: Push changes
       #   uses: ad-m/github-push-action@v0.6.0
       #   with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     name: Build Sphinx documentation
     runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
@@ -19,8 +22,12 @@ jobs:
           activate-environment: ucx_dev
           environment-file: conda/environments/builddocs_py37.yml
           auto-activate-base: false
-      - name: Build documentation
+      - name: Check conda env
         run: |
-          conda activate ucx_dev
-          cd docs
-          make html
+          conda info
+          conda list
+      # - name: Build documentation
+      #   run: |
+      #     conda activate ucx_dev
+      #     cd docs
+      #     make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,12 +22,18 @@ jobs:
           activate-environment: ucx_dev
           environment-file: conda/environments/builddocs_py37.yml
           auto-activate-base: false
-      - name: Check conda env
+      - name: Build documentation
         run: |
-          conda info
-          conda list
-      # - name: Build documentation
-      #   run: |
-      #     conda activate ucx_dev
-      #     cd docs
-      #     make html
+          conda activate ucx_dev
+          cd docs
+          make html
+      - name: Commit changes to docs
+        run: |
+          git clone https://github.com/charlesbluca/ucx-py.git --branch gh-pages --single-branch gh-pages
+          cp -r build/html/* gh-pages/
+          cd gh-pages
+          touch .nojekyll
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,3 +19,7 @@ jobs:
           activate-environment: ucx_dev
           environment-file: conda/environments/builddocs_py37.yml
           auto-activate-base: false
+      - name: Build documentation
+        run: |
+          cd docs
+          make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: ucx_dev
-          environment-file: conda/environments/builddocs_py37.yml
+          environment-file: latest/conda/environments/builddocs_py37.yml
           auto-activate-base: false
       - name: Build documentation
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: UCX-Py documentation build
 
 on:
   push:
-    branches: ["gha-docs-build"]
+    branches: ["branch-0.20"]
 
 jobs:
   build:
@@ -49,9 +49,3 @@ jobs:
           git push
         env:
           COMMIT_SHA: ${{ github.sha }}
-      # - name: Push changes
-      #   uses: ad-m/github-push-action@v0.6.0
-      #   with:
-      #     branch: gh-pages
-      #     directory: gh-pages
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: ucx_dev
-          environment-file: conda/environments/builddocs_py37.yml
+          environment-file: ../conda/environments/builddocs_py37.yml
           auto-activate-base: false
       - name: Build documentation
         uses: ammaraskar/sphinx-action@0.4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: UCX-Py documentation build
 
 on:
   push:
-    branches: ["branch-0.20"]
+    branches: ["gha-docs-build"]
 
 jobs:
   build:
@@ -12,8 +12,15 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - name: Checkout repository
+      - name: Checkout latest changes
         uses: actions/checkout@v2.3.4
+        with:
+          path: latest
+      - name: Checkout gh-pages
+        uses: actions/checkout@v2.3.4
+        with:
+          ref: gh-pages
+          path: gh-pages
       - name: Install libnuma
         run: |
           sudo apt-get update -y
@@ -26,22 +33,21 @@ jobs:
           auto-activate-base: false
       - name: Build documentation
         run: |
-          conda activate ucx_dev
-          cd docs
+          cd latest/docs
           make html
       - name: Commit changes to docs
         run: |
-          git clone https://github.com/rapidsai/ucx-py.git --branch gh-pages --single-branch gh-pages
-          cp -r docs/build/html/* gh-pages/
-          cd gh-pages
-          touch .nojekyll
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add .
-          git commit -m "Update documentation" -a || true
-      - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          branch: gh-pages
-          directory: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA=$(echo "${COMMIT_SHA}" | cut -c 1-7)
+          rm -rf gh-pages/*
+          cp -r latest/docs/build/html/* gh-pages/
+          git config user.name "GitHub Actions"
+          git config user.email "action@github.com"
+          git add --all
+          git commit --allow-empty -m "Update docs from ${COMMIT_SHA}"
+          git push
+      # - name: Push changes
+      #   uses: ad-m/github-push-action@v0.6.0
+      #   with:
+      #     branch: gh-pages
+      #     directory: gh-pages
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,15 +7,15 @@ jobs:
     name: Build Sphinx documentation
     runs-on: "ubuntu-latest"
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.4
       - name: Install libnuma
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libnuma-dev
-      - run: |
-          ls
-      # - name: Create docs environment
-      #   uses: conda-incubator/setup-miniconda@v2
-      #   with:
-      #     activate-environment: ucx_dev
-      #     environment-file: conda/environments/builddocs_py37.yml
-      #     auto-activate-base: false
+      - name: Create docs environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: ucx_dev
+          environment-file: conda/environments/builddocs_py37.yml
+          auto-activate-base: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,3 +37,9 @@ jobs:
           git config --local user.name "GitHub Action"
           git add .
           git commit -m "Update documentation" -a || true
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          branch: gh-pages
+          directory: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow triggered on merges to `branch-0.20` to build and publish the UCX-Py documentation through GitHub Pages. This handles the issue of libnuma dependencies which currently make this process difficult with RTD.

cc @quasiben 