### PR TITLE
Prevent endpoint canceling AM messages multiple times

### DIFF
--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -34,3 +34,32 @@ async def test_close_callback(server_close_callback):
     listener = ucp.create_listener(server_node,)
     await client_node(listener.port)
     assert closed[0] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    ucp.get_ucx_version() < (1, 11, 0),
+    reason="Endpoint error handling is unreliable in UCX releases prior to 1.11.0",
+)
+@pytest.mark.parametrize("transfer_api", ["am", "tag"])
+async def test_cancel(transfer_api):
+    async def server_node(ep):
+        await ep.close()
+
+    async def client_node(port):
+        ep = await ucp.create_endpoint(ucp.get_address(), port,)
+        if transfer_api == "am":
+            with pytest.raises(
+                ucp.exceptions.UCXCanceled, match="am_recv",
+            ):
+                await ep.am_recv()
+        else:
+            with pytest.raises(
+                ucp.exceptions.UCXCanceled, match="Recv.*tag",
+            ):
+                msg = bytearray(1)
+                await ep.recv(msg)
+        await ep.close()
+
+    listener = ucp.create_listener(server_node,)
+    await client_node(listener.port)

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -47,7 +47,7 @@ async def test_cancel(transfer_api):
         await ep.close()
 
     async def client_node(port):
-        ep = await ucp.create_endpoint(ucp.get_address(), port,)
+        ep = await ucp.create_endpoint(ucp.get_address(), port)
         if transfer_api == "am":
             with pytest.raises(
                 ucp.exceptions.UCXCanceled, match="am_recv",
@@ -61,5 +61,5 @@ async def test_cancel(transfer_api):
                 await ep.recv(msg)
         await ep.close()
 
-    listener = ucp.create_listener(server_node,)
+    listener = ucp.create_listener(server_node)
     await client_node(listener.port)

--- a/ucp/_libs/tests/test_cancel.py
+++ b/ucp/_libs/tests/test_cancel.py
@@ -40,7 +40,7 @@ def _server_cancel(queue, transfer_api):
         )
 
     listener = ucx_api.UCXListener(worker=worker, port=0, cb_func=_listener_handler)
-    queue.put(listener.port),
+    queue.put(listener.port)
 
     while ep[0] is None:
         worker.progress()

--- a/ucp/_libs/tests/test_cancel.py
+++ b/ucp/_libs/tests/test_cancel.py
@@ -1,0 +1,108 @@
+import multiprocessing as mp
+import re
+
+import pytest
+
+from ucp import get_address
+from ucp._libs import ucx_api
+from ucp._libs.arr import Array
+from ucp.exceptions import UCXCanceled
+
+mp = mp.get_context("spawn")
+
+WireupMessage = bytearray(b"wireup")
+DataMessage = bytearray(b"0" * 10)
+
+
+def _handler(request, exception, ret):
+    if exception is not None:
+        ret[0] = exception
+    else:
+        ret[0] = request
+
+
+def _server_cancel(queue, transfer_api):
+    """Server that establishes an endpoint to client and immediately closes
+    it, triggering received messages to be canceled on the client.
+    """
+    feature_flags = (
+        ucx_api.Feature.AM if transfer_api == "am" else ucx_api.Feature.TAG,
+    )
+    ctx = ucx_api.UCXContext(feature_flags=feature_flags)
+    worker = ucx_api.UCXWorker(ctx)
+
+    # Keep endpoint to be used from outside the listener callback
+    ep = [None]
+
+    def _listener_handler(conn_request):
+        ep[0] = ucx_api.UCXEndpoint.create_from_conn_request(
+            worker, conn_request, endpoint_error_handling=True,
+        )
+
+    listener = ucx_api.UCXListener(worker=worker, port=0, cb_func=_listener_handler)
+    queue.put(listener.port),
+
+    while ep[0] is None:
+        worker.progress()
+
+    ep[0].close()
+    worker.progress()
+
+
+def _client_cancel(queue, transfer_api):
+    """Client that connects to server and waits for messages to be received,
+    because the server closes without sending anything, the messages will
+    trigger cancelation.
+    """
+    feature_flags = (
+        ucx_api.Feature.AM if transfer_api == "am" else ucx_api.Feature.TAG,
+    )
+    ctx = ucx_api.UCXContext(feature_flags=feature_flags)
+    worker = ucx_api.UCXWorker(ctx)
+    port = queue.get()
+    ep = ucx_api.UCXEndpoint.create(
+        worker, get_address(), port, endpoint_error_handling=True,
+    )
+
+    ret = [None]
+
+    if transfer_api == "am":
+        ucx_api.am_recv_nb(ep, cb_func=_handler, cb_args=(ret,))
+
+        match_msg = ".*am_recv.*"
+    else:
+        msg = Array(bytearray(1))
+        ucx_api.tag_recv_nb(
+            worker, msg, msg.nbytes, tag=0, cb_func=_handler, cb_args=(ret,), ep=ep
+        )
+
+        match_msg = ".*tag_recv_nb.*"
+
+    while ep.is_alive():
+        worker.progress()
+
+    canceled = worker.cancel_inflight_messages()
+
+    while ret[0] is None:
+        worker.progress()
+
+    assert canceled == 1
+    assert isinstance(ret[0], UCXCanceled)
+    assert re.match(match_msg, ret[0].args[0])
+
+
+@pytest.mark.skipif(
+    ucx_api.get_ucx_version() < (1, 11, 0),
+    reason="Endpoint error handling is unreliable in UCX releases prior to 1.11.0",
+)
+@pytest.mark.parametrize("transfer_api", ["am", "tag"])
+def test_message_probe(transfer_api):
+    queue = mp.Queue()
+    server = mp.Process(target=_server_cancel, args=(queue, transfer_api),)
+    server.start()
+    client = mp.Process(target=_client_cancel, args=(queue, transfer_api),)
+    client.start()
+    client.join(timeout=10)
+    server.join(timeout=10)
+    assert client.exitcode == 0
+    assert server.exitcode == 0

