### PR TITLE
Fix core config tests for UCX 1.12

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -4,9 +4,12 @@ import ucp
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    ucp.get_ucx_version() < (1, 11, 0),
+    reason="Endpoint error handling is unreliable in UCX releases prior to 1.11.0",
+)
 @pytest.mark.parametrize("server_close_callback", [True, False])
 async def test_close_callback(server_close_callback):
-    endpoint_error_handling = ucp.get_ucx_version() >= (1, 10, 0)
     closed = [False]
 
     def _close_callback():
@@ -21,17 +24,13 @@ async def test_close_callback(server_close_callback):
             await ep.close()
 
     async def client_node(port):
-        ep = await ucp.create_endpoint(
-            ucp.get_address(), port, endpoint_error_handling=endpoint_error_handling
-        )
+        ep = await ucp.create_endpoint(ucp.get_address(), port,)
         if server_close_callback is False:
             ep.set_close_callback(_close_callback)
         await ep.send(bytearray(b"0" * 10))
         if server_close_callback is True:
             await ep.close()
 
-    listener = ucp.create_listener(
-        server_node, endpoint_error_handling=endpoint_error_handling
-    )
+    listener = ucp.create_listener(server_node,)
     await client_node(listener.port)
     assert closed[0] is True

--- a/tests/test_topological_distance.py
+++ b/tests/test_topological_distance.py
@@ -3,7 +3,7 @@ import os
 import pynvml
 import pytest
 
-from ucp._libs.topological_distance import TopologicalDistance
+topological_distance = pytest.importorskip("ucp._libs.topological_distance")
 
 
 def test_topological_distance_dgx():
@@ -56,7 +56,7 @@ def test_topological_distance_dgx():
     else:
         pytest.skip("DGX Server not recognized or not supported")
 
-    td = TopologicalDistance()
+    td = topological_distance.TopologicalDistance()
 
     for i in range(dev_count):
         closest_network = td.get_cuda_distances_from_device_index(i, "network")

--- a/ucp/_libs/tests/test_endpoint.py
+++ b/ucp/_libs/tests/test_endpoint.py
@@ -65,6 +65,10 @@ def _client(port, endpoint_error_handling, server_close_callback):
             worker.progress()
 
 
+@pytest.mark.skipif(
+    ucx_api.get_ucx_version() < (1, 11, 0),
+    reason="Endpoint error handling is unreliable in UCX releases prior to 1.11.0",
+)
 @pytest.mark.parametrize("server_close_callback", [True, False])
 def test_close_callback(server_close_callback):
     endpoint_error_handling = ucx_api.get_ucx_version() >= (1, 10, 0)


### PR DESCRIPTION
Config tests for UCX 1.12 with the async API were already fixed in https://github.com/rapidsai/ucx-py/pull/804, but the core tests missed the same fixes.

Additionally, skip `TopologicalDistance` tests when UCX-Py is built using `UCXPY_DISABLE_HWLOC=1`, as well as skipping endpoint close callback tests for UCX < 1.11.