### PR TITLE
Add missing `__init__.py` and copyright

### DIFF
--- a/ucp/benchmarks/backends/__init__.py
+++ b/ucp/benchmarks/backends/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.


### PR DESCRIPTION
With the reorganization in https://github.com/rapidsai/ucx-py/pull/873 , `ucp/benchmark/backends/__init__.py` was missing causing non-dev UCX-Py installs to fail when attempting to run `send_recv` benchmarks, this change adds the missing file.