### PR TITLE
Remove compiler variables

### DIFF
--- a/conda/recipes/ucx-py/meta.yaml
+++ b/conda/recipes/ucx-py/meta.yaml
@@ -12,11 +12,6 @@ source:
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-  script_env:
-    - VERSION_SUFFIX
-    - CC
-    - CXX
-    - CUDAHOSTCXX
   script:
     - {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
With the PR below merged, we no longer set the `CXX`, `CC`, or `CUDAHOSTCXX` variables in any of our CI images. This PR cleans up some references to them.


- https://github.com/rapidsai/gpuci-build-environment/pull/265


Also, I removed the `VERSION_SUFFIX` variable from the recipe since it doesn't appear to be used anywhere.