### PR TITLE
Close endpoints in ucp.core tests

### DIFF
--- a/tests/test_multiple_nodes.py
+++ b/tests/test_multiple_nodes.py
@@ -25,6 +25,7 @@ async def hello(ep):
 async def server_node(ep):
     await hello(ep)
     assert isinstance(ep.ucx_info(), str)
+    await ep.close()
 
 
 async def client_node(port):

--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -49,6 +49,7 @@ def make_echo_server(create_empty_data):
         msg = create_empty_data(msg_size[0])
         await ep.recv(msg)
         await ep.send(msg)
+        await ep.close()
 
     return echo_server
 
@@ -143,6 +144,7 @@ async def test_send_recv_error(blocking_progress_mode):
 
     async def say_hey_server(ep):
         await ep.send(bytearray(b"Hey"))
+        await ep.close()
 
     listener = ucp.create_listener(say_hey_server)
     client = await ucp.create_endpoint(ucp.get_address(), listener.port)
@@ -163,6 +165,7 @@ async def test_send_recv_obj(blocking_progress_mode):
     async def echo_obj_server(ep):
         obj = await ep.recv_obj()
         await ep.send_obj(obj)
+        await ep.close()
 
     listener = ucp.create_listener(echo_obj_server)
     client = await ucp.create_endpoint(ucp.get_address(), listener.port)
@@ -183,6 +186,7 @@ async def test_send_recv_obj_numpy(blocking_progress_mode):
     async def echo_obj_server(ep):
         obj = await ep.recv_obj(allocator=allocator)
         await ep.send_obj(obj)
+        await ep.close()
 
     listener = ucp.create_listener(echo_obj_server)
     client = await ucp.create_endpoint(ucp.get_address(), listener.port)

--- a/tests/test_send_recv_am.py
+++ b/tests/test_send_recv_am.py
@@ -67,6 +67,7 @@ def event_loop(scope="function"):
 def simple_server(size, recv):
     async def server(ep):
         recv.append(await ep.am_recv())
+        await ep.close()
 
     return server
 

--- a/tests/test_send_recv_two_workers.py
+++ b/tests/test_send_recv_two_workers.py
@@ -191,6 +191,9 @@ def cupy_obj():
 )
 @pytest.mark.parametrize("comm_api", ["tag", "am"])
 def test_send_recv_cu(cuda_obj_generator, comm_api):
+    if comm_api == "am" and not ucp._libs.ucx_api.is_am_supported():
+        pytest.skip("AM only supported in UCX >= 1.11")
+
     base_env = os.environ
     env_client = base_env.copy()
     # grab first two devices

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -15,6 +15,7 @@ async def test_tag_match():
         await asyncio.sleep(1)  # Let msg1 finish
         f2 = ep.send(msg2, tag="msg2")
         await asyncio.gather(f1, f2)
+        await ep.close()
 
     lf = ucp.create_listener(server_node)
     ep = await ucp.create_endpoint(ucp.get_address(), lf.port)

--- a/tests/test_ucx_getters.py
+++ b/tests/test_ucx_getters.py
@@ -10,6 +10,7 @@ async def test_get_ucp_worker():
 
     def server(ep):
         assert ep.get_ucp_worker() == worker
+        await ep.close()
 
     lt = ucp.create_listener(server)
     ep = await ucp.create_endpoint(ucp.get_address(), lt.port)
@@ -22,6 +23,7 @@ async def test_get_endpoint():
         ucp_ep = ep.get_ucp_endpoint()
         assert isinstance(ucp_ep, int)
         assert ucp_ep > 0
+        await ep.close()
 
     lt = ucp.create_listener(server)
     ep = await ucp.create_endpoint(ucp.get_address(), lt.port)

--- a/tests/test_ucx_getters.py
+++ b/tests/test_ucx_getters.py
@@ -8,7 +8,7 @@ async def test_get_ucp_worker():
     worker = ucp.get_ucp_worker()
     assert isinstance(worker, int)
 
-    def server(ep):
+    async def server(ep):
         assert ep.get_ucp_worker() == worker
         await ep.close()
 
@@ -19,7 +19,7 @@ async def test_get_ucp_worker():
 
 @pytest.mark.asyncio
 async def test_get_endpoint():
-    def server(ep):
+    async def server(ep):
         ucp_ep = ep.get_ucp_endpoint()
         assert isinstance(ucp_ep, int)
         assert ucp_ep > 0


### PR DESCRIPTION
This is a preparation for endpoint error handling. UCX-Py currently try as best as possible to ensure endpoints are closed according to each object's lifetime. However, this can't always be ensured given the async behavior in `ucp.core`. For example, a `ucp.core.Endpoint` object does not call `abort` or `close`, specifically `close` would be desired to inform the other end that it is closing. Because that is an async function, we can't rely on it for a destructor. It's ensured that the underlying synchronous `ucp._libs.UCXEndpoint` object is destroyed when its weakref count goes to zero, and `ucp_ep_close_nb` is called. With the endpoint error handling work in https://github.com/rapidsai/ucx-py/pull/693 , we will be switching to `UCP_EP_CLOSE_MODE_FORCE` that doesn't guarantee inflight messages will be flushed before the endpoint closes, potentially leading to "Connection reset by peer" errors if the other side is waiting to read a message.

From discussions with UCX devs, we should always call `ucp_ep_close_nb` on the _listener_ side, and currently we don't do it in many of our tests, relying solely on an endpoint's lifetime management, which is a bad practice from us. In many cases, simply not calling `ep.close()` would be fine when the last message is sent by client/received by listener, but reverting the order will not. This PR intends to correct this and avoid the need to rely on the correct order to close endpoints based on message direction.