### PR TITLE
Update `RAPIDS_VERSION` var and `update-version.sh` script

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -26,7 +26,7 @@ export HOME=$WORKSPACE
 cd $WORKSPACE
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
-export RAPIDS_VERSION="21.10"
+export RAPIDS_VERSION="21.12"
 export TEST_UCX_MASTER=0
 
 ################################################################################

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -24,3 +24,10 @@ NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
 echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
 
+# Inplace sed replace; workaround for Linux and Mac
+function sed_runner() {
+    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+}
+
+# cpp update
+sed_runner "s/export RAPIDS_VERSION=.*/export RAPIDS_VERSION=\"${NEXT_MAJOR}.${NEXT_MINOR}\"/g" ci/gpu/build.sh


### PR DESCRIPTION
This PR updates the `RAPIDS_VERSION` variable and also includes a command in `update-version.sh` to ensure that it gets updated during releases.