### PR TITLE
Forward-merge branch-0.30 to branch-0.31

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
       - repo: https://github.com/pycqa/isort
-        rev: 5.10.1
+        rev: 5.12.0
         hooks:
               - id: isort
                 args: ["--settings-path=pyproject.toml"]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.30` that creates a PR to keep `branch-0.31` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.