### PR TITLE
Ensure am_recv waiting futures are canceled

### DIFF
--- a/ucp/_libs/ucx_worker.pyx
+++ b/ucp/_libs/ucx_worker.pyx
@@ -120,7 +120,7 @@ cdef class UCXWorker(UCXObject):
         status = ucp_worker_create(context._handle, &worker_params, &self._handle)
         assert_ucs_status(status)
         self._inflight_msgs = set()
-        self._inflight_msgs_to_cancel = dict({"tag": set()})
+        self._inflight_msgs_to_cancel = {"tag": set()}
 
         IF CY_UCP_AM_SUPPORTED:
             cdef int AM_MSG_ID = 0

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -668,10 +668,9 @@ class Endpoint:
         if not isinstance(buffer, Array):
             buffer = Array(buffer)
         nbytes = buffer.nbytes
-        log = "[AM Send #%03d] ep: %s, tag: %s, nbytes: %d, type: %s" % (
+        log = "[AM Send #%03d] ep: %s, nbytes: %d, type: %s" % (
             self._send_count,
             hex(self.uid),
-            hex(self._tags["msg_send"]),
             nbytes,
             type(buffer.obj),
         )


### PR DESCRIPTION
When am_recv is being awaited and an endpoint error, the future needs to be canceled to prevent an indefinite hang.