### PR TITLE
Drain tag messages on worker finalizer

### DIFF
--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -254,6 +254,11 @@ cdef extern from "ucp/api/ucp.h":
                                        ucp_tag_t tag_mask, int remove,
                                        ucp_tag_recv_info_t *info)
 
+    ucs_status_ptr_t ucp_tag_msg_recv_nb(ucp_worker_h worker, void *buffer,
+                                         size_t count, ucp_datatype_t datatype,
+                                         ucp_tag_message_h message,
+                                         ucp_tag_recv_callback_t cb)
+
     ctypedef void (*ucp_stream_recv_callback_t)(void *request,  # noqa
                                                 ucs_status_t status,
                                                 size_t length)

--- a/ucp/_libs/ucx_worker.pyx
+++ b/ucp/_libs/ucx_worker.pyx
@@ -69,6 +69,9 @@ def _ucx_worker_handle_finalizer(
     assert ctx.initialized
     cdef ucp_worker_h handle = <ucp_worker_h>handle_as_int
 
+    # This drains all the receive messages that were not received by the user with
+    # `tag_recv_nb`. Without this, UCX raises warnings such as below upon exit:
+    # `unexpected tag-receive descriptor ... was not matched`
     _drain_worker_tag_recv(handle)
 
     # Cancel all inflight messages

--- a/ucp/_libs/ucx_worker.pyx
+++ b/ucp/_libs/ucx_worker.pyx
@@ -50,15 +50,17 @@ cdef _drain_worker_tag_recv(ucp_worker_h handle):
         status = ucp_tag_msg_recv_nb(
             handle, buf, info.length, ucp_dt_make_contig(1), message, _tag_recv_callback
         )
-        req = _handle_status(
-            status, info.length, _req_cb, (), {}, u"ucp_tag_msg_recv_nb", set()
-        )
 
-        if req is not None:
-            while _finished[0] is not True:
-                ucp_worker_progress(handle)
+        try:
+            req = _handle_status(
+                status, info.length, _req_cb, (), {}, u"ucp_tag_msg_recv_nb", set()
+            )
 
-        free(buf)
+            if req is not None:
+                while _finished[0] is not True:
+                    ucp_worker_progress(handle)
+        finally:
+            free(buf)
 
 
 def _ucx_worker_handle_finalizer(


### PR DESCRIPTION
The changes here resolve the issue that causes warnings to be raised at process termination, such as below:

```
[1621606990.204443] [dgx14:77681:0]       tag_match.c:61   UCX  WARN  unexpected tag-receive descriptor 0x55c9b1ff2fc0 was not matched
```

The reason for that was the we weren't draining the UCX worker during shutdown, where some messages may have gone uncatched, such as shutdown messages.