### PR TITLE
Use patch.dict to modify environment state

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 import pytest
 from utils import captured_logger
@@ -7,40 +8,36 @@ import ucp
 
 
 def test_get_config():
-    # Cache user-defined UCX_TLS and unset it to test default value
-    tls = os.environ.get("UCX_TLS", None)
-    if tls is not None:
-        del os.environ["UCX_TLS"]
-
-    ucp.reset()
-    config = ucp.get_config()
-    assert isinstance(config, dict)
-    assert config["TLS"] == "all"
-
-    # Restore user-defined UCX_TLS
-    if tls is not None:
-        os.environ["UCX_TLS"] = tls
+    with patch.dict(os.environ):
+        # Unset to test default value
+        if os.environ.get("UCX_TLS") is not None:
+            del os.environ["UCX_TLS"]
+        ucp.reset()
+        config = ucp.get_config()
+        assert isinstance(config, dict)
+        assert config["TLS"] == "all"
 
 
+@patch.dict(os.environ, {"UCX_SEG_SIZE": "2M"})
 def test_set_env():
     ucp.reset()
-    os.environ["UCX_SEG_SIZE"] = "2M"
     config = ucp.get_config()
     assert config["SEG_SIZE"] == os.environ["UCX_SEG_SIZE"]
 
 
+@patch.dict(os.environ, {"UCX_SEG_SIZE": "2M"})
 def test_init_options():
     ucp.reset()
-    os.environ["UCX_SEG_SIZE"] = "2M"  # Should be ignored
     options = {"SEG_SIZE": "3M"}
+    # environment specification should be ignored
     ucp.init(options)
     config = ucp.get_config()
     assert config["SEG_SIZE"] == options["SEG_SIZE"]
 
 
+@patch.dict(os.environ, {"UCX_SEG_SIZE": "4M"})
 def test_init_options_and_env():
     ucp.reset()
-    os.environ["UCX_SEG_SIZE"] = "4M"
     options = {"SEG_SIZE": "3M"}  # Should be ignored
     ucp.init(options, env_takes_precedence=True)
     config = ucp.get_config()
@@ -67,6 +64,7 @@ def test_init_invalid_option():
         ucp.init(options)
 
 
+@patch.dict(os.environ, {"UCX_SEG_SIZE": "2M"})
 def test_logging():
     """
     Test default logging configuration.
@@ -78,14 +76,12 @@ def test_logging():
     # ucp.init will only print INFO LINES
     with captured_logger(root, level=logging.INFO) as foreign_log:
         ucp.reset()
-        os.environ["UCX_SEG_SIZE"] = "2M"  # Should be ignored
         options = {"SEG_SIZE": "3M"}
         ucp.init(options)
     assert len(foreign_log.getvalue()) > 0
 
     with captured_logger(root, level=logging.ERROR) as foreign_log:
         ucp.reset()
-        os.environ["UCX_SEG_SIZE"] = "2M"  # Should be ignored
         options = {"SEG_SIZE": "3M"}
         ucp.init(options)
 

--- a/tests/test_from_worker_address_error.py
+++ b/tests/test_from_worker_address_error.py
@@ -3,6 +3,7 @@ import multiprocessing as mp
 import os
 import re
 import time
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -121,12 +122,16 @@ def _test_from_worker_address_error_client(q1, q2, error_type):
         "timeout_recv",
     ],
 )
+@patch.dict(
+    os.environ,
+    {
+        "UCX_WARN_UNUSED_ENV_VARS": "n",
+        # Set low timeouts to ensure tests quickly raise as expected
+        "UCX_KEEPALIVE_INTERVAL": "100ms",
+        "UCX_UD_TIMEOUT": "100ms",
+    },
+)
 def test_from_worker_address_error(error_type):
-    os.environ["UCX_WARN_UNUSED_ENV_VARS"] = "n"
-    # Set low timeouts to ensure tests quickly raise as expected
-    os.environ["UCX_KEEPALIVE_INTERVAL"] = "100ms"
-    os.environ["UCX_UD_TIMEOUT"] = "100ms"
-
     q1 = mp.Queue()
     q2 = mp.Queue()
 


### PR DESCRIPTION
To avoid changing the environment for later tests, patch the os.environ
dict and restore it after test exit. Fixes #842.