### PR TITLE
Add --delay-progress option to send-recv-core benchmark

### DIFF
--- a/benchmarks/send-recv-core.py
+++ b/benchmarks/send-recv-core.py
@@ -133,9 +133,12 @@ def server(queue, args):
 
     def _tag_recv_handle(request, exception, ep, msg):
         assert exception is None
-        ucx_api.tag_send_nb(
+        req = ucx_api.tag_send_nb(
             ep, msg, msg.nbytes, tag=0, cb_func=_send_handle, cb_args=(msg,)
         )
+        if req is None:
+            with finished_lock:
+                finished[0] += 1
 
     def _am_recv_handle(recv_obj, exception, ep):
         assert exception is None


### PR DESCRIPTION
After a lot of benchmarking of UCX-Py and digging into the details of `ucx_perftest`, I've found out that one of the biggest differences in performance there, particularly for short messages, is that it doesn't do blocking send/recv, but instead delays calling `ucp_worker_progress` based on the number of outstanding operations. This is great to show the maximum potential of UCX/UCX-Py, but I'm still unsure whether this can be used in the async API, much less in applications such as Dask.