### PR TITLE
Fix wireup assertion in AM core test

### DIFF
--- a/ucp/_libs/tests/test_server_client_am.py
+++ b/ucp/_libs/tests/test_server_client_am.py
@@ -126,7 +126,12 @@ def _echo_client(msg_size, datatype, port):
     recv_wireup = blocking_am_recv(worker, ep)
     recv_data = blocking_am_recv(worker, ep)
 
-    assert recv_wireup == send_wireup
+    # Cast recv_wireup to bytearray when using NumPy as a host allocator,
+    # this ensures the assertion below is correct
+    if datatype == "numpy":
+        recv_wireup = bytearray(recv_wireup)
+    assert bytearray(recv_wireup) == send_wireup
+
     if data["memory_type"] == "cuda" and send_data.nbytes < RNDV_THRESH:
         # Eager messages are always received on the host, if no host
         # allocator is registered UCX-Py defaults to `bytearray`.
@@ -140,7 +145,6 @@ def _echo_client(msg_size, datatype, port):
 @pytest.mark.parametrize("msg_size", [10, 2 ** 24])
 @pytest.mark.parametrize("datatype", get_data().keys())
 def test_server_client(msg_size, datatype):
-    print(datatype)
     put_queue, get_queue = mp.Queue(), mp.Queue()
     server = mp.Process(
         target=_echo_server, args=(put_queue, get_queue, msg_size, datatype)


### PR DESCRIPTION
This PR fixes an issue when asserting the wireup message and NumPy is used as a host allocator, as `numpy.ndarray` can't be directly compared to `bytearray`.