### PR TITLE
Add missing check for enabled AM in endpoint finalizer

### DIFF
--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -64,6 +64,9 @@ def _ucx_endpoint_finalizer(
     cdef ucp_ep_h handle = <ucp_ep_h>handle_as_int
     cdef ucs_status_ptr_t status
     cdef ucs_status_t ep_status
+    cdef bint am_enabled = (
+        is_am_supported() and Feature.AM in worker._context._feature_flags
+    )
 
     if <void *>status_handle_as_int == NULL:
         ep_status = UCS_OK
@@ -85,7 +88,7 @@ def _ucx_endpoint_finalizer(
 
     # Cancel waiting `am_recv` calls
     cdef dict recv_wait
-    if is_am_supported() and handle_as_int in worker._am_recv_wait:
+    if am_enabled and handle_as_int in worker._am_recv_wait:
         while len(worker._am_recv_wait[handle_as_int]) > 0:
             recv_wait = worker._am_recv_wait[handle_as_int].pop(0)
             cb_func = recv_wait["cb_func"]


### PR DESCRIPTION
Without this check the previous condition would fail in the event that AM is not enabled with errors such as below:

```python
Traceback (most recent call last):
  File "/datasets/pentschev/miniconda3/envs/gdf/lib/python3.8/weakref.py", line 642, in _exitfunc
    f()
  File "/datasets/pentschev/miniconda3/envs/gdf/lib/python3.8/weakref.py", line 566, in __call__
Exception ignored in: <finalize object at 0x7f37c01f1480; dead>
Traceback (most recent call last):
  File "/datasets/pentschev/miniconda3/envs/gdf/lib/python3.8/weakref.py", line 566, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
  File "ucp/_libs/ucx_object.pyx", line 16, in ucp._libs.ucx_api._handle_finalizer_wrapper
  File "ucp/_libs/ucx_endpoint.pyx", line 88, in ucp._libs.ucx_api._ucx_endpoint_finalizer
TypeError: 'NoneType' object is not iterable
    return info.func(*info.args, **(info.kwargs or {}))
  File "ucp/_libs/ucx_object.pyx", line 16, in ucp._libs.ucx_api._handle_finalizer_wrapper
  File "ucp/_libs/ucx_endpoint.pyx", line 88, in ucp._libs.ucx_api._ucx_endpoint_finalizer
TypeError: 'NoneType' object is not iterable
```