### PR TITLE
Remove unnecessary repo: param for wheels

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/ucx-py
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
@@ -50,7 +49,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-publish.yml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/ucx-py
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@main
     with:
       build_type: nightly
-      repo: rapidsai/ucx-py
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}


### PR DESCRIPTION
The repo key is no longer needed by the wheel workflow.