### PR TITLE
Remove `psutil` dependency

### DIFF
--- a/conda/environments/builddocs.yml
+++ b/conda/environments/builddocs.yml
@@ -15,6 +15,5 @@ dependencies:
 - recommonmark
 - pandoc=<2.0.0
 - pip
-- psutil
 - ucx
 - cython

--- a/conda/recipes/ucx-py/meta.yaml
+++ b/conda/recipes/ucx-py/meta.yaml
@@ -24,7 +24,6 @@ requirements:
   run:
     - python
     - numpy
-    - psutil
     - ucx
   run_constrained:
     - pynvml {{ pynvml }}

--- a/docker/ucx-py-cuda11.5.yml
+++ b/docker/ucx-py-cuda11.5.yml
@@ -7,7 +7,6 @@ dependencies:
   - python=3.8
   - cudatoolkit=11.5
   - setuptools
-  - psutil
   - cython>=0.29.14,<3.0.0a0
   - pytest
   - pytest-asyncio

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -55,7 +55,6 @@ Build Dependencies
 
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
-        psutil \
         "python=3.7" setuptools "cython>=0.29.14,<3.0.0a0"
 
 Test Dependencies

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ cmdclass["build_ext"] = build_ext
 
 install_requires = [
     "numpy",
-    "psutil",
     "pynvml",
 ]
 


### PR DESCRIPTION
In the past `psutil` was used to generate a random port number for the listener, but this is not anymore used as now UCX's random port generation is utilized, but the dependency to `psutil` was not removed. This PR removes the not anymore used dependency.