### PR TITLE
Add support for endpoints from worker address on async API

### DIFF
--- a/tests/test_from_worker_address.py
+++ b/tests/test_from_worker_address.py
@@ -1,0 +1,72 @@
+import asyncio
+import multiprocessing as mp
+
+import numpy as np
+
+import ucp
+
+mp = mp.get_context("spawn")
+
+
+def _test_from_worker_address_server(queue):
+    async def run():
+        # Send worker address to client process via multiprocessing.Queue
+        address = ucp.get_worker_address()
+        queue.put(address)
+
+        # Receive address size
+        address_size = np.empty(1, dtype=np.int64)
+        await ucp.recv(address_size, tag=0)
+
+        # Receive address buffer on tag 0 and create UCXAddress from it
+        remote_address = bytearray(address_size[0])
+        await ucp.recv(remote_address, tag=0)
+        remote_address = ucp._libs.ucx_api.UCXAddress.from_buffer(remote_address)
+
+        # Create endpoint to remote worker using the received address
+        ep = await ucp.create_endpoint_from_worker_address(remote_address)
+
+        # Send data to client's endpoint
+        send_msg = np.arange(10, dtype=np.int64)
+        await ep.send(send_msg, tag=1, force_tag=True)
+
+    asyncio.get_event_loop().run_until_complete(run())
+
+
+def _test_from_worker_address_client(queue):
+    async def run():
+        # Read local worker address
+        address = ucp.get_worker_address()
+
+        # Receive worker address from server via multiprocessing.Queue, create
+        # endpoint to server
+        remote_address = queue.get()
+        ep = await ucp.create_endpoint_from_worker_address(remote_address)
+
+        # Send local address to server on tag 0
+        await ep.send(np.array(address.length, np.int64), tag=0, force_tag=True)
+        await ep.send(address, tag=0, force_tag=True)
+
+        # Receive message from server
+        recv_msg = np.empty(10, dtype=np.int64)
+        await ucp.recv(recv_msg, tag=1)
+
+        np.testing.assert_array_equal(recv_msg, np.arange(10, dtype=np.int64))
+
+    asyncio.get_event_loop().run_until_complete(run())
+
+
+def test_from_worker_address():
+    queue = mp.Queue()
+
+    server = mp.Process(target=_test_from_worker_address_server, args=(queue,),)
+    server.start()
+
+    client = mp.Process(target=_test_from_worker_address_client, args=(queue,),)
+    client.start()
+
+    client.join()
+    server.join()
+
+    assert not server.exitcode
+    assert not client.exitcode

--- a/tests/test_from_worker_address.py
+++ b/tests/test_from_worker_address.py
@@ -24,7 +24,7 @@ def _test_from_worker_address_server(queue):
         # Receive address buffer on tag 0 and create UCXAddress from it
         remote_address = bytearray(address_size[0])
         await ucp.recv(remote_address, tag=0)
-        remote_address = ucp._libs.ucx_api.UCXAddress.from_buffer(remote_address)
+        remote_address = ucp.get_ucx_address_from_buffer(remote_address)
 
         # Create endpoint to remote worker using the received address
         ep = await ucp.create_endpoint_from_worker_address(remote_address)
@@ -140,9 +140,7 @@ def _test_from_worker_address_server_fixedsize(num_nodes, queue):
         async def _handle_client(packed_remote_address):
             # Unpack the fixed-size address+tag buffer
             unpacked = _unpack_address_and_tag(packed_remote_address)
-            remote_address = ucp._libs.ucx_api.UCXAddress.from_buffer(
-                unpacked["address"]
-            )
+            remote_address = ucp.get_ucx_address_from_buffer(unpacked["address"])
 
             # Create endpoint to remote worker using the received address
             ep = await ucp.create_endpoint_from_worker_address(remote_address)
@@ -193,9 +191,7 @@ def _test_from_worker_address_client_fixedsize(queue):
         remote_address = queue.get()
         ep = await ucp.create_endpoint_from_worker_address(remote_address)
 
-        # # Send local address to server on tag 0
-        # await ep.send(np.array(address.length, np.int64), tag=0, force_tag=True)
-        # await ep.send(address, tag=0, force_tag=True)
+        # Send local address to server on tag 0
         await ep.send(packed_address, tag=0, force_tag=True)
 
         # Receive message from server

