### PR TITLE
Reorder and reenable UCX_MEMTYPE_CACHE=n for all UCX versions

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -6,19 +6,20 @@
 import logging
 import os
 
-from ._version import get_versions as _get_versions
-from .core import *  # noqa
-from .core import get_ucx_version
-from .utils import get_address, get_ucxpy_logger  # noqa
-
 logger = logging.getLogger("ucx")
 
-# Notice, if we have to update environment variables
-# we need to do it before importing UCX
-if "UCX_MEMTYPE_CACHE" not in os.environ and get_ucx_version() < (1, 12, 0):
+# Notice, if we have to update environment variables we need to do it
+# before importing UCX, which must happen also before the Cython code
+# import to prevent UCS unused variable warnings.
+if "UCX_MEMTYPE_CACHE" not in os.environ:
     # See <https://github.com/openucx/ucx/wiki/NVIDIA-GPU-Support#known-issues>
     logger.debug("Setting env UCX_MEMTYPE_CACHE=n, which is required by UCX")
     os.environ["UCX_MEMTYPE_CACHE"] = "n"
+
+from ._version import get_versions as _get_versions  # noqa
+from .core import *  # noqa
+from .core import get_ucx_version  # noqa
+from .utils import get_address, get_ucxpy_logger  # noqa
 
 if "UCX_SOCKADDR_TLS_PRIORITY" not in os.environ and get_ucx_version() < (1, 11, 0):
     logger.debug(


### PR DESCRIPTION
UCX_MEMTYPE_CACHE=n is still required even for UCX 1.12 (see
https://github.com/openucx/ucx/issues/7575), so we reenable it.
Reordering the import is also required to prevent UCS warnings when
Cython code is imported.