### PR TITLE
Avoid explicitly closing loops in benchmarks/tests

### DIFF
--- a/benchmarks/send-recv.py
+++ b/benchmarks/send-recv.py
@@ -130,7 +130,6 @@ def server(queue, args):
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run())
-    loop.close()
 
 
 def client(queue, port, server_address, args):
@@ -203,7 +202,7 @@ def client(queue, port, server_address, args):
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run())
-    loop.close()
+
     times = queue.get()
     assert len(times) == args.n_iter
     print("Roundtrip benchmark")

--- a/tests/test_send_recv.py
+++ b/tests/test_send_recv.py
@@ -26,7 +26,6 @@ def event_loop(scope="function"):
     yield loop
     ucp.reset()
     loop.run_until_complete(asyncio.sleep(0))
-    loop.close()
 
 
 def make_echo_server(create_empty_data):

--- a/tests/test_send_recv_am.py
+++ b/tests/test_send_recv_am.py
@@ -61,7 +61,6 @@ def event_loop(scope="function"):
     yield loop
     ucp.reset()
     loop.run_until_complete(asyncio.sleep(0))
-    loop.close()
 
 
 def simple_server(size, recv):

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -22,7 +22,6 @@ def event_loop(scope="function"):
     yield loop
     ucp.reset()
     loop.run_until_complete(asyncio.sleep(0))
-    loop.close()
 
 
 def _skip_if_not_supported(message_type):


### PR DESCRIPTION
This is an attempt to fix errors such as:

```
sys:1: RuntimeWarning: coroutine 'BlockingMode._arm_worker' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Task was destroyed but it is pending!
```

This happens because the event loop is closed before the rest of
UCX-Py's finalizers/destructors are executed, which prevents the
`_arm_worker` task from being cancelled in `ProgressTask`'s destructor.