### PR TITLE
Add `recently_updated` check

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -6,3 +6,4 @@ branch_checker: false
 label_checker: false
 release_drafter: false
 copy_prs: true
+recently_updated: true


### PR DESCRIPTION
This change should've been added in #914.

It enables the _Recently Updated_ check that is intended to be used with our GitHub Actions implementation.

For more details on the check, view the docs page below:

- https://docs.rapids.ai/resources/recently-updated/