### PR TITLE
Add dockerfile using librdmacm to provide infiniband interfaces

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Contains reference dockerfile and build script to run UCX-Py tests and benchmarks. This is a minimal setup, without support for CUDA, MOFED or rdma-core.
+Contains reference dockerfile and build script to run UCX-Py tests and benchmarks. This is a minimal setup, without support for CUDA, MOFED, or rdma-core.
 
 ## Building Docker image
 
@@ -26,18 +26,18 @@ The container above will run UCX-Py tests and benchmarks.
 ## Infiniband/NVLink-enabled docker file
 
 In addition to the reference Docker image, there are two further docker
-files which (respectively) have support for CUDA devices and
-infiniband/nvlink-enabled communications using either
+files which have support for CUDA devices and
+InfiniBand/NVLink-enabled communications using either
 [rdma-core](https://github.com/linux-rdma/rdma-core) or
 [MOFED](https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed/).
-image with support for CUDA and MOFED. In both cases, the default base image is
-[nvidia/cuda:11.5.2-devel-ubuntu20.04](https://hub.docker.com/layers/cuda/nvidia/cuda/11.5.2-devel-ubuntu20.04/images/sha256-fed73168f35a44f5ff53d06d61a1c55da7c26e7ca5a543efd78f35d98f29fd4a?context=explore).
+In both cases, the default base image is
+[nvidia/cuda:11.5.2-devel-ubuntu20.04](https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=11.5.2-devel-ubuntu20.04).
 
-The rdma-core image should work as long as the host system has MOFED >= 5.x.
+The rdma-core image should work as long as the host system has MOFED >= 5.0.
 If you use the MOFED image, then the host version (reported by `ofed_info
 -s`) should match that used when building the container.
 
-To use these images, first build it
+To use one of these images, first build it
 ```bash
 docker build -t ucx-py-mofed -f UCXPy-MOFED.dockerfile .
 # or
@@ -48,13 +48,13 @@ docker built -t ucx-py-rdma -f UCXPy-rdma-core.dockerfile .
 
 You can control some of the behaviour of the docker file with docker `--build-arg` flags:
 
-- `UCX_VERSION_TAG`: git committish for the version of UCX to build (default `v1.12.1`)
-- `CONDA_HOME`: Where to install conda in the image (default `/opt/conda`)
-- `CONDA_ENV`: What to name the conda environment (default `ucx`)
-- `CONDA_ENV_SPEC`: yaml file used when initially creating the conda environment (default `ucx-py-cuda11.5.yml`)
-- `CUDA_VERSION`: version of cuda toolkit in the base image (default `11.5.2`), must exist in the [nvidia/cuda](https://hub.docker.com/layers/cuda/nvidia/cuda) docker hub image list
-- `DISTRIBUTION_VERSION`: version of distribution in the base image (default `ubuntu20.04`), must exist in the [nvidia/cuda](https://hub.docker.com/layers/cuda/nvidia/cuda) docker hub image list
-- `OFED_VERSION`: (MOFED image only) version of MOFED to download (default `5.3-1.0.5.0`)
+- `UCX_VERSION_TAG`: git committish for the version of UCX to build (default `v1.12.1`);
+- `CONDA_HOME`: Where to install conda in the image (default `/opt/conda`);
+- `CONDA_ENV`: What to name the conda environment (default `ucx`);
+- `CONDA_ENV_SPEC`: yaml file used when initially creating the conda environment (default `ucx-py-cuda11.5.yml`);
+- `CUDA_VERSION`: version of cuda toolkit in the base image (default `11.5.2`), must exist in the [nvidia/cuda](https://hub.docker.com/layers/cuda/nvidia/cuda) docker hub image list;
+- `DISTRIBUTION_VERSION`: version of distribution in the base image (default `ubuntu20.04`), must exist in the [nvidia/cuda](https://hub.docker.com/layers/cuda/nvidia/cuda) docker hub image list. Note that rdma-core provides forward-compatibility with version 28.0 (shipped with ubuntu20.04) supporting MOFED 5.0 and later. Other distributions may provide a different version of rdma-core for which MOFED compatibility may vary;
+- `MOFED_VERSION`: (MOFED image only) version of MOFED to download (default `5.3-1.0.5.0`), must match version on host system
 
 ### Running
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,16 +25,36 @@ The container above will run UCX-Py tests and benchmarks.
 
 ## Infiniband/NVLink-enabled docker file
 
-In addition to the reference Docker image, the `UCXPy-CUDA.dockerfile` builds an
-image with support for CUDA and MOFED. This is based on the
-[nvidia/cuda:11.5.2-devel-ubuntu20.04](https://hub.docker.com/layers/cuda/nvidia/cuda/11.5.2-devel-ubuntu20.04/images/sha256-fed73168f35a44f5ff53d06d61a1c55da7c26e7ca5a543efd78f35d98f29fd4a?context=explore)
-image, and uses MOFED version 5.3-1.0.5.0. To function successfully the OFED
-version reported by `ofed_info -s` on the host should match this version.
+In addition to the reference Docker image, there are two further docker
+files which (respectively) have support for CUDA devices and
+infiniband/nvlink-enabled communications using either
+[rdma-core](https://github.com/linux-rdma/rdma-core) or
+[MOFED](https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed/).
+image with support for CUDA and MOFED. In both cases, the default base image is
+[nvidia/cuda:11.5.2-devel-ubuntu20.04](https://hub.docker.com/layers/cuda/nvidia/cuda/11.5.2-devel-ubuntu20.04/images/sha256-fed73168f35a44f5ff53d06d61a1c55da7c26e7ca5a543efd78f35d98f29fd4a?context=explore).
 
-To use this image, first build it
+The rdma-core image should work as long as the host system has MOFED >= 5.x.
+If you use the MOFED image, then the host version (reported by `ofed_info
+-s`) should match that used when building the container.
+
+To use these images, first build it
 ```bash
-docker build -t ucx-py-ib -f UCXPy-CUDA.dockerfile .
+docker build -t ucx-py-mofed -f UCXPy-MOFED.dockerfile .
+# or
+docker built -t ucx-py-rdma -f UCXPy-rdma-core.dockerfile .
 ```
+
+### Controlling build-args
+
+You can control some of the behaviour of the docker file with docker `--build-arg` flags:
+
+- `UCX_VERSION_TAG`: git committish for the version of UCX to build (default `v1.12.1`)
+- `CONDA_HOME`: Where to install conda in the image (default `/opt/conda`)
+- `CONDA_ENV`: What to name the conda environment (default `ucx`)
+- `CONDA_ENV_SPEC`: yaml file used when initially creating the conda environment (default `ucx-py-cuda11.5.yml`)
+- `CUDA_VERSION`: version of cuda toolkit in the base image (default `11.5.2`), must exist in the [nvidia/cuda](https://hub.docker.com/layers/cuda/nvidia/cuda) docker hub image list
+- `DISTRIBUTION_VERSION`: version of distribution in the base image (default `ubuntu20.04`), must exist in the [nvidia/cuda](https://hub.docker.com/layers/cuda/nvidia/cuda) docker hub image list
+- `OFED_VERSION`: (MOFED image only) version of MOFED to download (default `5.3-1.0.5.0`)
 
 ### Running
 

--- a/docker/UCXPy-MOFED.dockerfile
+++ b/docker/UCXPy-MOFED.dockerfile
@@ -21,11 +21,6 @@ ENV CONDA_HOME="${CONDA_HOME}"
 # Where cuda is installed
 ENV CUDA_HOME="/usr/local/cuda"
 
-ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
-RUN bash /miniconda.sh -b -p ${CONDA_HOME} && rm /miniconda.sh
-
-ENV PATH="${CONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${CUDA_HOME}/bin"
-
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update -y \
@@ -41,16 +36,23 @@ RUN apt-get update -y \
         make \
         pkg-config \
         udev \
-        wget \
+        curl \
     && apt-get autoremove -y \
     && apt-get clean
 
-ADD https://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz /MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz
-RUN tar -xzf /MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz
-RUN cd MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64 \
-    && yes | ./mlnxofedinstall --user-space-only --without-fw-update --without-neohost-backend \
+RUN curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    -o /miniconda.sh \
+    && bash /miniconda.sh -b -p ${CONDA_HOME} \
+    && rm /miniconda.sh
+
+ENV PATH="${CONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${CUDA_HOME}/bin"
+
+RUN curl -fsSL https://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz | tar xz \
+    && (cd MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64 \
+        && yes | ./mlnxofedinstall --user-space-only --without-fw-update \
+           --without-neohost-backend) \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /MLNX_OFED_LINUX*
+    && rm -rf /MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64
 
 WORKDIR /root
 COPY ${CONDA_ENV_SPEC} /root/conda-env.yml

--- a/docker/UCXPy-MOFED.dockerfile
+++ b/docker/UCXPy-MOFED.dockerfile
@@ -5,7 +5,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-${DISTRIBUTION_VERSION}
 # Make available to later build stages
 ARG DISTRIBUTION_VERSION
 # Should match host OS OFED version (as reported by ofed_info -s)
-ARG OFED_VERSION=5.3-1.0.5.0
+ARG MOFED_VERSION=5.3-1.0.5.0
 # Tag to checkout from UCX repository
 ARG UCX_VERSION_TAG=v1.12.1
 # Where to install conda, and what to name the created environment
@@ -20,11 +20,6 @@ ENV CONDA_HOME="${CONDA_HOME}"
 
 # Where cuda is installed
 ENV CUDA_HOME="/usr/local/cuda"
-
-# This can go once the nvidia images have updated the signing key?
-RUN apt-key del 7fa2af80 \
-    && apt-key adv --fetch-keys \
-        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 
 ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
 RUN bash /miniconda.sh -b -p ${CONDA_HOME} && rm /miniconda.sh
@@ -50,9 +45,9 @@ RUN apt-get update -y \
     && apt-get autoremove -y \
     && apt-get clean
 
-ADD https://content.mellanox.com/ofed/MLNX_OFED-${OFED_VERSION}/MLNX_OFED_LINUX-${OFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz /MLNX_OFED_LINUX-${OFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz
-RUN tar -xzf /MLNX_OFED_LINUX-${OFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz
-RUN cd MLNX_OFED_LINUX-${OFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64 \
+ADD https://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz /MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz
+RUN tar -xzf /MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64.tgz
+RUN cd MLNX_OFED_LINUX-${MOFED_VERSION}-${DISTRIBUTION_VERSION}-x86_64 \
     && yes | ./mlnxofedinstall --user-space-only --without-fw-update --without-neohost-backend \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /MLNX_OFED_LINUX*

--- a/docker/UCXPy-rdma-core.dockerfile
+++ b/docker/UCXPy-rdma-core.dockerfile
@@ -17,11 +17,6 @@ ENV CONDA_HOME="${CONDA_HOME}"
 # Where cuda is installed
 ENV CUDA_HOME="/usr/local/cuda"
 
-ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
-RUN bash /miniconda.sh -b -p ${CONDA_HOME} && rm /miniconda.sh
-
-ENV PATH="${CONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${CUDA_HOME}/bin"
-
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update -y \
@@ -37,12 +32,18 @@ RUN apt-get update -y \
         make \
         pkg-config \
         udev \
-        wget \
+        curl \
         librdmacm-dev \
         rdma-core \
     && apt-get autoremove -y \
     && apt-get clean
 
+RUN curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    -o /miniconda.sh \
+    && bash /miniconda.sh -b -p ${CONDA_HOME} \
+    && rm /miniconda.sh
+
+ENV PATH="${CONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${CUDA_HOME}/bin"
 
 WORKDIR /root
 COPY ${CONDA_ENV_SPEC} /root/conda-env.yml

--- a/docker/UCXPy-rdma-core.dockerfile
+++ b/docker/UCXPy-rdma-core.dockerfile
@@ -1,0 +1,59 @@
+ARG CUDA_VERSION=11.5.2
+ARG DISTRIBUTION_VERSION=ubuntu20.04
+FROM nvidia/cuda:${CUDA_VERSION}-devel-${DISTRIBUTION_VERSION}
+
+# Tag to checkout from UCX repository
+ARG UCX_VERSION_TAG=v1.12.1
+# Where to install conda, and what to name the created environment
+ARG CONDA_HOME=/opt/conda
+ARG CONDA_ENV=ucx
+# Name of conda spec file in the current working directory that
+# will be used to build the conda environment.
+ARG CONDA_ENV_SPEC=ucx-py-cuda11.5.yml
+
+ENV CONDA_ENV="${CONDA_ENV}"
+ENV CONDA_HOME="${CONDA_HOME}"
+
+# Where cuda is installed
+ENV CUDA_HOME="/usr/local/cuda"
+
+# This can go once the nvidia images have updated the signing key?
+RUN apt-key del 7fa2af80 \
+    && apt-key adv --fetch-keys \
+        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+
+ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
+RUN bash /miniconda.sh -b -p ${CONDA_HOME} && rm /miniconda.sh
+
+ENV PATH="${CONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${CUDA_HOME}/bin"
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update -y \
+    && apt-get --fix-missing upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
+    && apt-get install -y \
+        automake \
+        dh-make \
+        git \
+        libcap2 \
+        libnuma-dev \
+        libtool \
+        make \
+        pkg-config \
+        udev \
+        wget \
+        librdmacm-dev \
+        rdma-core \
+    && apt-get autoremove -y \
+    && apt-get clean
+
+
+WORKDIR /root
+COPY ${CONDA_ENV_SPEC} /root/conda-env.yml
+COPY build-ucx.sh /root/build-ucx.sh
+COPY build-ucx-py.sh /root/build-ucx-py.sh
+
+RUN conda env create -n ${CONDA_ENV} --file /root/conda-env.yml
+RUN bash ./build-ucx.sh ${UCX_VERSION_TAG} ${CONDA_HOME} ${CONDA_ENV} ${CUDA_HOME}
+RUN bash ./build-ucx-py.sh ${CONDA_HOME} ${CONDA_ENV}

--- a/docker/UCXPy-rdma-core.dockerfile
+++ b/docker/UCXPy-rdma-core.dockerfile
@@ -17,11 +17,6 @@ ENV CONDA_HOME="${CONDA_HOME}"
 # Where cuda is installed
 ENV CUDA_HOME="/usr/local/cuda"
 
-# This can go once the nvidia images have updated the signing key?
-RUN apt-key del 7fa2af80 \
-    && apt-key adv --fetch-keys \
-        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-
 ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
 RUN bash /miniconda.sh -b -p ${CONDA_HOME} && rm /miniconda.sh
 

--- a/docker/build-ucx-py.sh
+++ b/docker/build-ucx-py.sh
@@ -8,5 +8,4 @@ source ${CONDA_HOME}/etc/profile.d/conda.sh
 conda activate ${CONDA_ENV}
 
 git clone https://github.com/rapidsai/ucx-py.git
-pushd ucx-py
-pip install -v -e .
+pip install -v -e ucx-py

--- a/docker/build-ucx-py.sh
+++ b/docker/build-ucx-py.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+
+CONDA_HOME=${1:-"/opt/conda"}
+CONDA_ENV=${2:-"ucx"}
+
+source ${CONDA_HOME}/etc/profile.d/conda.sh
+conda activate ${CONDA_ENV}
+
+git clone https://github.com/rapidsai/ucx-py.git
+pushd ucx-py
+pip install -v -e .

--- a/docker/build-ucx.sh
+++ b/docker/build-ucx.sh
@@ -13,11 +13,10 @@ conda activate ${CONDA_ENV}
 
 git clone https://github.com/openucx/ucx.git
 
-pushd ucx
+cd ucx
 git checkout ${UCX_VERSION_TAG}
 ./autogen.sh
-mkdir build-linux
-pushd build-linux
+mkdir build-linux && cd build-linux
 ../contrib/configure-release --prefix=${CONDA_PREFIX} --with-sysroot --enable-cma \
     --enable-mt --enable-numa --with-gnu-ld --with-rdmacm --with-verbs \
     --with-cuda=${CUDA_HOME} \

--- a/docker/build-ucx.sh
+++ b/docker/build-ucx.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+UCX_VERSION_TAG=${1:-"v1.12.1"}
+CONDA_HOME=${2:-"/opt/conda"}
+CONDA_ENV=${3:-"ucx"}
+CUDA_HOME=${4:-"/usr/local/cuda"}
+# Send any remaining arguments to configure
+CONFIGURE_ARGS=${@:5}
+
+source ${CONDA_HOME}/etc/profile.d/conda.sh
+conda activate ${CONDA_ENV}
+
+git clone https://github.com/openucx/ucx.git
+
+pushd ucx
+git checkout ${UCX_VERSION_TAG}
+./autogen.sh
+mkdir build-linux
+pushd build-linux
+../contrib/configure-release --prefix=${CONDA_PREFIX} --with-sysroot --enable-cma \
+    --enable-mt --enable-numa --with-gnu-ld --with-rdmacm --with-verbs \
+    --with-cuda=${CUDA_HOME} \
+    ${CONFIGURE_ARGS}
+make -j install

--- a/docker/ucx-py-cuda11.5.yml
+++ b/docker/ucx-py-cuda11.5.yml
@@ -1,0 +1,18 @@
+channels:
+  - rapidsai
+  - nvidia
+  - conda-forge
+
+dependencies:
+  - python=3.8
+  - cudatoolkit=11.5
+  - setuptools
+  - psutil
+  - cython>=0.29.14,<3.0.0a0
+  - pytest
+  - pytest-asyncio
+  - dask
+  - distributed
+  - cupy
+  - numba>=0.46
+  - rmm


### PR DESCRIPTION
Rather than relying on exact matching MOFED versions, use rdma-core
which is forward-compatible with MOFED version >= 5.x.

To facilitate downstream users adopting the build setup, split the
building and installing of UCX and UCX-Py into scripted steps for which
the conda environment name and UCX version to use can be configured.
Adapt the existing MOFED-based docker file to use this setup too.

Closes #846.

- [x] Update readme on the different docker file versions
- [x] Test on more than a single host MOFED version.