### PR TITLE
Fix bad documentation in UCXIO

### DIFF
--- a/ucp/_libs/ucxio.pyx
+++ b/ucp/_libs/ucxio.pyx
@@ -14,8 +14,6 @@ class UCXIO(RawIOBase):
 
         Parameters
         ----------
-        ep: UCXEndpoint
-            A UCXEndpoint that will be used to drive the RMA operations
         dest: int
             A 64 bit number that represents the remote address that will be written to
             and read from.


### PR DESCRIPTION
While making this class I found out that I could remove an ep parameter after I found out it was in rkey and I could use that instead of passing it in. It wasn't removed from the docs though. Fix the docs so that users won't be confused.