### PR TITLE
Add compile-time variable UCXPY_DISABLE_HWLOC

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -55,9 +55,11 @@ Build Dependencies
 
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
-        libhwloc psutil \
+        psutil \
         "python=3.7" setuptools "cython>=0.29.14,<3.0.0a0"
 
+
+If you are using UCX 1.9 and older and using both CUDA and InfiniBand support, ensure ``libhwloc`` is also on the list above.
 
 Test Dependencies
 ~~~~~~~~~~~~~~~~~
@@ -157,3 +159,8 @@ UCX-Py
     pip install .
     # or for develop build
     pip install -v -e .
+
+In UCX 1.10 and above, or for builds that don't need CUDA and InfiniBand support, users can disable building with hwloc support:
+
+::
+    UCXPY_DISABLE_HWLOC=1 pip install .

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extra_compile_args = ["-std=c99", "-Werror"]
 DISABLE_HWLOC = int(os.environ.get("UCXPY_DISABLE_HWLOC", "0"))
 topological_distance_ext = []
 if DISABLE_HWLOC == 0:
-    libraries.append(["hwloc"])
+    libraries.append("hwloc")
     topological_distance_ext = [
         Extension(
             "ucp._libs.topological_distance",

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,31 @@ with open("README.md", "r") as fh:
 
 include_dirs = [os.path.dirname(get_python_inc())]
 library_dirs = [get_config_var("LIBDIR")]
-libraries = ["ucp", "uct", "ucm", "ucs", "hwloc"]
+libraries = ["ucp", "uct", "ucm", "ucs"]
 extra_compile_args = ["-std=c99", "-Werror"]
+
+
+DISABLE_HWLOC = int(os.environ.get("UCXPY_DISABLE_HWLOC", "0"))
+topological_distance_ext = []
+if DISABLE_HWLOC == 0:
+    libraries.append(["hwloc"])
+    topological_distance_ext = [
+        Extension(
+            "ucp._libs.topological_distance",
+            sources=[
+                "ucp/_libs/topological_distance.pyx",
+                "ucp/_libs/src/topological_distance.c",
+            ],
+            depends=[
+                "ucp/_libs/src/topological_distance.h",
+                "ucp/_libs/topological_distance_dep.pxd",
+            ],
+            include_dirs=include_dirs,
+            library_dirs=library_dirs,
+            libraries=libraries,
+            extra_compile_args=extra_compile_args,
+        ),
+    ]
 
 
 def get_ucp_version():
@@ -59,22 +82,8 @@ ext_modules = cythonize(
             libraries=libraries,
             extra_compile_args=extra_compile_args,
         ),
-        Extension(
-            "ucp._libs.topological_distance",
-            sources=[
-                "ucp/_libs/topological_distance.pyx",
-                "ucp/_libs/src/topological_distance.c",
-            ],
-            depends=[
-                "ucp/_libs/src/topological_distance.h",
-                "ucp/_libs/topological_distance_dep.pxd",
-            ],
-            include_dirs=include_dirs,
-            library_dirs=library_dirs,
-            libraries=libraries,
-            extra_compile_args=extra_compile_args,
-        ),
-    ],
+    ]
+    + topological_distance_ext,
     compile_time_env={"CY_UCP_AM_SUPPORTED": _am_supported},
 )
 


### PR DESCRIPTION
For UCX 1.9 and older we needed hwloc to determine the closest InfiniBand device to a GPU. With UCX 1.10+ this isn't necessary anymore, so it's a deprecated feature. Since building with hwloc can be problematic for some use cases, add a new compile-time environment variable to allow disabling build of topological distance code.