### PR TITLE
Add `ip_address` as argument to listener

### DIFF
--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,0 +1,38 @@
+import pytest
+
+import ucp
+
+
+@pytest.mark.asyncio
+async def test_bind_ip():
+    listener = ucp.create_listener(lambda: None, ip_address="127.0.0.1")
+
+    assert isinstance(listener.port, int)
+    assert listener.port >= 1024
+
+    assert isinstance(listener.ip, str)
+    assert listener.ip == "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_bind_port():
+    listener = None
+    port = None
+
+    for i in range(10000, 20000):
+        try:
+            listener = ucp.create_listener(
+                lambda: None,
+                i,
+            )
+        except ucp.UCXError:
+            # Port already in use, try another
+            continue
+        else:
+            port = i
+            break
+
+    assert isinstance(listener.port, int)
+    assert listener.port == port
+
+    assert isinstance(listener.ip, str)

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -234,6 +234,7 @@ class ApplicationContext:
         callback_func,
         port=0,
         endpoint_error_handling=True,
+        ip_address=None,
     ):
         """Create and start a listener to accept incoming connections
 
@@ -257,6 +258,9 @@ class ApplicationContext:
             but prevents a process from terminating unexpectedly that may
             happen when disabled. If `False` endpoint endpoint error handling
             is disabled.
+        ip_address: str, optional
+            IP address to bind the listener to. Binds to `0.0.0.0` if not
+            specified.
 
         Returns
         -------
@@ -274,6 +278,7 @@ class ApplicationContext:
                 port=port,
                 cb_func=_listener_handler,
                 cb_args=(callback_func, self, endpoint_error_handling),
+                ip_address=ip_address,
             )
         )
         return ret
@@ -992,11 +997,14 @@ def register_am_allocator(allocator, allocator_type):
     return _get_ctx().register_am_allocator(allocator, allocator_type)
 
 
-def create_listener(callback_func, port=None, endpoint_error_handling=True):
+def create_listener(
+    callback_func, port=None, endpoint_error_handling=True, ip_address=None
+):
     return _get_ctx().create_listener(
         callback_func,
         port,
         endpoint_error_handling=endpoint_error_handling,
+        ip_address=ip_address,
     )
 
 


### PR DESCRIPTION
Allows binding the listener to a specific IP address, instead of always listening on `0.0.0.0`.

Blocker: manual verification through `netstat` confirms binding works, but listening IP address reported by UCX always show an IPv6 address instead, possibly a UCX bug.