### PR TITLE
Handle negation (^) when determining cuda_support from UCX_TLS

### DIFF
--- a/ucp/_libs/ucx_context.pyx
+++ b/ucp/_libs/ucx_context.pyx
@@ -76,7 +76,11 @@ cdef class UCXContext(UCXObject):
 
         # UCX supports CUDA if "cuda" is part of the TLS or TLS is "all"
         cdef str tls = self._config["TLS"]
-        self.cuda_support = tls == "all" or "cuda" in tls
+        if tls.startswith("^"):
+            # UCX_TLS=^x,y,z means "all \ {x, y, z}"
+            self.cuda_support = "cuda" not in tls
+        else:
+            self.cuda_support = tls == "all" or "cuda" in tls
 
         self.add_handle_finalizer(
             _ucx_context_handle_finalizer,

--- a/ucp/_libs/ucx_context.pyx
+++ b/ucp/_libs/ucx_context.pyx
@@ -76,11 +76,16 @@ cdef class UCXContext(UCXObject):
 
         # UCX supports CUDA if "cuda" is part of the TLS or TLS is "all"
         cdef str tls = self._config["TLS"]
+        cuda_transports = {"cuda", "cuda_copy"}
         if tls.startswith("^"):
             # UCX_TLS=^x,y,z means "all \ {x, y, z}"
-            self.cuda_support = "cuda" not in tls
+            disabled = set(tls[1:].split(","))
+            self.cuda_support = not (disabled & cuda_transports)
         else:
-            self.cuda_support = tls == "all" or "cuda" in tls
+            enabled = set(tls.split(","))
+            self.cuda_support = bool(
+                enabled & ({"all", "cuda_ipc"} | cuda_transports)
+            )
 
         self.add_handle_finalizer(
             _ucx_context_handle_finalizer,


### PR DESCRIPTION
The UCX_TLS environment variable allows one to specify either:

- specific transports to enable (e.g. UCX_TLS=rc,tcp,cuda);
- specific transports to disable (via a negation flag at the front of
  the list). For example UCX_TLS=^cma,xpmem means all \ {cma, xpmem}.

To correctly determine whether the UCX context has cuda support we
need to handle both of these cases. Closes #856.