### PR TITLE
Add reference Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
+    apt-get install -y \
+        automake \
+        dh-make \
+        g++ \
+        git \
+        libcap2 \
+        libhwloc-dev \
+        libnuma-dev \
+        libtool \
+        make \
+        udev \
+        wget \
+    && apt-get remove -y openjdk-11-* || apt-get autoremove -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY run.sh /root
+
+WORKDIR /root
+
+CMD [ "/root/run.sh" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# Docker container
+
+## Summary
+
+Contains reference dockerfile and build script to run UCX-Py tests and benchmarks. This is a minimal setup, without support for CUDA, MOFED or rdma-core.
+
+## Building Docker image
+
+To begin, it's necessary to build the image, this is done as follows:
+
+```bash
+cd docker
+docker build -t ucx-py -f Dockerfile .
+```
+
+## Running
+
+Once building the Docker image is complete, the container can be started with the following command:
+
+```bash
+docker run ucx-py
+```
+
+The container above will run UCX-Py tests and benchmarks.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright (c) 2021, NVIDIA CORPORATION.
+set -e
+
+function logger {
+    echo -e "\n$@\n"
+}
+
+PYTHON_PREFIX=$(python -c "import distutils.sysconfig; print(distutils.sysconfig.PREFIX)")
+
+################################################################################
+# SETUP - Install python packages and check environment
+################################################################################
+
+pip install \
+    "pytest" "pytest-asyncio" \
+    "dask" "distributed" \
+	"cython"
+
+logger "Check versions"
+python --version
+pip list
+
+################################################################################
+# BUILD - Build UCX master, UCX-Py and run tests
+################################################################################
+logger "Build UCX master"
+cd $HOME
+git clone https://github.com/openucx/ucx
+cd ucx
+./autogen.sh
+./contrib/configure-devel \
+    --prefix=$PYTHON_PREFIX \
+    --enable-gtest=no \
+    --with-valgrind=no
+make -j install
+
+echo $PYTHON_PREFIX >> /etc/ld.so.conf.d/python.conf
+ldconfig
+
+logger "UCX Version and Build Information"
+ucx_info -v
+
+
+################################################################################
+# TEST - Run pytests for ucx-py
+################################################################################
+logger "Clone and Build UCX-Py"
+cd $HOME
+git clone https://github.com/rapidsai/ucx-py
+cd ucx-py
+python setup.py build_ext --inplace
+python -m pip install -e .
+
+for tls in "tcp" "all"; do
+    export UCX_TLS=$tls
+
+    logger "Python pytest for ucx-py"
+
+    # Test with TCP/Sockets
+    logger "Tests (UCX_TLS=$UCX_TLS)"
+    pytest --cache-clear -vs ucp/_libs/tests
+    pytest --cache-clear -vs tests/
+
+    logger "Benchmarks (UCX_TLS=$UCX_TLS)"
+    python benchmarks/send-recv.py -o numpy \
+        --server-dev 0 --client-dev 0 --reuse-alloc
+    python benchmarks/send-recv-core.py -o numpy \
+        --server-dev 0 --client-dev 0 --reuse-alloc
+done


### PR DESCRIPTION
To help users get started with UCX-Py, add a reference Docker container. The container is based off of the official `python:3` container, we then install dependencies required to build and use UCX and UCX-Py via `apt`. When running, the container will install Python dependencies required by UCX-Py, build UCX from source, build UCX-Py and run tests and benchmarks. Currently includes a minimal setup only, without CUDA, MOFED or rdma-core support.