### PR TITLE
Bump isort, enable Cython package resorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,12 @@
 repos:
-      - repo: https://github.com/timothycrosley/isort
-        rev: 5.0.7
+      - repo: https://github.com/pycqa/isort
+        rev: 5.6.4
         hooks:
               - id: isort
+                args: ["--settings-path=setup.cfg"]
+                exclude: __init__.py$
+                types: [text]
+                types_or: [python, cython, pyi]
       - repo: https://github.com/ambv/black
         rev: 19.10b0
         hooks:

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -15,7 +15,7 @@ LANG=C.UTF-8
 conda activate rapids
 
 # Run isort and get results/return code
-ISORT=`isort --recursive --check-only .`
+ISORT=`isort --check-only . --settings-path=setup.cfg`
 ISORT_RETVAL=$?
 
 # Run black and get results/return code


### PR DESCRIPTION
With rapidsai/integration#286, the version of `isort` running on gpuCI will be bumped to 5.6.4, allowing us to enforce the sorting of packages in Cython (pyx, pxd) files. This PR intends to:

- Enable these checks in the gpuCI style script
- Enable Cython package resorting in the pre-commit hook
- Resort all the Cython files in this repo so they pass the newly enabled checks
