### PR TITLE
Use mamba rather than conda in docker files

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -68,15 +68,19 @@ for more details. To expose the infiniband devices using IPoIB, we need to in
 addition map the relevant host network interfaces, a catchall is just to use `--network host`.
 
 For example, a run command that exposes all devices available in
-`/dev/infiniband` along with the network interfaces on the host is:
+`/dev/infiniband` along with the network interfaces on the host is (assuming
+that the `ucx-py-rdma` image tag has been built as above):
 
 ```bash
-docker run --ulimit memlock=-1 --device /dev/infiniband --network host -ti ucx-py-ib /bin/bash
+docker run --ulimit memlock=-1 --device /dev/infiniband --network host -ti ucx-py-rdma /bin/bash
 ```
 
-UCX-Py is installed via conda in the `ucx` environment; so 
+UCX-Py is installed via
+[mamba](https://mamba.readthedocs.io/en/latest/index.html) in the `ucx`
+environment; so 
 ```bash
 source /opt/conda/etc/profile.d/conda.sh
-conda activate ucx`
+source /opt/conda/etc/profile.d/mamba.sh
+mamba activate ucx
 ```
-in the container will provide a python with UCX-Py available.
+in the container will provide a Python with UCX-Py available.

--- a/docker/UCXPy-MOFED.dockerfile
+++ b/docker/UCXPy-MOFED.dockerfile
@@ -40,10 +40,10 @@ RUN apt-get update -y \
     && apt-get autoremove -y \
     && apt-get clean
 
-RUN curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    -o /miniconda.sh \
-    && bash /miniconda.sh -b -p ${CONDA_HOME} \
-    && rm /miniconda.sh
+RUN curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh \
+    -o /minimamba.sh \
+    && bash /minimamba.sh -b -p ${CONDA_HOME} \
+    && rm /minimamba.sh
 
 ENV PATH="${CONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${CUDA_HOME}/bin"
 
@@ -60,7 +60,7 @@ COPY build-ucx.sh /root/build-ucx.sh
 COPY build-ucx-py.sh /root/build-ucx-py.sh
 COPY bench-all.sh /root/bench-all.sh
 
-RUN conda env create -n ${CONDA_ENV} --file /root/conda-env.yml
+RUN mamba env create -n ${CONDA_ENV} --file /root/conda-env.yml
 RUN bash ./build-ucx.sh ${UCX_VERSION_TAG} ${CONDA_HOME} ${CONDA_ENV} ${CUDA_HOME}
 RUN bash ./build-ucx-py.sh ${CONDA_HOME} ${CONDA_ENV}
 CMD ["/root/bench-all.sh", "tcp,cuda_copy,cuda_ipc", "rc,cuda_copy", "all"]

--- a/docker/UCXPy-rdma-core.dockerfile
+++ b/docker/UCXPy-rdma-core.dockerfile
@@ -38,10 +38,10 @@ RUN apt-get update -y \
     && apt-get autoremove -y \
     && apt-get clean
 
-RUN curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    -o /miniconda.sh \
-    && bash /miniconda.sh -b -p ${CONDA_HOME} \
-    && rm /miniconda.sh
+RUN curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh \
+    -o /minimamba.sh \
+    && bash /minimamba.sh -b -p ${CONDA_HOME} \
+    && rm /minimamba.sh
 
 ENV PATH="${CONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${CUDA_HOME}/bin"
 
@@ -50,6 +50,6 @@ COPY ${CONDA_ENV_SPEC} /root/conda-env.yml
 COPY build-ucx.sh /root/build-ucx.sh
 COPY build-ucx-py.sh /root/build-ucx-py.sh
 
-RUN conda env create -n ${CONDA_ENV} --file /root/conda-env.yml
+RUN mamba env create -n ${CONDA_ENV} --file /root/conda-env.yml
 RUN bash ./build-ucx.sh ${UCX_VERSION_TAG} ${CONDA_HOME} ${CONDA_ENV} ${CUDA_HOME}
 RUN bash ./build-ucx-py.sh ${CONDA_HOME} ${CONDA_ENV}

--- a/docker/build-ucx-py.sh
+++ b/docker/build-ucx-py.sh
@@ -5,7 +5,8 @@ CONDA_HOME=${1:-"/opt/conda"}
 CONDA_ENV=${2:-"ucx"}
 
 source ${CONDA_HOME}/etc/profile.d/conda.sh
-conda activate ${CONDA_ENV}
+source ${CONDA_HOME}/etc/profile.d/mamba.sh
+mamba activate ${CONDA_ENV}
 
 git clone https://github.com/rapidsai/ucx-py.git
-pip install -v -e ucx-py
+pip install -v ucx-py/

--- a/docker/build-ucx.sh
+++ b/docker/build-ucx.sh
@@ -9,7 +9,8 @@ CUDA_HOME=${4:-"/usr/local/cuda"}
 CONFIGURE_ARGS=${@:5}
 
 source ${CONDA_HOME}/etc/profile.d/conda.sh
-conda activate ${CONDA_ENV}
+source ${CONDA_HOME}/etc/profile.d/mamba.sh
+mamba activate ${CONDA_ENV}
 
 git clone https://github.com/openucx/ucx.git
 


### PR DESCRIPTION
This significantly speeds up building images, and makes installing
packages in the image much more pleasant, since the solver is so much
faster.

This is low-priority, but a reasonable quality of life improvement when building the containers regularly.