### PR TITLE
Set `RAPIDS_NO_INITIALIZE` in `conftest.py`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,16 @@
 import asyncio
+import os
 
 import pytest
 
 import ucp
+
+# Prevent calls such as `cudf = pytest.importorskip("cudf")` from initializing
+# a CUDA context. Such calls may cause tests that must initialize the CUDA
+# context on the appropriate device to fail.
+# For example, without `RAPIDS_NO_INITIALIZE=True`, `test_benchmark_cluster`
+# will succeed if running alone, but fails when all tests are run in batch.
+os.environ["RAPIDS_NO_INITIALIZE"] = "True"
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Without this variable set, some tests that need to initialize the CUDA context on the appropriate device will fail, as importing a library such as `cudf` in another test will cause CUDA context to be created.