--- a/tests/test_from_worker_address.py
+++ b/tests/test_from_worker_address.py
@@ -152,7 +152,7 @@ def _test_from_worker_address_server_fixedsize(num_nodes, queue):
             await ep.send(send_msg, tag=unpacked["send_tag"], force_tag=True)
 
             # Receive data from client's endpoint
-            recv_msg = np.arange(20, dtype=np.int64)
+            recv_msg = np.empty(20, dtype=np.int64)
             await ep.recv(recv_msg, tag=unpacked["recv_tag"], force_tag=True)
 
             np.testing.assert_array_equal(recv_msg, np.arange(20, dtype=np.int64))
@@ -205,7 +205,7 @@ def _test_from_worker_address_client_fixedsize(queue):
         np.testing.assert_array_equal(recv_msg, np.arange(10, dtype=np.int64))
 
         # Send message to server
-        send_msg = np.empty(20, dtype=np.int64)
+        send_msg = np.arange(20, dtype=np.int64)
         await ep.send(send_msg, tag=send_tag, force_tag=True)
 
     asyncio.get_event_loop().run_until_complete(run())

--- a/tests/test_from_worker_address.py
+++ b/tests/test_from_worker_address.py
@@ -211,7 +211,6 @@ def _test_from_worker_address_client_fixedsize(queue):
     asyncio.get_event_loop().run_until_complete(run())
 
 
-@pytest.mark.skipif(ucp.get_ucx_version() < (1, 11, 0), reason="Fails in UCX < 1.11")
 @pytest.mark.parametrize("num_nodes", [1, 2, 4, 8])
 def test_from_worker_address_multinode(num_nodes):
     queue = mp.Queue()

--- a/tests/test_from_worker_address.py
+++ b/tests/test_from_worker_address.py
@@ -1,7 +1,10 @@
 import asyncio
 import multiprocessing as mp
+import os
+import struct
 
 import numpy as np
+import pytest
 
 import ucp
 
@@ -49,7 +52,7 @@ def _test_from_worker_address_client(queue):
 
         # Receive message from server
         recv_msg = np.empty(10, dtype=np.int64)
-        await ucp.recv(recv_msg, tag=1)
+        await ep.recv(recv_msg, tag=1, force_tag=True)
 
         np.testing.assert_array_equal(recv_msg, np.arange(10, dtype=np.int64))
 
@@ -66,6 +69,168 @@ def test_from_worker_address():
     client.start()
 
     client.join()
