### PR TITLE
Reduce error handling verbosity in CI tests scripts

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -56,6 +57,10 @@ rapids-mamba-retry install \
   --channel "${PYTHON_CHANNEL}" \
   ucx-py
 
+EXITCODE=0
+trap "EXITCODE=1" ERR
+set +e
+
 rapids-logger "Run tests with conda package"
 run_tests
 
@@ -81,3 +86,6 @@ if [[ "${TEST_UCX_MASTER}" == 1 ]]; then
     rapids-logger "Run tests with pip package against ucx master"
     run_tests
 fi
+
+rapids-logger "Test script exiting with value: $EXITCODE"
+exit ${EXITCODE}


### PR DESCRIPTION
This PR adds a less verbose [trap method](https://github.com/rapidsai/cugraph/blob/f2b081075704aabc789603e14ce552eac3fbe692/ci/test.sh#L19), for error handling to help ensure that we capture all potential error codes in our test scripts, and works as follows:

- setting an environment variable, EXITCODE, with a default value of 0
- setting a trap statement triggered by ERR signals which will set EXITCODE=1 when any commands return a non-zero exit code

cc @ajschmidt8