### PR TITLE
Fix `assert_eq` related imports

### DIFF
--- a/debug-tests/client.py
+++ b/debug-tests/client.py
@@ -82,7 +82,7 @@ def client(env, port, func, verbose):
     # cuda_obj_generator = cloudpickle.loads(func)
     # pure_cuda_obj = cuda_obj_generator()
 
-    # from cudf.tests.utils import assert_eq
+    # from cudf.testing._utils import assert_eq
     # import cupy as cp
 
     # if isinstance(rx_cuda_obj, cp.ndarray):

--- a/tests/test_custom_send_recv.py
+++ b/tests/test_custom_send_recv.py
@@ -115,7 +115,7 @@ async def test_send_recv_cudf(event_loop, g):
     typ = type(msg)
     res = typ.deserialize(ucx_header, cudf_buffer)
 
-    from cudf.tests.utils import assert_eq
+    from cudf.testing._utils import assert_eq
 
     assert_eq(res, msg)
     await uu.comm.ep.close()

--- a/tests/test_send_recv_two_workers.py
+++ b/tests/test_send_recv_two_workers.py
@@ -12,7 +12,7 @@ from distributed.comm.utils import to_frames
 from distributed.protocol import to_serialize
 from distributed.utils import nbytes
 
-import cudf.tests.utils
+import cudf.testing._utils
 
 import ucp
 
@@ -89,7 +89,7 @@ def client(port, func, comm_api):
     if isinstance(rx_cuda_obj, cupy.ndarray):
         cupy.testing.assert_allclose(rx_cuda_obj, pure_cuda_obj)
     else:
-        cudf.tests.utils.assert_eq(rx_cuda_obj, pure_cuda_obj)
+        cudf.testing._utils.assert_eq(rx_cuda_obj, pure_cuda_obj)
 
 
 def server(port, func, comm_api):


### PR DESCRIPTION
Recently there has been a change of location of where the testing utils of cudf reside. This PR is adapting to those changes.

