### PR TITLE
Add `get_event_loop()` util function

### DIFF
--- a/benchmarks/send-recv.py
+++ b/benchmarks/send-recv.py
@@ -30,6 +30,7 @@ from ucp._libs.utils import (
     print_key_value,
     print_separator,
 )
+from ucp.utils import get_event_loop
 
 mp = mp.get_context("spawn")
 
@@ -111,7 +112,7 @@ def server(queue, args):
         while not lf.closed():
             await asyncio.sleep(0.5)
 
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     loop.run_until_complete(run())
 
 
@@ -184,7 +185,7 @@ def client(queue, port, server_address, args):
             xp.cuda.profiler.stop()
         queue.put(times)
 
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     loop.run_until_complete(run())
 
     times = queue.get()

--- a/debug-tests/client.py
+++ b/debug-tests/client.py
@@ -14,6 +14,7 @@ from debug_utils import (
 from utils import recv, send
 
 import ucp
+from ucp.utils import get_event_loop
 
 pynvml.nvmlInit()
 
@@ -63,7 +64,7 @@ def client(env, port, func, verbose):
     for i in range(ITERATIONS):
         print("ITER: ", i)
         t = time.time()
-        asyncio.get_event_loop().run_until_complete(read())
+        get_event_loop().run_until_complete(read())
         if verbose:
             print("Time take for interation %d: %ss" % (i, time.time() - t))
 

--- a/debug-tests/server.py
+++ b/debug-tests/server.py
@@ -10,6 +10,7 @@ from distributed.comm.utils import to_frames
 from distributed.protocol import to_serialize
 
 import ucp
+from ucp.utils import get_event_loop
 
 cmd = "nvidia-smi nvlink --setcontrol 0bz"  # Get output in bytes
 # subprocess.check_call(cmd, shell=True)
@@ -64,7 +65,7 @@ def server(env, port, func, verbose):
         except ucp.UCXCloseError:
             pass
 
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     while True:
         loop.run_until_complete(f(port))
 

--- a/debug-tests/test_endpoint_error_callback.py
+++ b/debug-tests/test_endpoint_error_callback.py
@@ -17,6 +17,7 @@ from distributed.comm.utils import to_frames
 from distributed.protocol import to_serialize
 
 import ucp
+from ucp.utils import get_event_loop
 
 cupy = pytest.importorskip("cupy")
 
@@ -53,7 +54,7 @@ def client(port, func, endpoint_error_handling):
         # on the server
         os.kill(os.getpid(), signal.SIGKILL)
 
-    asyncio.get_event_loop().run_until_complete(read())
+    get_event_loop().run_until_complete(read())
 
 
 def server(port, func, endpoint_error_handling):
@@ -114,7 +115,7 @@ def server(port, func, endpoint_error_handling):
         except ucp.UCXCloseError:
             pass
 
-    asyncio.get_event_loop().run_until_complete(f(port))
+    get_event_loop().run_until_complete(f(port))
 
     if ep_failure_occurred:
         sys.exit(0)

--- a/debug-tests/test_send_recv_many_workers.py
+++ b/debug-tests/test_send_recv_many_workers.py
@@ -14,6 +14,7 @@ from distributed.comm.utils import to_frames
 from distributed.protocol import to_serialize
 
 import ucp
+from ucp.utils import get_event_loop
 
 cupy = pytest.importorskip("cupy")
 rmm = pytest.importorskip("rmm")
@@ -68,7 +69,7 @@ def client(env, port, func, enable_rmm):
 
     for i in range(EP_ITERATIONS):
         print("ITER: ", i)
-        asyncio.get_event_loop().run_until_complete(read())
+        get_event_loop().run_until_complete(read())
 
     print("FINISHED")
 
@@ -86,7 +87,7 @@ def server(env, port, func, enable_rmm, num_workers, proc_conn):
 
     numba.cuda.current_context()
 
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
 
     # Creates frames only once to prevent filling the entire GPU
     print("CREATING CUDA OBJECT IN SERVER...")

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import ucp
+from ucp.utils import get_event_loop
 
 mp = mp.get_context("spawn")
 
@@ -54,7 +55,7 @@ def _test_shutdown_unexpected_closed_peer_server(
 
     log_stream = StringIO()
     logging.basicConfig(stream=log_stream, level=logging.DEBUG)
-    asyncio.get_event_loop().run_until_complete(run())
+    get_event_loop().run_until_complete(run())
     log = log_stream.getvalue()
 
     if endpoint_error_handling is True:
@@ -77,7 +78,7 @@ def _test_shutdown_unexpected_closed_peer_client(
         msg = np.empty(100, dtype=np.int64)
         await ep.recv(msg)
 
-    asyncio.get_event_loop().run_until_complete(run())
+    get_event_loop().run_until_complete(run())
 
 
 @pytest.mark.parametrize("endpoint_error_handling", [True, False])

--- a/tests/test_from_worker_address.py
+++ b/tests/test_from_worker_address.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import ucp
+from ucp.utils import get_event_loop
 
 mp = mp.get_context("spawn")
 
@@ -33,7 +34,7 @@ def _test_from_worker_address_server(queue):
         send_msg = np.arange(10, dtype=np.int64)
         await ep.send(send_msg, tag=1, force_tag=True)
 
-    asyncio.get_event_loop().run_until_complete(run())
+    get_event_loop().run_until_complete(run())
 
 
 def _test_from_worker_address_client(queue):
@@ -56,7 +57,7 @@ def _test_from_worker_address_client(queue):
 
         np.testing.assert_array_equal(recv_msg, np.arange(10, dtype=np.int64))
 
-    asyncio.get_event_loop().run_until_complete(run())
+    get_event_loop().run_until_complete(run())
 
 
 def test_from_worker_address():
@@ -182,7 +183,7 @@ def _test_from_worker_address_server_fixedsize(num_nodes, queue):
         # Await handling each client request
         await asyncio.gather(*server_tasks)
 
-    asyncio.get_event_loop().run_until_complete(run())
+    get_event_loop().run_until_complete(run())
 
 
 def _test_from_worker_address_client_fixedsize(queue):
@@ -211,7 +212,7 @@ def _test_from_worker_address_client_fixedsize(queue):
         send_msg = np.arange(20, dtype=np.int64)
         await ep.send(send_msg, tag=send_tag, force_tag=True)
 
-    asyncio.get_event_loop().run_until_complete(run())
+    get_event_loop().run_until_complete(run())
 
 
 @pytest.mark.parametrize("num_nodes", [1, 2, 4, 8])

--- a/tests/test_from_worker_address_error.py
+++ b/tests/test_from_worker_address_error.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 import ucp
+from ucp.utils import get_event_loop
 
 mp = mp.get_context("spawn")
 
@@ -34,7 +35,7 @@ def _test_from_worker_address_error_server(q1, q2, error_type):
 
             q1.put("disconnected")
 
-    asyncio.get_event_loop().run_until_complete(run())
+    get_event_loop().run_until_complete(run())
 
 
 def _test_from_worker_address_error_client(q1, q2, error_type):
@@ -109,7 +110,7 @@ def _test_from_worker_address_error_client(q1, q2, error_type):
 
                     await task
 
-    asyncio.get_event_loop().run_until_complete(run())
+    get_event_loop().run_until_complete(run())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_multiple_nodes.py
+++ b/tests/test_multiple_nodes.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 import ucp
-from ucp.utils import get_event_loop
 
 
 def get_somaxconn():
@@ -52,4 +51,4 @@ async def test_many_servers_many_clients(num_servers, num_clients):
         clients = []
         for __ in range(i, min(i + somaxconn, num_clients * num_servers)):
             clients.append(client_node(listeners[__ % num_servers].port))
-        await asyncio.gather(*clients, loop=get_event_loop())
+        await asyncio.gather(*clients)

--- a/tests/test_multiple_nodes.py
+++ b/tests/test_multiple_nodes.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import ucp
+from ucp.utils import get_event_loop
 
 
 def get_somaxconn():
@@ -51,4 +52,4 @@ async def test_many_servers_many_clients(num_servers, num_clients):
         clients = []
         for __ in range(i, min(i + somaxconn, num_clients * num_servers)):
             clients.append(client_node(listeners[__ % num_servers].port))
-        await asyncio.gather(*clients, loop=asyncio.get_event_loop())
+        await asyncio.gather(*clients, loop=get_event_loop())

--- a/tests/test_send_recv_two_workers.py
+++ b/tests/test_send_recv_two_workers.py
@@ -8,6 +8,7 @@ import pytest
 from utils import am_recv, am_send, get_cuda_devices, get_num_gpus, recv, send
 
 import ucp
+from ucp.utils import get_event_loop
 
 cupy = pytest.importorskip("cupy")
 rmm = pytest.importorskip("rmm")
@@ -70,7 +71,7 @@ def client(port, func, comm_api):
         print("Shutting Down Client...")
         return msg["data"]
 
-    rx_cuda_obj = asyncio.get_event_loop().run_until_complete(read())
+    rx_cuda_obj = get_event_loop().run_until_complete(read())
     rx_cuda_obj + rx_cuda_obj
     num_bytes = nbytes(rx_cuda_obj)
     print(f"TOTAL DATA RECEIVED: {num_bytes}")
@@ -143,7 +144,7 @@ def server(port, func, comm_api):
         except ucp.UCXCloseError:
             pass
 
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     loop.run_until_complete(f(port))
 
 

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -23,7 +23,7 @@ def _call_ucx_api(event_loop, func, *args, **kwargs):
     Basically, all the communication functions have the
     same structure, which this wrapper implements.
     """
-    event_loop = event_loop if event_loop else get_event_loop()
+    event_loop = event_loop or get_event_loop()
     ret = event_loop.create_future()
     # All the comm functions takes the call-back function and its arguments
     kwargs["cb_func"] = _cb_func
@@ -111,7 +111,7 @@ def am_recv(
     event_loop=None,
 ) -> asyncio.Future:
 
-    event_loop = event_loop if event_loop else get_event_loop()
+    event_loop = event_loop or get_event_loop()
     ret = event_loop.create_future()
     # All the comm functions takes the call-back function and its arguments
     cb_args = (event_loop, ret)

--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import Union
 
 from ._libs import arr, ucx_api
+from .utils import get_event_loop
 
 
 def _cb_func(request, exception, event_loop, future):
@@ -22,7 +23,7 @@ def _call_ucx_api(event_loop, func, *args, **kwargs):
     Basically, all the communication functions have the
     same structure, which this wrapper implements.
     """
-    event_loop = event_loop if event_loop else asyncio.get_event_loop()
+    event_loop = event_loop if event_loop else get_event_loop()
     ret = event_loop.create_future()
     # All the comm functions takes the call-back function and its arguments
     kwargs["cb_func"] = _cb_func
@@ -110,7 +111,7 @@ def am_recv(
     event_loop=None,
 ) -> asyncio.Future:
 
-    event_loop = event_loop if event_loop else asyncio.get_event_loop()
+    event_loop = event_loop if event_loop else get_event_loop()
     ret = event_loop.create_future()
     # All the comm functions takes the call-back function and its arguments
     cb_args = (event_loop, ret)

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -18,7 +18,7 @@ from ._libs import ucx_api
 from ._libs.arr import Array
 from .continuous_ucx_progress import BlockingMode, NonBlockingMode
 from .exceptions import UCXCanceled, UCXCloseError, UCXError
-from .utils import hash64bits
+from .utils import get_event_loop, hash64bits
 
 logger = logging.getLogger("ucx")
 
@@ -397,9 +397,9 @@ class ApplicationContext:
         ----------
         event_loop: asyncio.event_loop, optional
             The event loop to evoke UCX progress. If None,
-            `asyncio.get_event_loop()` is used.
+            `ucp.utils.get_event_loop()` is used.
         """
-        loop = event_loop if event_loop is not None else asyncio.get_event_loop()
+        loop = event_loop if event_loop is not None else get_event_loop()
         if loop in self.progress_tasks:
             return  # Progress has already been guaranteed for the current event loop
 

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -399,7 +399,7 @@ class ApplicationContext:
             The event loop to evoke UCX progress. If None,
             `ucp.utils.get_event_loop()` is used.
         """
-        loop = event_loop if event_loop is not None else get_event_loop()
+        loop = event_loop or get_event_loop()
         if loop in self.progress_tasks:
             return  # Progress has already been guaranteed for the current event loop
 

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -16,6 +16,23 @@ from ._libs import ucx_api
 mp = mp.get_context("spawn")
 
 
+def get_event_loop():
+    """
+    Get running or create new event loop
+
+    In Python 3.10, the behavior of `get_event_loop()` is deprecated and in
+    the future it will be an alias of `get_running_loop()`. In several
+    situations, UCX-Py needs to create a new event loop, so this function
+    will remain for now as an alternative to the behavior of `get_event_loop()`
+    from Python < 3.10, returning the `get_running_loop()` if an event loop
+    exists, or returning a new one with `new_event_loop()` otherwise.
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.new_event_loop()
+
+
 def get_ucxpy_logger():
     """
     Get UCX-Py logger with custom formatting


### PR DESCRIPTION
Since `asyncio.get_event_loop()` is deprecated starting on Python 3.10 and will eventually become an alias to `asyncio.get_running_loop()`, implement a new function to emulate the old behavior to be used where appropriate.

In https://github.com/dask/distributed/pull/6231, some of the fixtures were updated to match `asyncio`'s updates, which also caused some problems with the event loop being created in `ucp.ApplicationContext`, which can be seen in [this log](https://raw.githack.com/pentschev/ucx-py-ci/test-results/assets/ucx-master-dask-cuda-202207052200.html#0161d81a-ac60-4f1b-87ac-9b4bde5931e5) of nightly runs on a DGX-1, this fixes that.