### PR TITLE
Probe AM messages before raising UCXCloseError

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -9,8 +9,7 @@ import ucp
     reason="Endpoint error handling is unreliable in UCX releases prior to 1.11.0",
 )
 @pytest.mark.parametrize("server_close_callback", [True, False])
-@pytest.mark.parametrize("transfer_api", ["am", "tag"])
-async def test_close_callback(server_close_callback, transfer_api):
+async def test_close_callback(server_close_callback):
     closed = [False]
 
     def _close_callback():
@@ -19,11 +18,6 @@ async def test_close_callback(server_close_callback, transfer_api):
     async def server_node(ep):
         if server_close_callback is True:
             ep.set_close_callback(_close_callback)
-        if transfer_api == "am":
-            await ep.am_recv()
-        else:
-            msg = bytearray(10)
-            await ep.recv(msg)
         if server_close_callback is False:
             await ep.close()
 
@@ -31,10 +25,6 @@ async def test_close_callback(server_close_callback, transfer_api):
         ep = await ucp.create_endpoint(ucp.get_address(), port,)
         if server_close_callback is False:
             ep.set_close_callback(_close_callback)
-        if transfer_api == "am":
-            await ep.am_send(bytearray(b"0" * 10))
-        else:
-            await ep.send(bytearray(b"0" * 10))
         if server_close_callback is True:
             await ep.close()
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -9,7 +9,8 @@ import ucp
     reason="Endpoint error handling is unreliable in UCX releases prior to 1.11.0",
 )
 @pytest.mark.parametrize("server_close_callback", [True, False])
-async def test_close_callback(server_close_callback):
+@pytest.mark.parametrize("transfer_api", ["am", "tag"])
+async def test_close_callback(server_close_callback, transfer_api):
     closed = [False]
 
     def _close_callback():
@@ -18,8 +19,11 @@ async def test_close_callback(server_close_callback):
     async def server_node(ep):
         if server_close_callback is True:
             ep.set_close_callback(_close_callback)
-        msg = bytearray(10)
-        await ep.recv(msg)
+        if transfer_api == "am":
+            await ep.am_recv()
+        else:
+            msg = bytearray(10)
+            await ep.recv(msg)
         if server_close_callback is False:
             await ep.close()
 
@@ -27,7 +31,10 @@ async def test_close_callback(server_close_callback):
         ep = await ucp.create_endpoint(ucp.get_address(), port,)
         if server_close_callback is False:
             ep.set_close_callback(_close_callback)
-        await ep.send(bytearray(b"0" * 10))
+        if transfer_api == "am":
+            await ep.am_send(bytearray(b"0" * 10))
+        else:
+            await ep.send(bytearray(b"0" * 10))
         if server_close_callback is True:
             await ep.close()
 

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,38 @@
+import pytest
+
+import ucp
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    ucp.get_ucx_version() < (1, 11, 0),
+    reason="Endpoint error handling is unreliable in UCX releases prior to 1.11.0",
+)
+@pytest.mark.parametrize("transfer_api", ["am", "tag"])
+async def test_message_probe(transfer_api):
+    msg = bytearray(b"0" * 10)
+
+    async def server_node(ep):
+        # Wait for remote endpoint to close before probing the endpoint for
+        # in-transit message and receiving it.
+        while not ep.closed():
+            pass
+
+        if transfer_api == "am":
+            assert ep._ep.am_probe() is True
+            received = await ep.am_recv()
+        else:
+            assert ep._ctx.worker.tag_probe(ep._tags["msg_recv"]) is True
+            received = bytearray(10)
+            await ep.recv(received)
+        assert received == msg
+
+    async def client_node(port):
+        ep = await ucp.create_endpoint(ucp.get_address(), port,)
+        if transfer_api == "am":
+            await ep.am_send(msg)
+        else:
+            await ep.send(msg)
+
+    listener = ucp.create_listener(server_node,)
+    await client_node(listener.port)

--- a/ucp/_libs/tests/test_probe.py
+++ b/ucp/_libs/tests/test_probe.py
@@ -31,20 +31,20 @@ def _server_probe(queue, transfer_api):
     worker = ucx_api.UCXWorker(ctx)
 
     # Keep endpoint to be used from outside the listener callback
-    global ep
-    ep = None
+    ep = [None]
 
     def _listener_handler(conn_request):
