### PR TITLE
Fix use after free bug in PackedRemoteKey

### DIFF
--- a/ucp/_libs/packed_remote_key.pyx
+++ b/ucp/_libs/packed_remote_key.pyx
@@ -56,7 +56,7 @@ cdef class PackedRemoteKey:
         packed_key = PackedRemoteKey(<uintptr_t>key, len)
         ucp_rkey_buffer_release(key)
         assert_ucs_status(status)
-        return PackedRemoteKey(<uintptr_t>key, len)
+        return packed_key
 
     def __dealloc__(self):
         free(self._key)


### PR DESCRIPTION
This one was fun to track down. Small fix so that the `from_mem_handle` function path returns the correct object, instead of returning a new copy with a 'use after free' bug.