### PR TITLE
Use `setup.py` installed ucx-py in docs build

### DIFF
--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -18,3 +18,4 @@ dependencies:
 - psutil
 - libhwloc
 - ucx
+- cython

--- a/conda/environments/builddocs_py37.yml
+++ b/conda/environments/builddocs_py37.yml
@@ -18,4 +18,3 @@ dependencies:
 - psutil
 - libhwloc
 - ucx
-- ucx-py

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ build:
 
 python:
    version: 3.7
-   setup_py_install: false
+   setup_py_install: true
 
 conda:
    file: conda/environments/builddocs_py37.yml


### PR DESCRIPTION
After retargetting the repo/branch for the Read the Docs builds, I noticed that builds pass when using the standard version of UCX:

- https://readthedocs.org/projects/ucx-py/builds/13648990/

However, this build depends on a Conda installed version of UCX-Py, specifically disabling the `setup.py` install of the package:

https://github.com/rapidsai/ucx-py/blob/8a597a56882107ce6ef6c0574a36a1d36626f525/readthedocs.yml#L4-L6

This means that the API reference will be out of date, and also [breaks builds](https://readthedocs.org/projects/ucx-py/builds/13648544/) triggered by the [`readthedocs`](https://github.com/rapidsai/ucx-py/tree/readthedocs) branch, which does not have UCX-Py listed in its docs environment. This PR enables this install, and removes the package from the Conda environment.

If the RTD build passes with this merged, then we probably don't need the `readthedocs` branch or associated workflow anymore. If it fails, then we know it has something to do with how UCX-Py is installed, and we should add it to the [docs env in `readthedocs`](https://github.com/rapidsai/ucx-py/blob/readthedocs/conda/environments/builddocs_py37.yml).

cc @pentschev 