### PR TITLE
Improve benchmarks results output and features

### DIFF
--- a/benchmarks/send-recv-core.py
+++ b/benchmarks/send-recv-core.py
@@ -26,7 +26,12 @@ from time import perf_counter as clock
 import ucp
 from ucp._libs import ucx_api
 from ucp._libs.arr import Array
-from ucp._libs.utils import format_bytes, parse_bytes
+from ucp._libs.utils import (
+    format_bytes,
+    parse_bytes,
+    print_key_value,
+    print_separator,
+)
 from ucp._libs.utils_test import (
     blocking_am_recv,
     blocking_am_send,
@@ -39,14 +44,6 @@ from ucp._libs.utils_test import (
 mp = mp.get_context("spawn")
 
 WireupMessage = bytearray(b"wireup")
-
-
-def print_separator(separator="-", length=80):
-    print(separator * length)
-
-
-def print_key_value(key, value, key_length=25):
-    print(f"{key: <{key_length}} | {value}")
 
 
 def register_am_allocators(args, worker):

--- a/benchmarks/send-recv.py
+++ b/benchmarks/send-recv.py
@@ -24,17 +24,14 @@ import os
 from time import perf_counter as clock
 
 import ucp
-from ucp._libs.utils import format_bytes, parse_bytes
+from ucp._libs.utils import (
+    format_bytes,
+    parse_bytes,
+    print_key_value,
+    print_separator,
+)
 
 mp = mp.get_context("spawn")
-
-
-def print_separator(separator="-", length=80):
-    print(separator * length)
-
-
-def print_key_value(key, value, key_length=25):
-    print(f"{key: <{key_length}} | {value}")
 
 
 def register_am_allocators(args):

--- a/ucp/_libs/utils.py
+++ b/ucp/_libs/utils.py
@@ -30,3 +30,13 @@ except ImportError:
             return f"{x / 1024**4:.2f} TiB"
 
     parse_bytes = None
+
+
+def print_separator(separator="-", length=80):
+    """Print a single separator character multiple times"""
+    print(separator * length)
+
+
+def print_key_value(key, value, key_length=25):
+    """Print a key and value with fixed key-field length"""
+    print(f"{key: <{key_length}} | {value}")


### PR DESCRIPTION
The following improvements are introduced:

- More consistency formatting of results output
- Latency results
- `--n-warmup-iter` argument
- `--no-detailed-report` argument to `send-recv.py`
- Remove Dask dependency on benchmarks when unavailable