### PR TITLE
Fix environment override logic in ucp.init

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ ignore =
     # whitespace before :
     E203
 
+[tool:pytest]
+xfail_strict=true
 
 [isort]
 line_length=79

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,13 +36,14 @@ def test_init_options():
 
 
 @patch.dict(os.environ, {"UCX_SEG_SIZE": "4M"})
-@pytest.mark.xfail(reason="Incorrect handling of environment override in ucp.init()")
 def test_init_options_and_env():
     ucp.reset()
     options = {"SEG_SIZE": "3M"}  # Should be ignored
     ucp.init(options, env_takes_precedence=True)
     config = ucp.get_config()
     assert config["SEG_SIZE"] == os.environ["UCX_SEG_SIZE"]
+    # Provided options dict was not modified.
+    assert options == {"SEG_SIZE": "3M"}
 
 
 @pytest.mark.skipif(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,12 +36,13 @@ def test_init_options():
 
 
 @patch.dict(os.environ, {"UCX_SEG_SIZE": "4M"})
+@pytest.mark.xfail(reason="Incorrect handling of environment override in ucp.init()")
 def test_init_options_and_env():
     ucp.reset()
     options = {"SEG_SIZE": "3M"}  # Should be ignored
     ucp.init(options, env_takes_precedence=True)
     config = ucp.get_config()
-    assert config["SEG_SIZE"] == options["SEG_SIZE"]
+    assert config["SEG_SIZE"] == os.environ["UCX_SEG_SIZE"]
 
 
 @pytest.mark.skipif(

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -909,11 +909,20 @@ def init(options={}, env_takes_precedence=False, blocking_progress_mode=None):
             "UCX is already initiated. Call reset() and init() "
             "in order to re-initate UCX with new options."
         )
-    if env_takes_precedence:
-        options = options.copy()
-        for k, v in options.items():
-            options[k] = os.environ.get(f"UCX_{k}", v)
-
+    options = options.copy()
+    for k, v in options.items():
+        env_k = f"UCX_{k}"
+        env_v = os.environ.get(env_k)
+        if env_v is not None:
+            if env_takes_precedence:
+                options[k] = env_v
+                logger.debug(
+                    f"Ignoring option {k}={v}; using environment {env_k}={env_v}"
+                )
+            else:
+                logger.debug(
+                    f"Ignoring environment {env_k}={env_v}; using option {k}={v}"
+                )
     _ctx = ApplicationContext(options, blocking_progress_mode=blocking_progress_mode)
 
 

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -910,9 +910,9 @@ def init(options={}, env_takes_precedence=False, blocking_progress_mode=None):
             "in order to re-initate UCX with new options."
         )
     if env_takes_precedence:
-        for k in os.environ.keys():
-            if k in options:
-                del options[k]
+        options = options.copy()
+        for k, v in options.items():
+            options[k] = os.environ.get(f"UCX_{k}", v)
 
     _ctx = ApplicationContext(options, blocking_progress_mode=blocking_progress_mode)
 


### PR DESCRIPTION
In the config dict, UCX variables are not prefixed with UCX_, so we must
take that into account when comparing to the environment.

While we're here, take a copy of the user-provided config dict so that
we don't modify it behind their back.