+    server.join()
+
+    assert not server.exitcode
+    assert not client.exitcode
+
+
+def _get_address_info(address=None):
+    # Fixed frame size
+    frame_size = 10000
+
+    # Header format: Recv Tag (Q) + Send Tag (Q) + UCXAddress.length (Q)
+    header_fmt = "QQQ"
+
+    # Data length
+    data_length = frame_size - struct.calcsize(header_fmt)
+
+    # Padding length
+    padding_length = None if address is None else (data_length - address.length)
+
+    # Header + UCXAddress string + padding
+    fixed_size_address_buffer_fmt = header_fmt + str(data_length) + "s"
+
+    assert struct.calcsize(fixed_size_address_buffer_fmt) == frame_size
+
+    return {
+        "frame_size": frame_size,
+        "data_length": data_length,
+        "padding_length": padding_length,
+        "fixed_size_address_buffer_fmt": fixed_size_address_buffer_fmt,
+    }
+
+
+def _pack_address_and_tag(address, recv_tag, send_tag):
+    address_info = _get_address_info(address)
+
+    fixed_size_address_packed = struct.pack(
+        address_info["fixed_size_address_buffer_fmt"],
+        recv_tag,  # Recv Tag
+        send_tag,  # Send Tag
+        address.length,  # Address buffer length
+        (
+            bytearray(address) + bytearray(address_info["padding_length"])
+        ),  # Address buffer + padding
+    )
+
+    assert len(fixed_size_address_packed) == address_info["frame_size"]
+
+    return fixed_size_address_packed
+
+
+def _unpack_address_and_tag(address_packed):
+    address_info = _get_address_info()
+
+    recv_tag, send_tag, address_length, address_padded = struct.unpack(
+        address_info["fixed_size_address_buffer_fmt"], address_packed,
+    )
+
+    # Swap send and recv tags, as they are used by the remote process in the
+    # opposite direction.
+    return {
+        "address": address_padded[:address_length],
+        "recv_tag": send_tag,
+        "send_tag": recv_tag,
+    }
+
+
+def _test_from_worker_address_server_fixedsize(num_nodes, queue):
+    async def run():
+        async def _handle_client(packed_remote_address):
+            # Unpack the fixed-size address+tag buffer
+            unpacked = _unpack_address_and_tag(packed_remote_address)
+            remote_address = ucp._libs.ucx_api.UCXAddress.from_buffer(
+                unpacked["address"]
+            )
+
+            # Create endpoint to remote worker using the received address
+            ep = await ucp.create_endpoint_from_worker_address(remote_address)
+
+            # Send data to client's endpoint
+            send_msg = np.arange(10, dtype=np.int64)
+            await ep.send(send_msg, tag=unpacked["send_tag"], force_tag=True)
+
+            # Receive data from client's endpoint
+            recv_msg = np.arange(20, dtype=np.int64)
+            await ep.recv(recv_msg, tag=unpacked["recv_tag"], force_tag=True)
+
+            np.testing.assert_array_equal(recv_msg, np.arange(20, dtype=np.int64))
+
+        # Send worker address to client processes via multiprocessing.Queue,
+        # one entry for each client.
+        address = ucp.get_worker_address()
+        for i in range(num_nodes):
+            queue.put(address)
+
+        address_info = _get_address_info()
+
+        server_tasks = []
+        for i in range(num_nodes):
+            # Receive fixed-size address+tag buffer on tag 0
+            packed_remote_address = bytearray(address_info["frame_size"])
+            await ucp.recv(packed_remote_address, tag=0)
+
+            # Create an async task for client
+            server_tasks.append(_handle_client(packed_remote_address))
+
+        # Await handling each client request
+        await asyncio.gather(*server_tasks)
+
+    asyncio.get_event_loop().run_until_complete(run())
+
+
+def _test_from_worker_address_client_fixedsize(queue):
+    async def run():
+        # Read local worker address
+        address = ucp.get_worker_address()
+        recv_tag = ucp.utils.hash64bits(os.urandom(16))
+        send_tag = ucp.utils.hash64bits(os.urandom(16))
+        packed_address = _pack_address_and_tag(address, recv_tag, send_tag)
+
+        # Receive worker address from server via multiprocessing.Queue, create
+        # endpoint to server
+        remote_address = queue.get()
+        ep = await ucp.create_endpoint_from_worker_address(remote_address)
+
+        # # Send local address to server on tag 0
+        # await ep.send(np.array(address.length, np.int64), tag=0, force_tag=True)
+        # await ep.send(address, tag=0, force_tag=True)
+        await ep.send(packed_address, tag=0, force_tag=True)
+
+        # Receive message from server
+        recv_msg = np.empty(10, dtype=np.int64)
+        await ep.recv(recv_msg, tag=recv_tag, force_tag=True)
+
+        np.testing.assert_array_equal(recv_msg, np.arange(10, dtype=np.int64))
+
+        # Send message to server
+        send_msg = np.empty(20, dtype=np.int64)
+        await ep.send(send_msg, tag=send_tag, force_tag=True)
+
+    asyncio.get_event_loop().run_until_complete(run())
+
+
+@pytest.mark.parametrize("num_nodes", [1, 2, 4, 8])
+def test_from_worker_address_multinode(num_nodes):
+    queue = mp.Queue()
+
+    server = mp.Process(
+        target=_test_from_worker_address_server_fixedsize, args=(num_nodes, queue),
+    )
+    server.start()
+
+    clients = []
+    for i in range(num_nodes):
+        client = mp.Process(
+            target=_test_from_worker_address_client_fixedsize, args=(queue,),
+        )
+        client.start()
+        clients.append(client)
+
+    for client in clients:
+        client.join()
+
     server.join()
 
     assert not server.exitcode

