### PR TITLE
Cancel waiting `am_recv` if endpoint closes

### DIFF
--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -25,6 +25,11 @@ def event_loop(scope="function"):
     loop.close()
 
 
+def _skip_if_not_supported(message_type):
+    if message_type == "am" and not ucp._libs.ucx_api.is_am_supported():
+        pytest.skip("AM only supported in UCX >= 1.11")
+
+
 async def _shutdown_send(ep, message_type):
     msg = np.arange(10 ** 6)
     if message_type == "tag":
@@ -46,6 +51,8 @@ async def _shutdown_recv(ep, message_type):
 async def test_server_shutdown(message_type):
     """The server calls shutdown"""
     endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
+
+    _skip_if_not_supported(message_type)
 
     async def server_node(ep):
         with pytest.raises(ucp.exceptions.UCXCanceled):
@@ -73,6 +80,8 @@ async def test_client_shutdown(message_type):
     """The client calls shutdown"""
     endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
 
+    _skip_if_not_supported(message_type)
+
     async def client_node(port):
         ep = await ucp.create_endpoint(
             ucp.get_address(), port, endpoint_error_handling=endpoint_error_handling
@@ -95,6 +104,8 @@ async def test_client_shutdown(message_type):
 async def test_listener_close(message_type):
     """The server close the listener"""
     endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
+
+    _skip_if_not_supported(message_type)
 
     async def client_node(listener):
         ep = await ucp.create_endpoint(
@@ -123,6 +134,8 @@ async def test_listener_del(message_type):
     """The client delete the listener"""
     endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
 
+    _skip_if_not_supported(message_type)
+
     async def server_node(ep):
         await _shutdown_send(ep, message_type)
         await _shutdown_send(ep, message_type)
@@ -146,6 +159,8 @@ async def test_listener_del(message_type):
 async def test_close_after_n_recv(message_type):
     """The Endpoint.close_after_n_recv()"""
     endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
+
+    _skip_if_not_supported(message_type)
 
     async def server_node(ep):
         for _ in range(10):

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -114,6 +114,7 @@ async def test_listener_close(message_type):
             endpoint_error_handling=endpoint_error_handling,
         )
         await _shutdown_recv(ep, message_type)
+        await _shutdown_recv(ep, message_type)
         assert listener.closed() is False
         listener.close()
         assert listener.closed() is True

--- a/ucp/_libs/transfer_am.pyx
+++ b/ucp/_libs/transfer_am.pyx
@@ -230,18 +230,13 @@ def am_recv_nb(
         else:
             if ep_as_int not in worker._am_recv_wait:
                 worker._am_recv_wait[ep_as_int] = list()
-            wait_task = {
-                "cb_func": cb_func,
-                "cb_args": cb_args,
-                "cb_kwargs": cb_kwargs
-            }
-
-            # Handles message receive
-            worker._am_recv_wait[ep_as_int].append(wait_task)
-
-            # Handles endpoint closing
-            ep._am_recv_wait.append(wait_task)
-
+            worker._am_recv_wait[ep_as_int].append(
+                {
+                    "cb_func": cb_func,
+                    "cb_args": cb_args,
+                    "cb_kwargs": cb_kwargs
+                }
+            )
             logger.debug("AM recv waiting: ep %s" % (hex(ep_as_int), ))
     ELSE:
         if is_am_supported():

--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -85,7 +85,7 @@ def _ucx_endpoint_finalizer(
 
     # Cancel waiting `am_recv` calls
     cdef dict recv_wait
-    if handle_as_int in worker._am_recv_wait:
+    if is_am_supported() and handle_as_int in worker._am_recv_wait:
         while len(worker._am_recv_wait[handle_as_int]) > 0:
             recv_wait = worker._am_recv_wait[handle_as_int].pop(0)
             cb_func = recv_wait["cb_func"]


### PR DESCRIPTION
Cancelling `am_recv` was only done when an error occurred during AM message receive callback in the worker, but if an endpoint closed while the client is waiting for that message it would hang indefinitely. This change cancels any waiting `am_recv` at the endpoint finalizer as well.