### PR TITLE
Revert `update-version.sh` changes

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -30,4 +30,4 @@ function sed_runner() {
 }
 
 # cpp update
-sed_runner "s/export RAPIDS_VERSION=.*/export RAPIDS_VERSION=\"${NEXT_MAJOR}.${NEXT_MINOR}\"/g" ci/gpu/build.sh
+# sed_runner "s/export RAPIDS_VERSION=.*/export RAPIDS_VERSION=\"${NEXT_MAJOR}.${NEXT_MINOR}\"/g" ci/gpu/build.sh


### PR DESCRIPTION
I recently added a `sed` command (#811) to update the `RAPIDS_VERSION` in `ci/gpu/build.sh`. However, I now realize that the `NEXT_MAJOR` and `NEXT_MINOR` variables that I used correspond to the `ucx-py` versions (i.e. `0.22`) and not the RAPIDS versions (i.e. `22.12`). Therefore my changes would result in an incorrect string replacement.

I've commented out the line instead of removing it because we have some `update-version.sh` script improvements that are coming that will allow us to update both RAPIDS and `ucx-py` versions throughout the repositories.