### PR TITLE
Update cuDF merge benchmark

### DIFF
--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -366,10 +366,10 @@ def main():
     print_multi(values=["Row matching fraction", f"{args.frac_match}"])
     print_separator(separator="=", length=110)
     print_multi(values=["Wall-clock", f"{format_time(wc)}"])
-    print_multi(values=["Avg Bandwidth / GPU", f"{format_bytes(bw)}/s"])
-    print_multi(values=["Throughput / GPU", f"{format_bytes(tp)}/s"])
+    print_multi(values=["Bandwidth", f"{format_bytes(bw)}/s"])
+    print_multi(values=["Throughput", f"{format_bytes(tp)}/s"])
     print_separator(separator="=", length=110)
-    print_multi(values=["Run", "Wall-clock", "Avg Bandwidth / GPU", "Throughput / GPU"])
+    print_multi(values=["Run", "Wall-clock", "Bandwidth", "Throughput"])
     for i in range(args.iter):
         iter_results = stats[0]["iter_results"]
 

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -361,10 +361,10 @@ def main():
     print_multi(values=["Row matching fraction", f"{args.frac_match}"])
     print_separator(separator="=", length=110)
     print_multi(values=["Wall-clock", f"{format_time(wc)}"])
-    print_multi(values=["Bandwidth", f"{format_bytes(bw)}/s"])
-    print_multi(values=["Throughput", f"{format_bytes(tp)}/s"])
+    print_multi(values=["Avg Bandwidth / GPU", f"{format_bytes(bw)}/s"])
+    print_multi(values=["Throughput / GPU", f"{format_bytes(tp)}/s"])
     print_separator(separator="=", length=110)
-    print_multi(values=["Run", "Wall-clock", "Bandwidth", "Throughput"])
+    print_multi(values=["Run", "Wall-clock", "Avg Bandwidth / GPU", "Throughput / GPU"])
     for i in range(args.iter):
         iter_results = stats[0]["iter_results"]
 

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -213,9 +213,7 @@ async def worker(rank, eps, args):
         # Ensure the number of matches falls within `args.frac_match` +/- 1%
         expected_len = args.chunk_size * args.frac_match
         expected_len_err = expected_len * 0.01
-        assert len(ret) in range(
-            expected_len - expected_len_err, expected_len + expected_len_err
-        )
+        assert abs(len(ret) - expected_len) <= expected_len_err
 
         if args.collect_garbage:
             gc.collect()

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -307,6 +307,7 @@ def main():
         worker,
         worker_args=args,
         server_address=args.server_address,
+        ensure_cuda_device=True,
     )
 
     wc = stats[0]["wallclock"]

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -18,7 +18,7 @@ from dask.utils import format_bytes, format_time
 
 import ucp
 from ucp._libs.utils import print_multi, print_separator
-from ucp.utils import run_on_local_network
+from ucp.utils import hmean, run_on_local_network
 
 # Must be set _before_ importing RAPIDS libraries (cuDF, RMM)
 os.environ["RAPIDS_NO_INITIALIZE"] = "True"
@@ -343,7 +343,7 @@ def main():
     )
 
     wc = stats[0]["wallclock"]
-    bw = sum(s["bw"] for s in stats) / len(stats)
+    bw = hmean(np.array([s["bw"] for s in stats]))
     tp = stats[0]["throughput"]
     dp = sum(s["data_processed"] for s in stats)
     dp_iter = sum(s["iter_results"]["data_processed"][0] for s in stats)
@@ -366,7 +366,7 @@ def main():
         iter_results = stats[0]["iter_results"]
 
         iter_wc = iter_results["wallclock"][i]
-        iter_bw = sum(s["iter_results"]["bw"][i] for s in stats) / len(stats)
+        iter_bw = hmean(np.array([s["iter_results"]["bw"][i] for s in stats]))
         iter_tp = iter_results["throughput"][i]
 
         print_multi(

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -210,9 +210,9 @@ async def worker(rank, eps, args):
         await barrier(rank, eps)
         iter_took = clock() - iter_t
 
-        # Ensure the number of matches falls within `args.frac_match` +/- 1%
+        # Ensure the number of matches falls within `args.frac_match` +/- 2%
         expected_len = args.chunk_size * args.frac_match
-        expected_len_err = expected_len * 0.01
+        expected_len_err = expected_len * 0.02
         assert abs(len(ret) - expected_len) <= expected_len_err
 
         if args.collect_garbage:

--- a/benchmarks/cudf-merge.py
+++ b/benchmarks/cudf-merge.py
@@ -9,15 +9,18 @@ import io
 import os
 import pickle
 import pstats
-from time import perf_counter as clock
+from time import monotonic as clock
 
 import cupy
 import numpy as np
 
-from dask.utils import format_bytes, format_time
-
 import ucp
-from ucp._libs.utils import print_multi, print_separator
+from ucp._libs.utils import (
+    format_bytes,
+    format_time,
+    print_multi,
+    print_separator,
+)
 from ucp.utils import hmean, run_on_local_network
 
 # Must be set _before_ importing RAPIDS libraries (cuDF, RMM)

--- a/ucp/_libs/utils.py
+++ b/ucp/_libs/utils.py
@@ -40,3 +40,13 @@ def print_separator(separator="-", length=80):
 def print_key_value(key, value, key_length=25):
     """Print a key and value with fixed key-field length"""
     print(f"{key: <{key_length}} | {value}")
+
+
+def print_multi(values, key_length=25):
+    """Print a key and value with fixed key-field length"""
+    assert isinstance(values, tuple) or isinstance(values, list)
+    assert len(values) > 1
+
+    print_str = "".join(f"{s: <{key_length}} | " for s in values[:-1])
+    print_str += values[-1]
+    print(print_str)

--- a/ucp/_libs/utils.py
+++ b/ucp/_libs/utils.py
@@ -13,8 +13,18 @@ except ImportError:
 
 
 try:
-    from dask.utils import format_bytes, parse_bytes
+    from dask.utils import format_bytes, format_time, parse_bytes
 except ImportError:
+
+    def format_time(x):
+        if x < 1e-6:
+            return f"{x * 1e9:.3f} ns"
+        if x < 1e-3:
+            return f"{x * 1e6:.3f} us"
+        if x < 1:
+            return f"{x * 1e3:.3f} ms"
+        else:
+            return f"{x:.3f} s"
 
     def format_bytes(x):
         """Return formatted string in B, KiB, MiB, GiB or TiB"""

--- a/ucp/utils.py
+++ b/ucp/utils.py
@@ -216,3 +216,11 @@ def hash64bits(*args):
     h = hashlib.sha1(bytes(repr(args), "utf-8")).hexdigest()[:16]
     # Convert to an integer and return
     return int(h, 16)
+
+
+def hmean(a):
+    """Harmonic mean"""
+    if len(a):
+        return 1 / np.mean(1 / a)
+    else:
+        return 0


### PR DESCRIPTION
This adds several bugfixes and improvements:

- Correctly assign `CUDA_VISIBLE_DEVICES`;
- Create CUDA contexts before initializing UCX;
- Ensure merge uses the `"key"` column and asserts expected result size;
- Allow running the benchmark for multiple iterations;
- Allow running multiple warmup iterations;
- Prints results for each iteration;
- Allow enabling garbage collection after each itearation.