### PR TITLE
Update Docker scripts to reflect recent benchmark changes

### DIFF
--- a/docker/bench-all.sh
+++ b/docker/bench-all.sh
@@ -24,9 +24,9 @@ for tls in ${@:-"tcp" "all"}; do
 
     for array_type in "numpy" "cupy" "rmm"; do
         logger "Benchmarks (UCX_TLS=${UCX_TLS}, array_type=${array_type})"
-        python benchmarks/send-recv.py -o ${array_type} \
+        python ucp.benchmarks.send_recv -l ucp-async -o ${array_type} \
             --server-dev 0 --client-dev 0 --reuse-alloc
-        python benchmarks/send-recv-core.py -o ${array_type} \
+        python ucp.benchmarks.send_recv -l ucp-core -o ${array_type} \
             --server-dev 0 --client-dev 0 --reuse-alloc
     done
 done

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -63,8 +63,8 @@ for tls in "tcp" "all"; do
     pytest --cache-clear -vs tests/
 
     logger "Benchmarks (UCX_TLS=$UCX_TLS)"
-    python benchmarks/send-recv.py -o numpy \
+    python -m ucp.benchmarks.send_recv -l ucp-async -o numpy \
         --server-dev 0 --client-dev 0 --reuse-alloc
-    python benchmarks/send-recv-core.py -o numpy \
+    python -m ucp.benchmarks.send_recv -l ucp-core -o numpy \
         --server-dev 0 --client-dev 0 --reuse-alloc
 done


### PR DESCRIPTION
With recent changes from https://github.com/rapidsai/ucx-py/pull/873, launching benchmarks has been changed. Docker scripts must be adjusted accordingly.