### PR TITLE
Uvloop

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -41,6 +41,14 @@ if not os.environ.get("UCX_RNDV_SCHEME", False):
 logger = get_ucxpy_logger()
 
 
+try:
+    import uvloop
+
+    uvloop.install()
+except ImportError:
+    pass
+
+
 __version__ = _get_versions()["version"]
 __ucx_version__ = "%d.%d.%d" % get_ucx_version()
 

--- a/ucp/continuous_ucx_progress.py
+++ b/ucp/continuous_ucx_progress.py
@@ -82,7 +82,8 @@ class BlockingMode(ProgressTask):
 
         # Notice, we can safely overwrite `self.dangling_arm_task`
         # since previous arm task is finished by now.
-        assert self.asyncio_task is None or self.asyncio_task.done()
+        if self.asyncio_task is None or self.asyncio_task.done():
+            return
         self.asyncio_task = self.event_loop.create_task(self._arm_worker())
 
     async def _arm_worker(self):


### PR DESCRIPTION
Replace default asyncio by uvloop when available. Provides up to 2x speedup in preliminary benchmarks.

<details><summary>asyncio</summary>

```
$ python benchmarks/send-recv.py --reuse-alloc -o numpy --n-iter 10 -n 100kiB
Server Running at 10.33.225.163:37981
Client connecting to server at 10.33.225.163:37981
Roundtrip benchmark
--------------------------
n_iter          | 10
n_bytes         | 100.00 kiB
object          | numpy
reuse alloc     | True
transfer API    | TAG
UCX_TLS         | all
UCX_NET_DEVICES | all
==========================
Device(s)       | CPU-only
Server CPU      | affinity not set
Client CPU      | affinity not set
Average         | 602.88 MiB/s
Median          | 761.13 MiB/s
--------------------------
Iterations
--------------------------
000         |231.92 MiB/s
001         |558.95 MiB/s
002         |791.95 MiB/s
003         |897.06 MiB/s
004         |908.38 MiB/s
005         |611.67 MiB/s
006         |619.92 MiB/s
007         |732.61 MiB/s
008         |845.71 MiB/s
009         |824.81 MiB/s
```

</details>

<details><summary>uvloop</summary>

```
$ python benchmarks/send-recv.py --reuse-alloc -o numpy --n-iter 10 -n 100kiB
Server Running at 10.33.225.163:51962
Client connecting to server at 10.33.225.163:51962
Roundtrip benchmark
--------------------------
n_iter          | 10
n_bytes         | 100.00 kiB
object          | numpy
reuse alloc     | True
transfer API    | TAG
UCX_TLS         | all
UCX_NET_DEVICES | all
==========================
Device(s)       | CPU-only
Server CPU      | affinity not set
Client CPU      | affinity not set
Average         | 1.00 GiB/s
Median          | 1.21 GiB/s
--------------------------
Iterations
--------------------------
000         |409.89 MiB/s
001         | 1.23 GiB/s
002         | 1.14 GiB/s
003         | 1.31 GiB/s
004         | 1.01 GiB/s
005         | 1.43 GiB/s
006         | 1.43 GiB/s
007         | 1.44 GiB/s
008         | 0.93 GiB/s
009         | 1.19 GiB/s
```

</details>