### PR TITLE
Set UCX_CUDA_COPY_MAX_REG_RATIO=1.0 when GPUs permit

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -23,17 +23,23 @@ from .core import get_ucx_version  # noqa
 from .utils import get_ucxpy_logger  # noqa
 from ._libs.ucx_api import get_address  # noqa
 
+# Setup UCX-Py logger
+logger = get_ucxpy_logger()
+
+
 if "UCX_SOCKADDR_TLS_PRIORITY" not in os.environ and get_ucx_version() < (1, 11, 0):
-    logger.debug(
+    logger.info(
         "Setting env UCX_SOCKADDR_TLS_PRIORITY=sockcm, "
         "which is required to connect multiple nodes"
     )
     os.environ["UCX_SOCKADDR_TLS_PRIORITY"] = "sockcm"
 
 if "UCX_RNDV_THRESH" not in os.environ:
+    logger.info("Setting UCX_RNDV_THRESH=8192")
     os.environ["UCX_RNDV_THRESH"] = "8192"
 
 if "UCX_RNDV_SCHEME" not in os.environ:
+    logger.info("Setting UCX_RNDV_SCHEME=get_zcopy")
     os.environ["UCX_RNDV_SCHEME"] = "get_zcopy"
 
 if "UCX_CUDA_COPY_MAX_REG_RATIO" not in os.environ and get_ucx_version() >= (1, 12, 0):
@@ -53,13 +59,10 @@ if "UCX_CUDA_COPY_MAX_REG_RATIO" not in os.environ and get_ucx_version() >= (1, 
                 large_bar1[dev_idx] = True
 
         if all(large_bar1):
+            logger.info("Setting UCX_CUDA_COPY_MAX_REG_RATIO=1.0")
             os.environ["UCX_CUDA_COPY_MAX_REG_RATIO"] = "1.0"
     except ImportError:
         pass
-
-
-# After handling of environment variable logging, add formatting to the logger
-logger = get_ucxpy_logger()
 
 
 __version__ = _get_versions()["version"]

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -30,10 +30,10 @@ if "UCX_SOCKADDR_TLS_PRIORITY" not in os.environ and get_ucx_version() < (1, 11,
     )
     os.environ["UCX_SOCKADDR_TLS_PRIORITY"] = "sockcm"
 
-if not os.environ.get("UCX_RNDV_THRESH", False):
+if "UCX_RNDV_THRESH" not in os.environ:
     os.environ["UCX_RNDV_THRESH"] = "8192"
 
-if not os.environ.get("UCX_RNDV_SCHEME", False):
+if "UCX_RNDV_SCHEME" not in os.environ:
     os.environ["UCX_RNDV_SCHEME"] = "get_zcopy"
 
 if "UCX_CUDA_COPY_MAX_REG_RATIO" not in os.environ and get_ucx_version() >= (1, 12, 0):


### PR DESCRIPTION
This is necessary to maintain good performance on GPUs with large BAR1 size (greater or equal to the total GPU memory size). Starting with UCX 1.12 this value is set to 0.1 by default to ensure registration doesn't fail with GPUs that have a BAR1 size lower than the total GPU memory size (e.g., T4).

Currently we're setting to 1.0 when all GPUs have a large BAR1, in the future it may be useful to compute the real BAR1/TotalGPUMemory ratio to set this number. This is also a global setting, for fine-grained settings the application should take care of changing this value appropriately as UCX-Py doesn't know which GPUs are going to be used by the application at import time.

Additionally, setup logger before environment variables are set and log what's being set.
