### PR TITLE
Enable auto-merger

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,7 +1,7 @@
 # This file controls which features from the `ops-bot` repository below are enabled.
 # - https://github.com/rapidsai/ops-bot
 
-auto_merger: false
+auto_merger: true
 branch_checker: false
 label_checker: false
 release_drafter: false


### PR DESCRIPTION
This PR enables the auto-merge for `ucx-py`. This means that all future PRs can be merged with the `@gpucibot merge` command.