### PR TITLE
Change core tests default endpoint error handling according to UCX version

### DIFF
--- a/ucp/_libs/tests/test_mem.py
+++ b/ucp/_libs/tests/test_mem.py
@@ -5,6 +5,7 @@ import mmap
 import pytest
 
 from ucp._libs import ucx_api
+from ucp._libs.utils_test import get_endpoint_error_handling_default
 
 builtin_buffers = [
     b"",
@@ -59,7 +60,9 @@ def test_rkey_unpack():
     packed_rkey = mem.pack_rkey()
     worker = ucx_api.UCXWorker(ctx)
     ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, worker.get_address(), endpoint_error_handling=False
+        worker,
+        worker.get_address(),
+        endpoint_error_handling=get_endpoint_error_handling_default(),
     )
     rkey = ep.unpack_rkey(packed_rkey)
     assert rkey is not None

--- a/ucp/_libs/tests/test_peer_send_recv.py
+++ b/ucp/_libs/tests/test_peer_send_recv.py
@@ -5,14 +5,19 @@ from itertools import repeat
 import pytest
 
 from ucp._libs import ucx_api
-from ucp._libs.utils_test import blocking_flush, blocking_recv, blocking_send
+from ucp._libs.utils_test import (
+    blocking_flush,
+    blocking_recv,
+    blocking_send,
+    get_endpoint_error_handling_default,
+)
 
 mp = mp.get_context("spawn")
 
 
 def _rma_setup(worker, address, prkey, base, msg_size):
     ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, address, endpoint_error_handling=False
+        worker, address, endpoint_error_handling=get_endpoint_error_handling_default()
     )
     rkey = ep.unpack_rkey(prkey)
     mem = ucx_api.RemoteMemory(rkey, base, msg_size)
@@ -73,10 +78,14 @@ def _test_peer_communication_tag(queue, rank, msg_size):
     left_rank, left_address = queue.get()
 
     right_ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, right_address, endpoint_error_handling=False
+        worker,
+        right_address,
+        endpoint_error_handling=get_endpoint_error_handling_default(),
     )
     left_ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, left_address, endpoint_error_handling=False
+        worker,
+        left_address,
+        endpoint_error_handling=get_endpoint_error_handling_default(),
     )
     recv_msg = bytearray(msg_size)
     if rank == 0:

--- a/ucp/_libs/tests/test_rma.py
+++ b/ucp/_libs/tests/test_rma.py
@@ -6,7 +6,10 @@ import os
 import pytest
 
 from ucp._libs import ucx_api
-from ucp._libs.utils_test import blocking_flush
+from ucp._libs.utils_test import (
+    blocking_flush,
+    get_endpoint_error_handling_default,
+)
 
 builtin_buffers = [
     b"",
@@ -33,7 +36,9 @@ def test_flush():
     ctx = ucx_api.UCXContext({})
     worker = ucx_api.UCXWorker(ctx)
     ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, worker.get_address(), endpoint_error_handling=False
+        worker,
+        worker.get_address(),
+        endpoint_error_handling=get_endpoint_error_handling_default(),
     )
     req = ep.flush(_)
     if req is None:
@@ -50,7 +55,9 @@ def test_implicit(msg_size):
     packed_rkey = mem.pack_rkey()
     worker = ucx_api.UCXWorker(ctx)
     ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, worker.get_address(), endpoint_error_handling=False
+        worker,
+        worker.get_address(),
+        endpoint_error_handling=get_endpoint_error_handling_default(),
     )
     rkey = ep.unpack_rkey(packed_rkey)
     self_mem = ucx_api.RemoteMemory(rkey, mem.address, msg_size)
@@ -71,7 +78,9 @@ def test_explicit(msg_size):
     packed_rkey = mem.pack_rkey()
     worker = ucx_api.UCXWorker(ctx)
     ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, worker.get_address(), endpoint_error_handling=False
+        worker,
+        worker.get_address(),
+        endpoint_error_handling=get_endpoint_error_handling_default(),
     )
     rkey = ep.unpack_rkey(packed_rkey)
     self_mem = ucx_api.RemoteMemory(rkey, mem.address, msg_size)
@@ -94,7 +103,9 @@ def test_ucxio(msg_size):
     packed_rkey = mem.pack_rkey()
     worker = ucx_api.UCXWorker(ctx)
     ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, worker.get_address(), endpoint_error_handling=False
+        worker,
+        worker.get_address(),
+        endpoint_error_handling=get_endpoint_error_handling_default(),
     )
     rkey = ep.unpack_rkey(packed_rkey)
 
@@ -114,7 +125,9 @@ def test_force_requests():
     packed_rkey = mem.pack_rkey()
     worker = ucx_api.UCXWorker(ctx)
     ep = ucx_api.UCXEndpoint.create_from_worker_address(
-        worker, worker.get_address(), endpoint_error_handling=False
+        worker,
+        worker.get_address(),
+        endpoint_error_handling=get_endpoint_error_handling_default(),
     )
     rkey = ep.unpack_rkey(packed_rkey)
     self_mem = ucx_api.RemoteMemory(rkey, mem.address, msg_size)

--- a/ucp/_libs/utils_test.py
+++ b/ucp/_libs/utils_test.py
@@ -75,3 +75,7 @@ def blocking_am_recv(worker, ep):
     while ret[0] is None:
         worker.progress()
     return ret[0]
+
+
+def get_endpoint_error_handling_default():
+    return ucx_api.get_ucx_version() >= (1, 10, 0)


### PR DESCRIPTION
On newer UCX versions it's important to have endpoint error handling enabled, this ensures that core tests will enable it depending on the UCX version installed.