### PR TITLE
Move `get_address` and improve compatibility and error handling

### DIFF
--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -20,7 +20,7 @@ from ._version import get_versions as _get_versions  # noqa
 from .core import *  # noqa
 from .core import get_ucx_version  # noqa
 from .utils import get_ucxpy_logger  # noqa
-from ._libs.ucx_api import get_address  # noqa
+from ._libs.utils import get_address  # noqa
 
 try:
     import pynvml

--- a/ucp/_libs/tests/test_cancel.py
+++ b/ucp/_libs/tests/test_cancel.py
@@ -3,9 +3,9 @@ import re
 
 import pytest
 
-from ucp import get_address
 from ucp._libs import ucx_api
 from ucp._libs.arr import Array
+from ucp._libs.utils import get_address
 from ucp.exceptions import UCXCanceled
 
 mp = mp.get_context("spawn")

--- a/ucp/_libs/tests/test_endpoint.py
+++ b/ucp/_libs/tests/test_endpoint.py
@@ -4,6 +4,7 @@ import multiprocessing as mp
 import pytest
 
 from ucp._libs import ucx_api
+from ucp._libs.utils import get_address
 
 mp = mp.get_context("spawn")
 
@@ -56,7 +57,7 @@ def _client(port, server_close_callback):
     worker = ucx_api.UCXWorker(ctx)
     ep = ucx_api.UCXEndpoint.create(
         worker,
-        ucx_api.get_address(),
+        get_address(),
         port,
         endpoint_error_handling=True,
     )

--- a/ucp/_libs/tests/test_probe.py
+++ b/ucp/_libs/tests/test_probe.py
@@ -2,8 +2,8 @@ import multiprocessing as mp
 
 import pytest
 
-from ucp import get_address
 from ucp._libs import ucx_api
+from ucp._libs.utils import get_address
 from ucp._libs.utils_test import (
     blocking_am_recv,
     blocking_am_send,

--- a/ucp/_libs/tests/test_server_client.py
+++ b/ucp/_libs/tests/test_server_client.py
@@ -6,6 +6,7 @@ import pytest
 
 from ucp._libs import ucx_api
 from ucp._libs.arr import Array
+from ucp._libs.utils import get_address
 from ucp._libs.utils_test import blocking_recv, blocking_send
 
 mp = mp.get_context("spawn")
@@ -65,7 +66,7 @@ def _echo_client(msg_size, port):
     worker = ucx_api.UCXWorker(ctx)
     ep = ucx_api.UCXEndpoint.create(
         worker,
-        ucx_api.get_address(),
+        get_address(),
         port,
         endpoint_error_handling=True,
     )

--- a/ucp/_libs/tests/test_server_client_am.py
+++ b/ucp/_libs/tests/test_server_client_am.py
@@ -8,6 +8,7 @@ import pytest
 
 from ucp._libs import ucx_api
 from ucp._libs.arr import Array
+from ucp._libs.utils import get_address
 from ucp._libs.utils_test import blocking_am_recv, blocking_am_send
 
 mp = mp.get_context("spawn")
@@ -117,7 +118,7 @@ def _echo_client(msg_size, datatype, port):
 
     ep = ucx_api.UCXEndpoint.create(
         worker,
-        ucx_api.get_address(),
+        get_address(),
         port,
         endpoint_error_handling=True,
     )

--- a/ucp/_libs/utils.py
+++ b/ucp/_libs/utils.py
@@ -85,6 +85,11 @@ def get_address(ifname=None):
     address : str
         The inet addr associated with an interface.
 
+    Raises
+    ------
+    RuntimeError
+        If a network address could not be determined.
+
     Examples
     --------
     >>> get_address()
@@ -119,6 +124,11 @@ def get_address(ifname=None):
                     return _get_address(i)
                 except OSError:
                     pass
+
+        raise RuntimeError(
+            "A network address could not be determined, an interface that has a valid "
+            "IP address with the environment variable `UCXPY_IFNAME`."
+        )
 
     if ifname is None:
         ifname = os.environ.get("UCXPY_IFNAME")

--- a/ucp/_libs/utils.py
+++ b/ucp/_libs/utils.py
@@ -1,6 +1,12 @@
 # Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 # See file LICENSE for terms.
 
+import fcntl
+import glob
+import os
+import socket
+import struct
+
 try:
     from nvtx import annotate as nvtx_annotate
 except ImportError:
@@ -60,3 +66,64 @@ def print_multi(values, key_length=25):
     print_str = "".join(f"{s: <{key_length}} | " for s in values[:-1])
     print_str += values[-1]
     print(print_str)
+
+
+def get_address(ifname=None):
+    """
+    Get the address associated with a network interface.
+
+    Parameters
+    ----------
+    ifname : str
+        The network interface name to find the address for.
+        If None, it uses the value of environment variable `UCXPY_IFNAME`
+        and if `UCXPY_IFNAME` is not set it defaults to "ib0"
+        An OSError is raised for invalid interfaces.
+
+    Returns
+    -------
+    address : str
+        The inet addr associated with an interface.
+
+    Examples
+    --------
+    >>> get_address()
+    '10.33.225.160'
+
+    >>> get_address(ifname='lo')
+    '127.0.0.1'
+    """
+
+    def _get_address(ifname):
+        ifname = ifname.encode()
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            return socket.inet_ntoa(
+                fcntl.ioctl(
+                    s.fileno(), 0x8915, struct.pack("256s", ifname[:15])  # SIOCGIFADDR
+                )[20:24]
+            )
+
+    def _try_interfaces():
+        prefix_priority = ["ib", "eth", "en"]
+        iftypes = {p: [] for p in prefix_priority}
+        for i in glob.glob("/sys/class/net/*"):
+            name = i.split("/")[-1]
+            for p in prefix_priority:
+                if name.startswith(p):
+                    iftypes[p].append(name)
+        for p in prefix_priority:
+            iftype = iftypes[p]
+            iftype.sort()
+            for i in iftype:
+                try:
+                    return _get_address(i)
+                except OSError:
+                    pass
+
+    if ifname is None:
+        ifname = os.environ.get("UCXPY_IFNAME")
+
+    if ifname is not None:
+        return _get_address(ifname)
+    else:
+        return _try_interfaces()

--- a/ucp/_libs/utils.py
+++ b/ucp/_libs/utils.py
@@ -104,7 +104,7 @@ def get_address(ifname=None):
             )
 
     def _try_interfaces():
