### PR TITLE
Raise UCXNotConnected on stream receive callback

### DIFF
--- a/ucp/_libs/transfer_stream.pyx
+++ b/ucp/_libs/transfer_stream.pyx
@@ -9,7 +9,13 @@ from libc.stdint cimport uintptr_t
 from .arr cimport Array
 from .ucx_api_dep cimport *
 
-from ..exceptions import UCXCanceled, UCXError, UCXMsgTruncated, log_errors
+from ..exceptions import (
+    UCXCanceled,
+    UCXError,
+    UCXMsgTruncated,
+    UCXNotConnected,
+    log_errors,
+)
 
 
 def stream_send_nb(
@@ -113,6 +119,10 @@ cdef void _stream_recv_callback(
             name = req_info["name"]
             msg = "<%s>: " % name
             exception = UCXCanceled(msg)
+        if status == UCS_ERR_NOT_CONNECTED:
+            name = req_info["name"]
+            msg = "<%s>: " % name
+            exception = UCXNotConnected(msg)
         elif status != UCS_OK:
             name = req_info["name"]
             ucx_status_msg = ucs_status_string(status).decode("utf-8")

--- a/ucp/_libs/ucx_api_dep.pxd
+++ b/ucp/_libs/ucx_api_dep.pxd
@@ -137,6 +137,7 @@ cdef extern from "ucp/api/ucp.h":
     ucs_status_t UCS_ERR_NO_ELEM
     ucs_status_t UCS_ERR_BUSY
     ucs_status_t UCS_ERR_CANCELED
+    ucs_status_t UCS_ERR_NOT_CONNECTED
     ucs_status_t UCS_ERR_CONNECTION_RESET
 
     void ucp_get_version(unsigned * major_version,

--- a/ucp/exceptions.py
+++ b/ucp/exceptions.py
@@ -47,3 +47,7 @@ class UCXConnectionReset(UCXBaseException):
 
 class UCXMsgTruncated(UCXBaseException):
     pass
+
+
+class UCXNotConnected(UCXBaseException):
+    pass


### PR DESCRIPTION
This is an issue that occurs non-deterministically in Distributed, generally during `client._reconnect` at shutdown when peers have already begun closing. Therefore, we need to catch this exception and raise `CommClosedError` in Distributed to prevent unhandled errors.