### PR TITLE
Try different interfaces if UCXPY_IFNAME is undefined

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -83,8 +83,6 @@ function run_tests() {
     ls tests/
 
     # Setting UCX options
-    export UCXPY_IFNAME=eth0
-
     if [ "$UCX111" == "1" ]; then
         export UCX_TLS=tcp,cuda_copy
     else


### PR DESCRIPTION
If `UCXPY_IFNAME` is undefined, let `ucp.get_address` try to pick a suitable interface to establish connections. This is helpful to allow CI testing on different systems without knowing what interfaces are available to establish connection between two UCX processes.