--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -17,11 +17,21 @@ from ..exceptions import UCXCanceled, UCXConnectionReset, UCXError
 logger = logging.getLogger("ucx")
 
 
-cdef size_t _cancel_inflight_msgs(UCXWorker worker, set inflight_msgs):
+cdef bint _is_am_enabled(UCXWorker worker):
+    return is_am_supported() and Feature.AM in worker._context._feature_flags
+
+
+cdef size_t _cancel_inflight_msgs(UCXWorker worker, set inflight_msgs=None):
     cdef UCXRequest req
     cdef dict req_info
     cdef str name
-    cdef size_t len_inflight_msgs = len(inflight_msgs)
+    cdef size_t len_inflight_msgs
+
+    if inflight_msgs is None:
+        inflight_msgs = worker._inflight_msgs_to_cancel["tag"]
+
+    len_inflight_msgs = len(inflight_msgs)
+
     for req in list(inflight_msgs):
         if not req.closed():
             req_info = <dict>req._handle.info
@@ -36,13 +46,9 @@ cdef size_t _cancel_inflight_msgs(UCXWorker worker, set inflight_msgs):
 
 
 cdef size_t _cancel_am_recv_single(UCXWorker worker, uintptr_t handle_as_int):
-    cdef bint am_enabled = (
-        is_am_supported() and Feature.AM in worker._context._feature_flags
-    )
-
     cdef dict recv_wait
     cdef size_t len_wait = 0
-    if am_enabled and handle_as_int in worker._am_recv_wait:
+    if _is_am_enabled(worker) and handle_as_int in worker._am_recv_wait:
         len_wait = len(worker._am_recv_wait[handle_as_int])
         while len(worker._am_recv_wait[handle_as_int]) > 0:
             recv_wait = worker._am_recv_wait[handle_as_int].pop(0)
@@ -63,20 +69,22 @@ cdef size_t _cancel_am_recv_single(UCXWorker worker, uintptr_t handle_as_int):
 
     return len_wait
 
-cdef size_t _cancel_am_recv(UCXWorker worker, set inflight_msgs):
-    cdef bint am_enabled = (
-        is_am_supported() and Feature.AM in worker._context._feature_flags
-    )
-
+cdef size_t _cancel_am_recv(UCXWorker worker, uintptr_t handle_as_int=0):
     cdef size_t len_wait = 0
