### PR TITLE
Dockerfile with Infiniband/NVLink capabilities

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,3 +22,36 @@ docker run ucx-py
 ```
 
 The container above will run UCX-Py tests and benchmarks.
+
+## Infiniband/NVLink-enabled docker file
+
+In addition to the reference Docker image, the `UCXPy-CUDA.dockerfile` builds an
+image with support for CUDA and MOFED. This is based on the
+[nvidia/cuda:11.5.2-devel-ubuntu20.04](https://hub.docker.com/layers/cuda/nvidia/cuda/11.5.2-devel-ubuntu20.04/images/sha256-fed73168f35a44f5ff53d06d61a1c55da7c26e7ca5a543efd78f35d98f29fd4a?context=explore)
+image, and uses MOFED version 5.3-1.0.5.0. To function successfully the OFED
+version reported by `ofed_info -s` on the host should match this version.
+
+To use this image, first build it
+```bash
+docker build -t ucx-py-ib -f UCXPy-CUDA.dockerfile .
+```
+
+### Running
+
+To expose high-performance transports from the host in the container requires a
+number of additional flags when running the container. `docker run --privileged`
+is a catch-all that will definitely provide enough permissions (`ulimit -l
+unlimited` is then needed in the container). Alternately, provide `--ulimit
+memlock=-1` and expose devices with `--device /dev/infiniband`, see [the UCX
+documentation](https://openucx.readthedocs.io/en/master/running.html#running-in-docker-containers)
+for more details.
+
+For example, a run command that exposes all devices available in
+`/dev/infiniband` on the host is:
+
+```bash
+docker run --ulimit memlock=-1 --device /dev/infiniband -ti ucx-py-ib /bin/bash
+```
+
+UCX-Py is installed via conda in the `ucx` environment; so `conda activate ucx`
+in the container will provide a python with UCX-Py available.

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,13 +44,14 @@ catch-all that will definitely provide enough permissions (`ulimit -l unlimited`
 is then needed in the container). Alternately, provide `--ulimit memlock=-1` and
 expose devices with `--device /dev/infiniband`, see [the UCX
 documentation](https://openucx.readthedocs.io/en/master/running.html#running-in-docker-containers)
-for more details.
+for more details. To expose the infiniband devices using IPoIB, we need to in
+addition map the relevant host network interfaces, a catchall is just to use `--network host`.
 
 For example, a run command that exposes all devices available in
-`/dev/infiniband` on the host is:
+`/dev/infiniband` along with the network interfaces on the host is:
 
 ```bash
-docker run --ulimit memlock=-1 --device /dev/infiniband -ti ucx-py-ib /bin/bash
+docker run --ulimit memlock=-1 --device /dev/infiniband --network host -ti ucx-py-ib /bin/bash
 ```
 
 UCX-Py is installed via conda in the `ucx` environment; so 

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,5 +53,9 @@ For example, a run command that exposes all devices available in
 docker run --ulimit memlock=-1 --device /dev/infiniband -ti ucx-py-ib /bin/bash
 ```
 
