### PR TITLE
Remove try/except block for Cython import in `setup.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dask-worker-space
 __pytestcache__
 __pycache__
 *.egg-info/
+dist/
+.vscode
+

--- a/setup.py
+++ b/setup.py
@@ -9,17 +9,12 @@ import os
 import re
 from distutils.sysconfig import get_config_var, get_python_inc
 
+from Cython.Build import cythonize
+from Cython.Distutils.build_ext import new_build_ext as build_ext
 from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
 import versioneer
-
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils.build_ext import new_build_ext as build_ext
-except ImportError:
-    from setuptools.command.build_ext import build_ext
-
 
 with open("README.md", "r") as fh:
     readme = fh.read()


### PR DESCRIPTION
It looks like Cython is required to build from source, so the setup should just fail immediately if it can't be imported.