-        prefix_priority = ["ib", "eth", "en"]
+        prefix_priority = ["ib", "eth", "en", "docker"]
         iftypes = {p: [] for p in prefix_priority}
         for i in glob.glob("/sys/class/net/*"):
             name = i.split("/")[-1]

--- a/ucp/_libs/utils.pyx
+++ b/ucp/_libs/utils.pyx
@@ -4,12 +4,6 @@
 
 # cython: language_level=3
 
-import fcntl
-import glob
-import os
-import socket
-import struct
-
 from cpython.buffer cimport PyBUF_FORMAT, PyBUF_ND, PyBUF_WRITABLE
 from libc.stdio cimport (
     FILE,
@@ -180,64 +174,3 @@ def get_ucx_version():
     cdef unsigned int a, b, c
     ucp_get_version(&a, &b, &c)
     return (a, b, c)
-
-
-def get_address(ifname=None):
-    """
-    Get the address associated with a network interface.
-
-    Parameters
-    ----------
-    ifname : str
-        The network interface name to find the address for.
-        If None, it uses the value of environment variable `UCXPY_IFNAME`
-        and if `UCXPY_IFNAME` is not set it defaults to "ib0"
-        An OSError is raised for invalid interfaces.
-
-    Returns
-    -------
-    address : str
-        The inet addr associated with an interface.
-
-    Examples
-    --------
-    >>> get_address()
-    '10.33.225.160'
-
-    >>> get_address(ifname='lo')
-    '127.0.0.1'
-    """
-
-    def _get_address(ifname):
-        ifname = ifname.encode()
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-            return socket.inet_ntoa(
-                fcntl.ioctl(
-                    s.fileno(), 0x8915, struct.pack("256s", ifname[:15])  # SIOCGIFADDR
-                )[20:24]
-            )
-
-    def _try_interfaces():
-        prefix_priority = ["ib", "eth", "en"]
-        iftypes = {p: [] for p in prefix_priority}
-        for i in glob.glob("/sys/class/net/*"):
-            name = i.split("/")[-1]
-            for p in prefix_priority:
-                if name.startswith(p):
-                    iftypes[p].append(name)
-        for p in prefix_priority:
-            iftype = iftypes[p]
-            iftype.sort()
-            for i in iftype:
-                try:
-                    return _get_address(i)
-                except OSError:
-                    pass
-
-    if ifname is None:
-        ifname = os.environ.get("UCXPY_IFNAME")
-
-    if ifname is not None:
-        return _get_address(ifname)
-    else:
-        return _try_interfaces()

--- a/ucp/benchmarks/utils.py
+++ b/ucp/benchmarks/utils.py
@@ -9,7 +9,7 @@ from types import ModuleType
 
 import numpy as np
 
-from ucp._libs import ucx_api
+from ucp._libs.utils import get_address
 
 logger = logging.getLogger("ucx")
 
@@ -113,7 +113,7 @@ def _server_process(
         else:
             fp = open(server_file, mode="w")
         with fp:
-            json.dump({"address": ucx_api.get_address(), "port": lf.port}, fp)
+            json.dump({"address": get_address(), "port": lf.port}, fp)
 
         while len(results) != n_workers:
             await asyncio.sleep(0.1)
@@ -234,7 +234,7 @@ def _worker_process(
         server_ep = await ucp.create_endpoint(
             server_info["address"], server_info["port"]
         )
-        await send_pickled_msg(server_ep, (rank, ucx_api.get_address(), lf.port))
+        await send_pickled_msg(server_ep, (rank, get_address(), lf.port))
 
         logger.debug(f"Receiving network info from server {rank=}")
         workers_info = await recv_pickled_msg(server_ep)


### PR DESCRIPTION
Move `get_address` into `utils.py`, which is a pure-Python function that does not need to live in a Cython source file.

Optionally attempt to query for `docker*` network interface, if other known interfaces fail in a Docker container. If still no valid IP address could be determined, raise an exception with information on how the user can manually setup to proceed.