### PR TITLE
Make ucx-py installation blocks consistent

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -163,4 +163,6 @@ UCX-Py
 In UCX 1.10 and above, or for builds that don't need CUDA and InfiniBand support, users can disable building with hwloc support:
 
 ::
+
+    UCXPY_DISABLE_HWLOC=1 python setup.py build_ext --inplace
     UCXPY_DISABLE_HWLOC=1 pip install .

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -155,8 +155,7 @@ UCX-Py
     conda activate ucx
     git clone https://github.com/rapidsai/ucx-py.git
     cd ucx-py
-    python setup.py build_ext --inplace
-    pip install .
+    pip install -v .
     # or for develop build
     pip install -v -e .
 
@@ -164,5 +163,4 @@ In UCX 1.10 and above, or for builds that don't need CUDA and InfiniBand support
 
 ::
 
-    UCXPY_DISABLE_HWLOC=1 python setup.py build_ext --inplace
-    UCXPY_DISABLE_HWLOC=1 pip install .
+    UCXPY_DISABLE_HWLOC=1 pip install -v .


### PR DESCRIPTION
Consistently instructs users to use `pip install -v .` to install ucx-py, to remove any ambiguity from the instructions on disabling building with hwloc support.