### PR TITLE
Fix Cython exceptions

### DIFF
--- a/ucp/_libs/ucx_endpoint.pyx
+++ b/ucp/_libs/ucx_endpoint.pyx
@@ -131,7 +131,7 @@ cdef void _err_cb(void *arg, ucp_ep_h ep, ucs_status_t status) with gil:
 
 cdef (ucp_err_handler_cb_t, uintptr_t) _get_error_callback(
     str tls, bint endpoint_error_handling
-) except * with gil:
+) with gil:
     cdef ucp_err_handler_cb_t err_cb = <ucp_err_handler_cb_t>NULL
     cdef ucs_status_t *cb_status = <ucs_status_t *>NULL
 

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -28,7 +28,7 @@ from .exceptions import UCXConfigError, UCXError
 from .ucx_api_dep cimport *
 
 
-cdef FILE * create_text_fd():
+cdef FILE * create_text_fd() except *:
     cdef FILE *text_fd = tmpfile()
     if text_fd == NULL:
         raise IOError("tmpfile() failed")


### PR DESCRIPTION
A crash was reported after `tmpfile` in `create_text_fd()` raised an exception, causing a segmentation fault. This was due to the missing `except *` Cython handle for that function. The `_err_cb` also used `except *` handle which is unnecessary, that is now removed.