-UCX-Py is installed via conda in the `ucx` environment; so `conda activate ucx`
+UCX-Py is installed via conda in the `ucx` environment; so 
+```bash
+source /opt/conda/etc/profile.d/conda.sh
+conda activate ucx`
+```
 in the container will provide a python with UCX-Py available.

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,11 +38,11 @@ docker build -t ucx-py-ib -f UCXPy-CUDA.dockerfile .
 
 ### Running
 
-To expose high-performance transports from the host in the container requires a
-number of additional flags when running the container. `docker run --privileged`
-is a catch-all that will definitely provide enough permissions (`ulimit -l
-unlimited` is then needed in the container). Alternately, provide `--ulimit
-memlock=-1` and expose devices with `--device /dev/infiniband`, see [the UCX
+Running the container requires a number of additional flags to expose
+high-performance transports from the host. `docker run --privileged` is a
+catch-all that will definitely provide enough permissions (`ulimit -l unlimited`
+is then needed in the container). Alternately, provide `--ulimit memlock=-1` and
+expose devices with `--device /dev/infiniband`, see [the UCX
 documentation](https://openucx.readthedocs.io/en/master/running.html#running-in-docker-containers)
 for more details.
 

--- a/docker/UCXPy-CUDA.dockerfile
+++ b/docker/UCXPy-CUDA.dockerfile
@@ -68,5 +68,7 @@ RUN . /opt/conda/etc/profile.d/conda.sh \
     && conda activate ucx \
     && pip install -v -e .
 
-# Setup for interactive use of conda
-RUN conda init bash
+WORKDIR /root
+
+COPY bench-all.sh /root
+CMD ["/root/bench-all.sh", "tcp,cuda_copy,cuda_ipc", "rc,cuda_copy", "all"]

--- a/docker/UCXPy-CUDA.dockerfile
+++ b/docker/UCXPy-CUDA.dockerfile
@@ -1,0 +1,75 @@
+ARG CUDA_VERSION=11.5.2
+ARG DISTRIBUTION_VERSION=ubuntu20.04
+FROM nvidia/cuda:${CUDA_VERSION}-devel-${DISTRIBUTION_VERSION}
+
+# Make available to later build stages
+ARG DISTRIBUTION_VERSION
+
+# Should match host OS OFED version (as reported by ofed_info -s)
+ARG OFED_VERSION=5.3-1.0.5.0
+# Tag to checkout from UCX repository
+ARG UCX_VERSION_TAG=v1.12.1
+
+ENV CUDA_HOME="/usr/local/cuda"
+ENV PATH="${CUDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
+    && apt-get install -y \
+        automake \
+        dh-make \
+        git \
+        libcap2 \
+        libnuma-dev \
+        libtool \
+        make \
+        pkg-config \
+        udev \
+        wget \
+    && apt-get autoremove -y \
+    && apt-get clean
+
+ADD https://content.mellanox.com/ofed/MLNX_OFED-${OFED_VERSION}/MLNX_OFED_LINUX-${OFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz /MLNX_OFED_LINUX-${OFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz
+RUN tar -xzf /MLNX_OFED_LINUX-${OFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz
+RUN cd MLNX_OFED_LINUX-${OFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64 \
+    && yes | ./mlnxofedinstall --user-space-only --without-fw-update --without-neohost-backend \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /MLNX_OFED_LINUX*
+
+ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
+RUN bash /miniconda.sh -b -p /opt/conda
+
+ENV PATH="/opt/conda/bin:${CUDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# FIXME: We plausibly have two different CUDA runtimes after this.
+# The base image provides a build environment at /usr/local/cuda
+# but this install adds the cudatoolkit from the nvidia conda channel.
+# Hopefully they don't conflict...
+RUN conda create -n ucx -c conda-forge -c nvidia -c rapidsai \
+    "python=3.7" setuptools psutil "cython>=0.29.14,<3.0.0a0" \
+    pytest pytest-asyncio \
+    cupy "numba>=0.46" rmm distributed
+
+WORKDIR /root
+RUN git clone https://github.com/openucx/ucx.git
+WORKDIR /root/ucx
+RUN git checkout ${UCX_VERSION_TAG}
+RUN ./autogen.sh
+WORKDIR /root/ucx/build
+RUN . /opt/conda/etc/profile.d/conda.sh \
+    && conda activate ucx \
+    && ../configure --prefix=${CONDA_PREFIX} --with-sysroot --enable-cma --enable-mt \
+        --enable-numa --with-gnu-ld --with-rdmacm --with-verbs --with-cuda=${CUDA_HOME}
+RUN make -j install
+
+WORKDIR /root
+RUN git clone https://github.com/rapidsai/ucx-py.git
+WORKDIR /root/ucx-py
+RUN . /opt/conda/etc/profile.d/conda.sh \
+    && conda activate ucx \
+    && pip install -v -e .
+
+# Setup for interactive use of conda
+RUN conda init bash

--- a/docker/UCXPy-CUDA.dockerfile
+++ b/docker/UCXPy-CUDA.dockerfile
@@ -47,6 +47,7 @@ RUN conda create -n ucx -c conda-forge -c nvidia -c rapidsai \
     "python=3.8" "cudatoolkit=11.5" \
     setuptools psutil "cython>=0.29.14,<3.0.0a0" \
     pytest pytest-asyncio \
+    dask distributed \
     cupy "numba>=0.46" rmm
 
 WORKDIR /root

--- a/docker/UCXPy-CUDA.dockerfile
+++ b/docker/UCXPy-CUDA.dockerfile
@@ -43,14 +43,11 @@ RUN bash /miniconda.sh -b -p /opt/conda
 
 ENV PATH="/opt/conda/bin:${CUDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-# FIXME: We plausibly have two different CUDA runtimes after this.
-# The base image provides a build environment at /usr/local/cuda
-# but this install adds the cudatoolkit from the nvidia conda channel.
-# Hopefully they don't conflict...
 RUN conda create -n ucx -c conda-forge -c nvidia -c rapidsai \
-    "python=3.7" setuptools psutil "cython>=0.29.14,<3.0.0a0" \
+    "python=3.8" "cudatoolkit=11.5" \
+    setuptools psutil "cython>=0.29.14,<3.0.0a0" \
     pytest pytest-asyncio \
-    cupy "numba>=0.46" rmm distributed
+    cupy "numba>=0.46" rmm
 
 WORKDIR /root
 RUN git clone https://github.com/openucx/ucx.git

--- a/docker/bench-all.sh
+++ b/docker/bench-all.sh
@@ -12,7 +12,6 @@ function logger {
 source /opt/conda/etc/profile.d/conda.sh
 conda activate ucx
 
-# Expect ucx-py checkout here
 cd ucx-py/
 # Benchmark using command-line provided transports or else default
 for tls in ${@:-"tcp" "all"}; do

--- a/docker/bench-all.sh
+++ b/docker/bench-all.sh
@@ -19,14 +19,15 @@ for tls in ${@:-"tcp" "all"}; do
     export UCX_TLS=${tls}
     logger "Python pytest for ucx-py"
 
-    # Test with TCP/Sockets
-    logger "Tests (UCX_TLS=$UCX_TLS)"
+    logger "Tests (UCX_TLS=${UCX_TLS})"
     pytest --cache-clear -vs ucp/_libs/tests
     pytest --cache-clear -vs tests/
 
-    logger "Benchmarks (UCX_TLS=$UCX_TLS)"
-    python benchmarks/send-recv.py -o numpy \
-        --server-dev 0 --client-dev 0 --reuse-alloc
-    python benchmarks/send-recv-core.py -o numpy \
-        --server-dev 0 --client-dev 0 --reuse-alloc
+    for array_type in "numpy" "cupy" "rmm"; do
+        logger "Benchmarks (UCX_TLS=${UCX_TLS}, array_type=${array_type})"
+        python benchmarks/send-recv.py -o ${array_type} \
+            --server-dev 0 --client-dev 0 --reuse-alloc
+        python benchmarks/send-recv-core.py -o ${array_type} \
+            --server-dev 0 --client-dev 0 --reuse-alloc
+    done
 done

--- a/docker/bench-all.sh
+++ b/docker/bench-all.sh
@@ -12,10 +12,9 @@ function logger {
 source /opt/conda/etc/profile.d/conda.sh
 conda activate ucx
 
-pip install -v dask distributed
-# Except ucx-py checkout here
+# Expect ucx-py checkout here
 cd ucx-py/
-# Benchmark using the provided transports or else default
+# Benchmark using command-line provided transports or else default
 for tls in ${@:-"tcp" "all"}; do
     export UCX_TLS=${tls}
     logger "Python pytest for ucx-py"

--- a/docker/bench-all.sh
+++ b/docker/bench-all.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) 2022, NVIDIA CORPORATION.
+
+set -e
+
+function logger {
+    echo -e "\n$@\n"
+}
+
+# Requires conda installed at /opt/conda and the ucx environment setup
+# See UCXPy-CUDA.dockerfile
+source /opt/conda/etc/profile.d/conda.sh
+conda activate ucx
+
+pip install -v dask distributed
+# Except ucx-py checkout here
+cd ucx-py/
+# Benchmark using the provided transports or else default
+for tls in ${@:-"tcp" "all"}; do
+    export UCX_TLS=${tls}
+    logger "Python pytest for ucx-py"
+
+    # Test with TCP/Sockets
+    logger "Tests (UCX_TLS=$UCX_TLS)"
+    pytest --cache-clear -vs ucp/_libs/tests
+    pytest --cache-clear -vs tests/
+
+    logger "Benchmarks (UCX_TLS=$UCX_TLS)"
+    python benchmarks/send-recv.py -o numpy \
+        --server-dev 0 --client-dev 0 --reuse-alloc
+    python benchmarks/send-recv-core.py -o numpy \
+        --server-dev 0 --client-dev 0 --reuse-alloc
+done


### PR DESCRIPTION
Add a "full-fat" dockerfile that provisions a container with sufficient bits and pieces that UCX builds with IB and NVLink support.

Running the container and exposing sufficient devices from the host OS is non-trivial so update instructions for usage with an example scenario on a DGX-1.