### PR TITLE
Do not set UCX_MEMTYPE_CACHE for UCX >= 1.12

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("ucx")
 
 # Notice, if we have to update environment variables
 # we need to do it before importing UCX
-if "UCX_MEMTYPE_CACHE" not in os.environ:
+if "UCX_MEMTYPE_CACHE" not in os.environ and get_ucx_version() < (1, 12, 0):
     # See <https://github.com/openucx/ucx/wiki/NVIDIA-GPU-Support#known-issues>
     logger.debug("Setting env UCX_MEMTYPE_CACHE=n, which is required by UCX")
     os.environ["UCX_MEMTYPE_CACHE"] = "n"


### PR DESCRIPTION
`UCX_MEMTYPE_CACHE=n` is no longer needed with UCX 1.12 and above, and raises the warning below when set:

```
parser.c:1907 UCX  WARN  unused env variable: UCX_MEMTYPE_CACHE (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
```