### PR TITLE
[gpuCI] Forward-merge branch-0.20 to branch-0.21 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -26,6 +26,7 @@ export HOME=$WORKSPACE
 cd $WORKSPACE
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
+export RAPIDS_VERSION="21.06"
 export UCX_PATH=$CONDA_PREFIX
 
 ################################################################################
@@ -42,8 +43,8 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 gpuci_conda_retry install "cudatoolkit=${CUDA_REL}" \
-              "cudf=${MINOR_VERSION}" "dask-cudf=${MINOR_VERSION}" \
-              "rapids-build-env=${MINOR_VERSION}"
+              "cudf=${RAPIDS_VERSION}" "dask-cudf=${RAPIDS_VERSION}" \
+              "rapids-build-env=${RAPIDS_VERSION}"
 
 # Install the main version of dask and distributed
 gpuci_logger "pip install git+https://github.com/dask/distributed.git@main --upgrade --no-deps"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.20` that creates a PR to keep `branch-0.21` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.