-    for handle_as_int in inflight_msgs:
-        len_wait += _cancel_am_recv_single(worker, handle_as_int)
 
-    # Prevent endpoint canceling AM messages multiple times. This is important
-    # because UCX may reuse the same endpoint handle, and if a message is canceled
-    # during then endpoint finalizer, a message received on the same (new) endpoint
-    # handle may be canceled incorrectly.
-    inflight_msgs.clear()
+    if _is_am_enabled(worker):
+        if handle_as_int == 0:
+            for handle_as_int in worker._inflight_msgs_to_cancel["am"]:
+                len_wait += _cancel_am_recv_single(worker, handle_as_int)
+
+            # Prevent endpoint canceling AM messages multiple times. This is important
+            # because UCX may reuse the same endpoint handle, and if a message is
+            # canceled # during then endpoint finalizer, a message received on the same
+            # (new) endpoint handle may be canceled incorrectly.
+            worker._inflight_msgs_to_cancel["am"].clear()
+        else:
+            len_wait = _cancel_am_recv_single(worker, handle_as_int)
+            worker._inflight_msgs_to_cancel["am"].discard(handle_as_int)
 
     return len_wait
 
@@ -118,7 +126,7 @@ cdef void _err_cb(void *arg, ucp_ep_h ep, ucs_status_t status) with gil:
     # complete. This may happen if the user called ep.recv() or ep.am_recv()
     # but the remote worker errored before sending the message.
     ucx_worker._inflight_msgs_to_cancel["tag"].update(inflight_msgs)
-    if "am" in ucx_worker._inflight_msgs_to_cancel:
+    if _is_am_enabled(ucx_worker):
         ucx_worker._inflight_msgs_to_cancel["am"].add(<uintptr_t>ep)
 
 
@@ -165,7 +173,7 @@ def _ucx_endpoint_finalizer(
     _cancel_inflight_msgs(worker, inflight_msgs)
 
     # Cancel waiting `am_recv` calls
-    _cancel_am_recv_single(worker, handle_as_int)
+    _cancel_am_recv(worker, handle_as_int=handle_as_int)
 
     # Close the endpoint
     cdef str msg

--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -54,7 +54,7 @@ cdef int _cancel_am_recv(UCXWorker worker, uintptr_t handle_as_int):
                 **cb_kwargs
             )
 
-        # Prevent endpoint canceling AM messages multiple times.  This is important
+        # Prevent endpoint canceling AM messages multiple times. This is important
         # because UCX may reuse the same endpoint handle, and if a message is canceled
         # during then endpoint finalizer, a message received on the same (new) endpoint
         # handle may be canceled incorrectly.

--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -54,6 +54,13 @@ cdef int _cancel_am_recv(UCXWorker worker, uintptr_t handle_as_int):
                 **cb_kwargs
             )
 
+        # Prevent endpoint canceling AM messages multiple times.  This is important
+        # because UCX may reuse the same endpoint handle, and if a message is canceled
+        # during then endpoint finalizer, a message received on the same (new) endpoint
+        # handle may be canceled incorrectly.
+        del worker._am_recv_wait[handle_as_int]
+        worker._inflight_msgs_to_cancel["am"].discard(handle_as_int)
+
     return len_wait
 
 

--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -17,10 +17,11 @@ from ..exceptions import UCXCanceled, UCXConnectionReset, UCXError
 logger = logging.getLogger("ucx")
 
 
-cdef void _cancel_inflight_msgs(UCXWorker worker, set inflight_msgs):
+cdef size_t _cancel_inflight_msgs(UCXWorker worker, set inflight_msgs):
     cdef UCXRequest req
     cdef dict req_info
     cdef str name
+    cdef size_t len_inflight_msgs = len(inflight_msgs)
     for req in list(inflight_msgs):
         if not req.closed():
             req_info = <dict>req._handle.info
@@ -28,6 +29,10 @@ cdef void _cancel_inflight_msgs(UCXWorker worker, set inflight_msgs):
             logger.debug("Future cancelling: %s" % name)
             # Notice, `request_cancel()` evoke the send/recv callback functions
             worker.request_cancel(req)
