### PR TITLE
Enable copy_prs behavior of ops-bot

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,10 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+auto_merger: false
+branch_checker: false
+label_checker: false
+release_drafter: false
+external_contributors: false
+copy_prs: true
+rerun_tests: false


### PR DESCRIPTION
This file will enable ops-bot to perform the "copy_prs" action, described here: https://github.com/rapidsai/ops-bot/#plugins

It will help run GitHub Actions using rapidsai self-hosted runners from pull requests (needed for the wheel project).