### PR TITLE
Add FutureWarning of UCX < 1.11.1 deprecation

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -91,8 +91,8 @@ Instructions for building UCX 1.11.1:
     make -j install
 
 
-UCX-1.9
-~~~~~~~
+UCX-1.9 (Deprecated)
+~~~~~~~~~~~~~~~~~~~~
 
 Instructions for building ucx 1.9:
 
@@ -131,7 +131,7 @@ As noted above, the UCX conda package no longer builds support for IB/RDMA.  To 
 
 If OFED drivers are not installed on the machine, you can download drivers at directly from `Mellanox <https://www.mellanox.com/products/infiniband-drivers/linux/mlnx_ofed>`_.  For versions older than 5.1 click on, *archive versions*.
 
-Building UCX 1.9 or 1.11 as shown previously should automatically include IB/RDMA support if available in the system. It is possible to explicitly activate those, ensuring the system satisfies all dependencies or fail otherwise, by including the ``--with-rdmacm`` and ``--with-verbs`` build flags. For example:
+Building UCX 1.11.1 or 1.9 (deprecated) as shown previously should automatically include IB/RDMA support if available in the system. It is possible to explicitly activate those, ensuring the system satisfies all dependencies or fail otherwise, by including the ``--with-rdmacm`` and ``--with-verbs`` build flags. For example:
 
 ::
 

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import warnings
 
 from ._version import get_versions as _get_versions
 from .core import *  # noqa
@@ -40,3 +41,10 @@ logger = get_ucxpy_logger()
 
 __version__ = _get_versions()["version"]
 __ucx_version__ = "%d.%d.%d" % get_ucx_version()
+
+if get_ucx_version() < (1, 11, 1):
+    warnings.warn(
+        f"Support for UCX {__ucx_version__} is deprecated, it's highly recommended "
+        "upgrading to 1.11.1 or newer.",
+        FutureWarning,
+    )


### PR DESCRIPTION
Besides stability, UCX 1.11.1 includes important features such as:

* Automatic InfiniBand<->CUDA device mapping without specifying `UCX_NET_DEVICES` explicitly;
* InfiniBand allocation registration cache without patching source;
* Endpoint error handling with CUDA IPC;
* etc.

All features above will simplify usage both with and without Dask and RAPIDS. Therefore, we would like to deprecate older versions of UCX, to be removed at a later release.