### PR TITLE
Drop disconnect/shutdown tests without error handling in UCX >= 1.10

### DIFF
--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -80,8 +80,7 @@ def _test_shutdown_unexpected_closed_peer_client(
     asyncio.get_event_loop().run_until_complete(run())
 
 
-@pytest.mark.parametrize("endpoint_error_handling", [True, False])
-def test_shutdown_unexpected_closed_peer(caplog, endpoint_error_handling):
+def test_shutdown_unexpected_closed_peer(caplog):
     """
     Test clean server shutdown after unexpected peer close
 
@@ -89,21 +88,18 @@ def test_shutdown_unexpected_closed_peer(caplog, endpoint_error_handling):
     The main goal is to assert that the processes exit without errors
     despite a somewhat messy initial state.
     """
-    if endpoint_error_handling is True:
-        if ucp.get_ucx_version() < (1, 10, 0):
-            pytest.skip("Endpoint error handling is only supported for UCX >= 1.10")
-    else:
-        if any(
-            [
-                t.startswith(i)
-                for i in ("rc", "dc", "ud")
-                for t in ucp.get_active_transports()
-            ]
-        ):
-            pytest.skip(
-                "Endpoint error handling is required when rc, dc or ud"
-                "transport is enabled"
-            )
+    endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
+    if endpoint_error_handling is False and any(
+        [
+            t.startswith(i)
+            for i in ("rc", "dc", "ud")
+            for t in ucp.get_active_transports()
+        ]
+    ):
+        pytest.skip(
+            "Endpoint error handling is required when rc, dc or ud"
+            "transport is enabled"
+        )
 
     client_queue = mp.Queue()
     server_queue = mp.Queue()

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -26,11 +26,9 @@ def event_loop(scope="function"):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("endpoint_error_handling", [False, True])
-async def test_server_shutdown(endpoint_error_handling):
+async def test_server_shutdown():
     """The server calls shutdown"""
-    if ucp.get_ucx_version() < (1, 10, 0) and endpoint_error_handling is True:
-        pytest.skip("Endpoint error handling is only supported for UCX >= 1.10")
+    endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
 
     async def server_node(ep):
         msg = np.empty(10 ** 6)
@@ -55,11 +53,9 @@ async def test_server_shutdown(endpoint_error_handling):
     sys.version_info < (3, 7), reason="test currently fails for python3.6"
 )
 @pytest.mark.asyncio
-@pytest.mark.parametrize("endpoint_error_handling", [False, True])
-async def test_client_shutdown(endpoint_error_handling):
+async def test_client_shutdown():
     """The client calls shutdown"""
-    if ucp.get_ucx_version() < (1, 10, 0) and endpoint_error_handling is True:
-        pytest.skip("Endpoint error handling is only supported for UCX >= 1.10")
+    endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
 
     async def client_node(port):
         ep = await ucp.create_endpoint(
@@ -81,11 +77,9 @@ async def test_client_shutdown(endpoint_error_handling):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("endpoint_error_handling", [False, True])
-async def test_listener_close(endpoint_error_handling):
+async def test_listener_close():
     """The server close the listener"""
-    if ucp.get_ucx_version() < (1, 10, 0) and endpoint_error_handling is True:
-        pytest.skip("Endpoint error handling is only supported for UCX >= 1.10")
+    endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
 
     async def client_node(listener):
         ep = await ucp.create_endpoint(
@@ -111,11 +105,9 @@ async def test_listener_close(endpoint_error_handling):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("endpoint_error_handling", [False, True])
-async def test_listener_del(endpoint_error_handling):
+async def test_listener_del():
     """The client delete the listener"""
-    if ucp.get_ucx_version() < (1, 10, 0) and endpoint_error_handling is True:
-        pytest.skip("Endpoint error handling is only supported for UCX >= 1.10")
+    endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
 
     async def server_node(ep):
         await ep.send(np.arange(100, dtype=np.int64))
@@ -137,11 +129,9 @@ async def test_listener_del(endpoint_error_handling):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("endpoint_error_handling", [False, True])
-async def test_close_after_n_recv(endpoint_error_handling):
+async def test_close_after_n_recv():
     """The Endpoint.close_after_n_recv()"""
-    if ucp.get_ucx_version() < (1, 10, 0) and endpoint_error_handling is True:
-        pytest.skip("Endpoint error handling is only supported for UCX >= 1.10")
+    endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
 
     async def server_node(ep):
         for _ in range(10):


### PR DESCRIPTION
Endpoint error handling shall always be enabled on UCX 1.10 and above, this removes disconnect/shutdown testing of UCX 1.10+ when endpoint error handling is disabled.