### PR TITLE
Fix typo in CI script that sets wrong UCX_TLS for UCX 1.11

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -85,7 +85,7 @@ function run_tests() {
     # Setting UCX options
     export UCXPY_IFNAME=eth0
 
-    if [ "$UCX111" == "1"]; then
+    if [ "$UCX111" == "1" ]; then
         export UCX_TLS=tcp,cuda_copy
     else
         export UCX_TLS=tcp,cuda_copy,sockcm

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -108,7 +108,6 @@ function run_tests() {
         py.test --cache-clear -vs distributed/distributed/protocol/tests/test_numba.py
         py.test --cache-clear -vs distributed/distributed/protocol/tests/test_rmm.py
         py.test --cache-clear -vs distributed/distributed/protocol/tests/test_collection_cuda.py
-        py.test --cache-clear -vs distributed/distributed/comm/tests/test_ucx.py
         py.test --cache-clear -vs distributed/distributed/tests/test_nanny.py
         py.test --cache-clear -vs --runslow distributed/distributed/comm/tests/test_ucx.py
     fi


### PR DESCRIPTION
Additionally remove duplicate distributed tests covering UCX-Py.