### PR TITLE
Note for UCX_MAX_RNDV_RAILS on CPU-only systems

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -87,6 +87,10 @@ UCX_MAX_RNDV_RAILS
 
 Limiting the number of rails (network devices) to ``1`` allows UCX to use only the closest device according to NUMA locality and system topology. Particularly useful with InfiniBand and CUDA GPUs, ensuring all transfers from/to the GPU will use the closest InfiniBand device and thus implicitly enable GPUDirectRDMA.
 
+.. note::
+
+    On CPU-only systems, better network bandwidth performance with infiniband transports may be achieved by letting UCX use more than a single network device. This can be achieved by explicitly setting ``UCX_MAX_RNDV_RAILS`` to ``2`` or higher.
+
 Values: Int (UCX default: ``2``)
 
 UCX_RNDV_THRESH


### PR DESCRIPTION
On CPU-only systems, UCX-Py's setting of `UCX_MAX_RNDV_RAILS=1`
can be suboptimal for infiniband-enabled transports, so add a note to
the documentation of the option.