### PR TITLE
Update parse_bytes imports to resolve deprecation warnings

### DIFF
--- a/benchmarks/send-recv-core.py
+++ b/benchmarks/send-recv-core.py
@@ -44,7 +44,7 @@ import os
 from threading import Lock
 from time import perf_counter as clock
 
-from distributed.utils import format_bytes, parse_bytes
+from dask.utils import format_bytes, parse_bytes
 
 import ucp
 from ucp._libs import ucx_api

--- a/benchmarks/send-recv.py
+++ b/benchmarks/send-recv.py
@@ -44,7 +44,7 @@ import multiprocessing as mp
 import os
 from time import perf_counter as clock
 
-from distributed.utils import format_bytes, parse_bytes
+from dask.utils import format_bytes, parse_bytes
 
 import ucp
 

--- a/debug-tests/debug_utils.py
+++ b/debug-tests/debug_utils.py
@@ -5,7 +5,7 @@ import cloudpickle
 import cupy
 from utils import get_num_gpus
 
-from distributed.utils import parse_bytes
+from dask.utils import parse_bytes
 
 import rmm
 


### PR DESCRIPTION
Resolves deprecation warnings such as the one below:

```python
FutureWarning: parse_bytes is deprecated and will be removed in a future release. Please use dask.utils.parse_bytes instead.
    from distributed.utils import parse_bytes
```