### PR TITLE
Correctly parse bytes argument when dask unavailable

### DIFF
--- a/ucp/benchmarks/send_recv.py
+++ b/ucp/benchmarks/send_recv.py
@@ -176,6 +176,7 @@ def parse_args():
             "--n-bytes",
             metavar="BYTES",
             default=10_000_000,
+            type=int,
             help="Message size in bytes. Default '10_000_000'.",
         )
     parser.add_argument(


### PR DESCRIPTION
We need to ensure the value we read is converted to int.