+
+    inflight_msgs.clear()
+
+    return len_inflight_msgs
 
 
 cdef size_t _cancel_am_recv_single(UCXWorker worker, uintptr_t handle_as_int):

--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -79,7 +79,7 @@ cdef size_t _cancel_am_recv(UCXWorker worker, uintptr_t handle_as_int=0):
 
             # Prevent endpoint canceling AM messages multiple times. This is important
             # because UCX may reuse the same endpoint handle, and if a message is
-            # canceled # during then endpoint finalizer, a message received on the same
+            # canceled during the endpoint finalizer, a message received on the same
             # (new) endpoint handle may be canceled incorrectly.
             worker._inflight_msgs_to_cancel["am"].clear()
         else:

--- a/ucp/_libs/ucx_worker.pyx
+++ b/ucp/_libs/ucx_worker.pyx
@@ -290,11 +290,8 @@ cdef class UCXWorker(UCXObject):
         -------
         total: The total number of inflight messages canceled.
         """
-        len_tag = len(self._inflight_msgs_to_cancel["tag"])
         len_am = 0
-        if len_tag > 0:
-            _cancel_inflight_msgs(self, self._inflight_msgs_to_cancel["tag"])
-            self._inflight_msgs_to_cancel["tag"] = set()
+        len_tag = _cancel_inflight_msgs(self, self._inflight_msgs_to_cancel["tag"])
         if "am" in self._inflight_msgs_to_cancel:
             len_am = _cancel_am_recv(self, self._inflight_msgs_to_cancel["am"])
         return len_tag + len_am

--- a/ucp/_libs/ucx_worker.pyx
+++ b/ucp/_libs/ucx_worker.pyx
@@ -296,7 +296,5 @@ cdef class UCXWorker(UCXObject):
             _cancel_inflight_msgs(self, self._inflight_msgs_to_cancel["tag"])
             self._inflight_msgs_to_cancel["tag"] = set()
         if "am" in self._inflight_msgs_to_cancel:
-            for ep in self._inflight_msgs_to_cancel["am"]:
-                len_am += _cancel_am_recv(self, ep)
-            self._inflight_msgs_to_cancel["am"] = set()
+            len_am = _cancel_am_recv(self, self._inflight_msgs_to_cancel["am"])
         return len_tag + len_am

--- a/ucp/_libs/ucx_worker.pyx
+++ b/ucp/_libs/ucx_worker.pyx
@@ -120,7 +120,7 @@ cdef class UCXWorker(UCXObject):
         status = ucp_worker_create(context._handle, &worker_params, &self._handle)
         assert_ucs_status(status)
         self._inflight_msgs = set()
-        self._inflight_msgs_to_cancel = {"tag": set()}
+        self._inflight_msgs_to_cancel = {"am": set(), "tag": set()}
 
         IF CY_UCP_AM_SUPPORTED:
             cdef int AM_MSG_ID = 0
@@ -129,7 +129,6 @@ cdef class UCXWorker(UCXObject):
                 self._am_recv_wait = dict()
                 self._am_host_allocator = bytearray
                 self._am_cuda_allocator = None
-                self._inflight_msgs_to_cancel["am"] = set()
                 am_handler_param.field_mask = (
                     UCP_AM_HANDLER_PARAM_FIELD_ID |
                     UCP_AM_HANDLER_PARAM_FIELD_CB |
@@ -290,8 +289,6 @@ cdef class UCXWorker(UCXObject):
         -------
         total: The total number of inflight messages canceled.
         """
-        len_am = 0
-        len_tag = _cancel_inflight_msgs(self, self._inflight_msgs_to_cancel["tag"])
-        if "am" in self._inflight_msgs_to_cancel:
-            len_am = _cancel_am_recv(self, self._inflight_msgs_to_cancel["am"])
+        len_tag = _cancel_inflight_msgs(self)
+        len_am = _cancel_am_recv(self)
         return len_tag + len_am


### PR DESCRIPTION
This is important because UCX may reuse the same endpoint handle, and if a message is canceled during then endpoint finalizer, a message received on the same (new) endpoint handle may be canceled incorrectly.

Due to this, `test_close_after_n_recv[am]` would fail non-deterministically.