-        global ep
-        ep = ucx_api.UCXEndpoint.create_from_conn_request(
+        ep[0] = ucx_api.UCXEndpoint.create_from_conn_request(
             worker, conn_request, endpoint_error_handling=True,
         )
 
     listener = ucx_api.UCXListener(worker=worker, port=0, cb_func=_listener_handler)
     queue.put(listener.port),
 
-    while ep is None:
+    while ep[0] is None:
         worker.progress()
+
+    ep = ep[0]
 
     # Ensure wireup and inform client before it can disconnect
     if transfer_api == "am":

--- a/ucp/_libs/tests/test_probe.py
+++ b/ucp/_libs/tests/test_probe.py
@@ -1,0 +1,92 @@
+import multiprocessing as mp
+
+import pytest
+
+from ucp._libs import ucx_api
+from ucp._libs.utils_test import (
+    blocking_am_recv,
+    blocking_am_send,
+    blocking_recv,
+    blocking_send,
+)
+
+mp = mp.get_context("spawn")
+
+
+def _server_probe(queue, transfer_api):
+    """Server that send received message back to the client
+
+    Notice, since it is illegal to call progress() in call-back functions,
+    we use a "chain" of call-back functions.
+    """
+    feature_flags = (
+        ucx_api.Feature.AM if transfer_api == "am" else ucx_api.Feature.TAG,
+    )
+    ctx = ucx_api.UCXContext(feature_flags=feature_flags)
+    worker = ucx_api.UCXWorker(ctx)
+
+    listener_finished = [False]
+
+    def _listener_handler(conn_request):
+        global ep
+        ep = ucx_api.UCXEndpoint.create_from_conn_request(
+            worker, conn_request, endpoint_error_handling=True,
+        )
+        while ep.is_alive():
+            worker.progress()
+
+        if transfer_api == "am":
+            assert ep.am_probe() is True
+
+            received = blocking_am_recv(worker, ep)
+        else:
+            assert worker.tag_probe(0) is True
+
+            received = bytearray(10)
+            blocking_recv(worker, ep, received)
+
+        assert received == bytearray(b"0" * 10)
+
+        listener_finished[0] = True
+
+    listener = ucx_api.UCXListener(worker=worker, port=0, cb_func=_listener_handler)
+    queue.put(listener.port),
+
+    while listener_finished[0] is False:
+        worker.progress()
+
+
+def _client_probe(port, transfer_api):
+    msg = bytearray(b"0" * 10)
+
+    feature_flags = (
+        ucx_api.Feature.AM if transfer_api == "am" else ucx_api.Feature.TAG,
+    )
+    ctx = ucx_api.UCXContext(feature_flags=feature_flags)
+    worker = ucx_api.UCXWorker(ctx)
+    ep = ucx_api.UCXEndpoint.create(
+        worker, "localhost", port, endpoint_error_handling=True,
+    )
+
+    if transfer_api == "am":
+        blocking_am_send(worker, ep, msg)
+    else:
+        blocking_send(worker, ep, msg)
+
+
+@pytest.mark.skipif(
+    ucx_api.get_ucx_version() < (1, 11, 0),
+    reason="Endpoint error handling is unreliable in UCX releases prior to 1.11.0",
+)
+@pytest.mark.parametrize("transfer_api", ["am", "tag"])
+def test_message_probe(transfer_api):
+    queue = mp.Queue()
+    server = mp.Process(target=_server_probe, args=(queue, transfer_api),)
+    server.start()
+    port = queue.get()
+    client = mp.Process(target=_client_probe, args=(port, transfer_api),)
+    client.start()
+    client.join(timeout=10)
+    server.join(timeout=10)
+    assert client.exitcode == 0
+    assert server.exitcode == 0

--- a/ucp/_libs/tests/test_probe.py
+++ b/ucp/_libs/tests/test_probe.py
@@ -2,6 +2,7 @@ import multiprocessing as mp
 
 import pytest
 
+from ucp import get_address
 from ucp._libs import ucx_api
 from ucp._libs.utils_test import (
     blocking_am_recv,
@@ -12,12 +13,16 @@ from ucp._libs.utils_test import (
 
 mp = mp.get_context("spawn")
 
+WireupMessage = bytearray(b"wireup")
+DataMessage = bytearray(b"0" * 10)
+
 
 def _server_probe(queue, transfer_api):
-    """Server that send received message back to the client
+    """Server that probes and receives message after client disconnected.
 
-    Notice, since it is illegal to call progress() in call-back functions,
-    we use a "chain" of call-back functions.
+    Note that since it is illegal to call progress() in callback functions,
+    we keep a reference to the endpoint after the listener callback has
+    terminated, this way we can progress even after Python blocking calls.
     """
     feature_flags = (
         ucx_api.Feature.AM if transfer_api == "am" else ucx_api.Feature.TAG,
@@ -25,53 +30,67 @@ def _server_probe(queue, transfer_api):
     ctx = ucx_api.UCXContext(feature_flags=feature_flags)
     worker = ucx_api.UCXWorker(ctx)
 
-    listener_finished = [False]
+    # Keep endpoint to be used from outside the listener callback
+    global ep
+    ep = None
 
     def _listener_handler(conn_request):
         global ep
         ep = ucx_api.UCXEndpoint.create_from_conn_request(
             worker, conn_request, endpoint_error_handling=True,
         )
-        while ep.is_alive():
-            worker.progress()
-
-        if transfer_api == "am":
-            assert ep.am_probe() is True
-
-            received = blocking_am_recv(worker, ep)
-        else:
-            assert worker.tag_probe(0) is True
-
-            received = bytearray(10)
-            blocking_recv(worker, ep, received)
-
-        assert received == bytearray(b"0" * 10)
-
-        listener_finished[0] = True
 
     listener = ucx_api.UCXListener(worker=worker, port=0, cb_func=_listener_handler)
     queue.put(listener.port),
 
-    while listener_finished[0] is False:
+    while ep is None:
         worker.progress()
 
+    # Ensure wireup and inform client before it can disconnect
+    if transfer_api == "am":
+        wireup = blocking_am_recv(worker, ep)
+    else:
+        wireup = bytearray(len(WireupMessage))
+        blocking_recv(worker, ep, wireup)
+    queue.put("wireup completed")
 
-def _client_probe(port, transfer_api):
-    msg = bytearray(b"0" * 10)
+    # Ensure client has disconnected -- endpoint is not alive anymore
+    while ep.is_alive() is True:
+        worker.progress()
 
+    # Probe/receive message even after the remote endpoint has disconnected
+    if transfer_api == "am":
+        while ep.am_probe() is False:
+            worker.progress()
+        received = blocking_am_recv(worker, ep)
+    else:
+        while worker.tag_probe(0) is False:
+            worker.progress()
+        received = bytearray(len(DataMessage))
+        blocking_recv(worker, ep, received)
+
+    assert wireup == WireupMessage
+    assert received == DataMessage
+
+
+def _client_probe(queue, transfer_api):
     feature_flags = (
         ucx_api.Feature.AM if transfer_api == "am" else ucx_api.Feature.TAG,
     )
     ctx = ucx_api.UCXContext(feature_flags=feature_flags)
     worker = ucx_api.UCXWorker(ctx)
+    port = queue.get()
     ep = ucx_api.UCXEndpoint.create(
-        worker, "localhost", port, endpoint_error_handling=True,
+        worker, get_address(), port, endpoint_error_handling=True,
     )
 
-    if transfer_api == "am":
-        blocking_am_send(worker, ep, msg)
-    else:
-        blocking_send(worker, ep, msg)
+    _send = blocking_am_send if transfer_api == "am" else blocking_send
+
+    _send(worker, ep, WireupMessage)
+    _send(worker, ep, DataMessage)
+
+    # Wait for wireup before disconnecting
+    assert queue.get() == "wireup completed"
 
 
 @pytest.mark.skipif(
@@ -83,8 +102,7 @@ def test_message_probe(transfer_api):
     queue = mp.Queue()
     server = mp.Process(target=_server_probe, args=(queue, transfer_api),)
     server.start()
-    port = queue.get()
-    client = mp.Process(target=_client_probe, args=(port, transfer_api),)
+    client = mp.Process(target=_client_probe, args=(queue, transfer_api),)
     client.start()
     client.join(timeout=10)
     server.join(timeout=10)

--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -341,3 +341,6 @@ cdef class UCXEndpoint(UCXObject):
 
     def set_close_callback(self, cb_func):
         self._endpoint_close_callback.set(cb_func)
+
+    def am_probe(self):
+        return self.handle in self.worker._am_recv_pool

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -736,8 +736,11 @@ class Endpoint:
     async def am_recv(self):
         """Receive from connected peer.
         """
-        if self.closed():
-            raise UCXCloseError("Endpoint closed")
+        if not self._ep.am_probe():
+            self._ep.raise_on_error()
+            if self.closed():
+                raise UCXCloseError("Endpoint closed")
+
         log = "[AM Recv #%03d] ep: %s" % (self._recv_count, hex(self.uid))
         logger.debug(log)
         self._recv_count += 1


### PR DESCRIPTION
When receiving with the AM API, it may happen that a remote endpoint has closed but messages were delivered to the local worker. By allowing to probe that worker for messages, it's possible to consume those instead of discarding them. Only after the remote endpoint has closed and no more messages exist on the local worker a `UCXCloseError` is raised.