--- a/tests/test_from_worker_address.py
+++ b/tests/test_from_worker_address.py
@@ -211,6 +211,7 @@ def _test_from_worker_address_client_fixedsize(queue):
     asyncio.get_event_loop().run_until_complete(run())
 
 
+@pytest.mark.skipif(ucp.get_ucx_version() < (1, 11, 0), reason="Fails in UCX < 1.11")
 @pytest.mark.parametrize("num_nodes", [1, 2, 4, 8])
 def test_from_worker_address_multinode(num_nodes):
     queue = mp.Queue()

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -3,6 +3,7 @@
 # See file LICENSE for terms.
 
 import asyncio
+from typing import Union
 
 from ._libs import arr, ucx_api
 
@@ -80,7 +81,7 @@ def stream_send(
 
 
 def tag_recv(
-    ep: ucx_api.UCXEndpoint,
+    obj: Union[ucx_api.UCXEndpoint, ucx_api.UCXWorker],
     buffer: arr.Array,
     nbytes: int,
     tag: int,
@@ -88,15 +89,11 @@ def tag_recv(
     event_loop=None,
 ) -> asyncio.Future:
 
+    worker = obj if isinstance(obj, ucx_api.UCXWorker) else obj.worker
+    ep = obj if isinstance(obj, ucx_api.UCXEndpoint) else None
+
     return _call_ucx_api(
-        event_loop,
-        ucx_api.tag_recv_nb,
-        ep.worker,
-        buffer,
-        nbytes,
-        tag,
-        name=name,
-        ep=ep,
+        event_loop, ucx_api.tag_recv_nb, worker, buffer, nbytes, tag, name=name, ep=ep,
     )
 
 

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -471,8 +471,8 @@ class ApplicationContext:
         self.worker.register_am_allocator(allocator, allocator_type)
 
     @nvtx_annotate("UCXPY_WORKER_RECV", color="red", domain="ucxpy")
-    async def recv(self, buffer, tag=None):
-        """Receive from connected peer into `buffer`.
+    async def recv(self, buffer, tag):
+        """Receive directly on worker without a local Endpoint into `buffer`.
 
         Parameters
         ----------
@@ -480,9 +480,7 @@ class ApplicationContext:
             The buffer to receive into. Raise ValueError if buffer
             is smaller than nbytes or read-only.
         tag: hashable, optional
-            Set a tag that must match the received message. Notice, currently
-            UCX-Py doesn't support a "any tag" thus `tag=None` only matches a
-            send that also sets `tag=None`.
+            Set a tag that must match the received message.
         """
         if not isinstance(buffer, Array):
             buffer = Array(buffer)
@@ -999,7 +997,7 @@ def get_worker_address():
     return _get_ctx().get_worker_address()
 
 
-async def recv(buffer, tag=None):
+async def recv(buffer, tag):
     return await _get_ctx().recv(buffer, tag=tag)
 
 

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -218,6 +218,11 @@ class ApplicationContext:
                 self, _epoll_fd_finalizer, self.epoll_fd, self.progress_tasks
             )
 
+        # Ensure progress even before Endpoints get created, for example to
+        # receive messages directly on a worker after a remote endpoint
+        # connected with `create_endpoint_from_worker_address`.
+        self.continuous_ucx_progress()
+
     def create_listener(
         self, callback_func, port=0, endpoint_error_handling=None,
     ):

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -997,6 +997,10 @@ def get_worker_address():
     return _get_ctx().get_worker_address()
 
 
+def get_ucx_address_from_buffer(buffer):
+    return ucx_api.UCXAddress.from_buffer(buffer)
+
+
 async def recv(buffer, tag):
     return await _get_ctx().recv(buffer, tag=tag)
 


### PR DESCRIPTION
Using a UCX listener may not be possible for systems that are IP-less, as that is required to create an endpoint to the listening server. For such cases, it's possible to use the UCX worker address to connect to a remote worker. This PR exposes the worker address feature to the UCX-Py async API, additionally includes a couple of tests that can be used as reference for setting up a "server" worker that exposes its address and handle client connections in a similar way to how the UCX-Py listener does.