### PR TITLE
Update GH Action Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
       - "branch-*"
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
-  workflow_call:
+  workflow_dispatch:
     inputs:
       branch:
         required: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: test
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       branch:
         required: true


### PR DESCRIPTION
This PR updates the workflows to change some of the events used to trigger the `build.yaml` and `test.yaml` workflows.

These changes are necessary due to a recent change in how we call these workflows from the nightly pipeline in the https://github.com/rapidsai/actions.

See https://github.com/rapidsai/actions/pull/7 for more details.