### PR TITLE
Upgrade Python version to 3.8 in docs

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -27,14 +27,14 @@ With GPU support:
 ::
 
     conda create -n ucx -c conda-forge -c rapidsai \
-      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.7
+      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.8
 
 Without GPU support:
 
 ::
 
     conda create -n ucx -c conda-forge -c rapidsai \
-      ucx-proc=*=cpu ucx ucx-py python=3.7
+      ucx-proc=*=cpu ucx ucx-py python=3.8
 
 
 Source
@@ -55,7 +55,7 @@ Build Dependencies
 
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
-        "python=3.7" setuptools "cython>=0.29.14,<3.0.0a0"
+        "python=3.8" setuptools "cython>=0.29.14,<3.0.0a0"
 
 Test Dependencies
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,14 +10,14 @@ With GPU support:
 ::
 
     conda create -n ucx -c conda-forge -c rapidsai \
-      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.7
+      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.8
 
 Without GPU support:
 
 ::
 
     conda create -n ucx -c conda-forge -c rapidsai \
-      ucx-proc=*=cpu ucx ucx-py python=3.7
+      ucx-proc=*=cpu ucx ucx-py python=3.8
 
 For a more detailed guide on installation options please refer to the :doc:`install` page.
 


### PR DESCRIPTION
Python 3.6 and above _should_ still work, but are not actively tested, thus upgrading to 3.8 which is actually tested should be encouraged.