### PR TITLE
xfail AM `test_from_worker_address_error` on UCX 1.11

### DIFF
--- a/tests/test_from_worker_address_error.py
+++ b/tests/test_from_worker_address_error.py
@@ -150,11 +150,11 @@ def test_from_worker_address_error(error_type):
     assert not server.exitcode
 
     if ucp.get_ucx_version() < (1, 12, 0) and client.exitcode == 1:
-        if error_type == "timeout_send":
+        if all(t in error_type for t in ["timeout", "send"]):
             pytest.xfail(
                 "Requires https://github.com/openucx/ucx/pull/7527 with rc/ud."
             )
-        elif error_type == "timeout_recv":
+        elif all(t in error_type for t in ["timeout", "recv"]):
             pytest.xfail(
                 "Requires https://github.com/openucx/ucx/pull/7531 with rc/ud."
             )


### PR DESCRIPTION
Only TAG messages were covered by the xfail condition in `test_from_worker_address_error`, but AM should also xfail on UCX 1.11.