### PR TITLE
Add pyproject.toml file.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [build-system]
-build-backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta:__legacy__"
 requires = [
     "setuptools",
     "cython>=0.29,<0.30",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [build-system]
-
+build-backend = "setuptools.build_meta"
 requires = [
     "setuptools",
     "cython>=0.29,<0.30",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[build-system]
+
+requires = [
+    "setuptools",
+    "cython>=0.29,<0.30",
+]


### PR DESCRIPTION
This file is required for using newer PEP517-compliant projects.