### PR TITLE
Fix conditional in _stream_recv_callback

### DIFF
--- a/ucp/_libs/transfer_stream.pyx
+++ b/ucp/_libs/transfer_stream.pyx
@@ -119,7 +119,7 @@ cdef void _stream_recv_callback(
             name = req_info["name"]
             msg = "<%s>: " % name
             exception = UCXCanceled(msg)
-        if status == UCS_ERR_NOT_CONNECTED:
+        elif status == UCS_ERR_NOT_CONNECTED:
             name = req_info["name"]
             msg = "<%s>: " % name
             exception = UCXNotConnected(msg)


### PR DESCRIPTION
With https://github.com/rapidsai/ucx-py/pull/799 I introduced a subtle but highly problematic issue that ironically cancels out the `UCXCanceled` error in the stream receive callback, this PR fixes that.