### PR TITLE
Fix "coroutine was never awaited" warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
       - repo: https://github.com/pycqa/isort
-        rev: 5.10.1
+        rev: 5.12.0
         hooks:
               - id: isort
                 args: ["--settings-path=pyproject.toml"]


### PR DESCRIPTION
Fix warnings such as the one below:

```
sys:1: RuntimeWarning: coroutine 'BlockingMode._arm_worker' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Task was destroyed but it is pending!
task: <Task pending name='Task-22' coro=<BlockingMode._arm_worker() running at /opt/conda/envs/rn-230213/lib/python3.10/site-packages/ucp/continuous_ucx_progress.py:88>>
```

The fix requires introducing a fairly complex mechanism that checks for references to the UCP context and preemptively stop continuous progress when no listeners or endpoints are alive anymore.

TODO: Verify how to still provide continuous progress for workers that do not make use of listeners, instead relying on `ucp.recv()`, which receives messages directly on the worker.