### PR TITLE
Fix UCXAddress finalizer

### DIFF
--- a/ucp/_libs/ucx_address.pyx
+++ b/ucp/_libs/ucx_address.pyx
@@ -32,7 +32,7 @@ cdef class UCXAddress(UCXObject):
     def __cinit__(
             self,
             uintptr_t address_as_int,
-            Py_ssize_t length,
+            size_t length,
             UCXWorker worker=None,
     ):
         address = <ucp_address_t *> address_as_int
@@ -63,7 +63,7 @@ cdef class UCXAddress(UCXObject):
         cdef size_t length
         status = ucp_worker_get_address(ucp_worker, &address, &length)
         assert_ucs_status(status)
-        return UCXAddress(int(<uintptr_t>address), length, worker=worker)
+        return UCXAddress(<uintptr_t>address, length, worker=worker)
 
     @property
     def address(self):

--- a/ucp/_libs/ucx_address.pyx
+++ b/ucp/_libs/ucx_address.pyx
@@ -27,7 +27,7 @@ def _ucx_address_finalizer(
 cdef class UCXAddress(UCXObject):
     """Python representation of ucp_address_t"""
     cdef ucp_address_t *_address
-    cdef Py_ssize_t _length
+    cdef size_t _length
 
     def __cinit__(
             self,


### PR DESCRIPTION
According to the UCX documentation, the [worker address cannot be used after `ucp_worker_release_address`](https://openucx.github.io/ucx/api/v1.11/html/group___u_c_p___w_o_r_k_e_r.html#ga94260829739496267d2c8d86414b863d). This change fixes that by adding a finalizer to `UCXAddress` that will only release the handle when the object is destroyed.

Even though `test_peer_communication` passed, the errors would be printed to stdout, which this change resolves as well.

```python
Traceback (most recent call last):
  File "/datasets/pentschev/miniconda3/envs/gdf/lib/python3.8/site-packages/ucp/exceptions.py", line 13, in log_errors
    yield
  File "ucp/_libs/transfer_common.pyx", line 55, in ucp._libs.ucx_api._send_callback
    cb_func(req, exception, *cb_args, **cb_kwargs)
  File "ucp/_libs/ucx_rkey.pyx", line 13, in ucp._libs.ucx_api._ucx_remote_mem_finalizer_post_flush
    assert exception is None
AssertionError
[1629385917.006941] [dgx13:18276:0]           mpool.c:44   UCX  WARN  object 0x558daf1c9a40 was not returned to mpool ucp_rkeys
[1629385917.006965] [dgx13:18276:0]           mpool.c:44   UCX  WARN  object 0x558daf1c9bc0 was not returned to mpool ucp_rkeys
[1629385917.020369] [dgx13:18174:0]           mpool.c:44   UCX  WARN  object 0x5606b2b67bc0 was not returned to mpool ucp_rkeys
[1629385917.020377] [dgx13:18174:0]           mpool.c:44   UCX  WARN  object 0x5606b2b67c80 was not returned to mpool ucp_rkeys
```