### PR TITLE
Set `UCX_MAX_RNDV_RAILS=1` on UCX >= 1.12.0 and update configurations docs

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -64,6 +64,10 @@ if "UCX_CUDA_COPY_MAX_REG_RATIO" not in os.environ and get_ucx_version() >= (1, 
     except ImportError:
         pass
 
+if "UCX_MAX_RNDV_RAILS" not in os.environ and get_ucx_version() >= (1, 12, 0):
+    logger.info("Setting UCX_MAX_RNDV_RAILS=1")
+    os.environ["UCX_MAX_RNDV_RAILS"] = "1"
+
 
 __version__ = _get_versions()["version"]
 __ucx_version__ = "%d.%d.%d" % get_ucx_version()


### PR DESCRIPTION
Add `UCX_MAX_RNDV_RAILS=1` to prevent crashes in UCX 1.12.0 caused by recent changes, more specifically when `UCX_CUDA_COPY_MAX_REG_RATIO=1.0` to maintain better performance on GPUs with large BAR1.

Add new subsection on UCX-Py default environment variables and further improve UCX-Py configuration docs.