### PR TITLE
Fix RTD workflow

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -16,6 +16,8 @@ jobs:
           fetch-depth: 0
       - name: Merge upstream changes
         run: |
+          git config user.name "GitHub Actions"
+          git config user.email "action@github.com"
           git fetch origin
           git merge origin/branch-0.20
           git push


### PR DESCRIPTION
Forgot you need to set a Git username and email in order to make the commit and push it; this should fix build failures.