### PR TITLE
Update requirement to Python >= 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
     "numpy",
     "pynvml",

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 
 import numpy as np
 import pytest
@@ -46,9 +45,6 @@ async def test_server_shutdown(message_type):
     await client_node(listener.port)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="test currently fails for python3.6"
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("message_type", ["tag", "am"])
 async def test_client_shutdown(message_type):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -20,12 +20,7 @@ async def test_tag_match():
     lf = ucp.create_listener(server_node)
     ep = await ucp.create_endpoint(ucp.get_address(), lf.port)
     m1, m2 = (bytearray(len(msg1)), bytearray(len(msg2)))
-    # May be dropped in favor of `asyncio.create_task` only
-    # once Python 3.6 is dropped.
-    if hasattr(asyncio, "create_future"):
-        f2 = asyncio.create_task(ep.recv(m2, tag="msg2"))
-    else:
-        f2 = asyncio.ensure_future(ep.recv(m2, tag="msg2"))
+    f2 = asyncio.create_task(ep.recv(m2, tag="msg2"))
 
     # At this point f2 shouldn't be able to finish because its
     # tag "msg2" doesn't match the servers send tag "msg1"


### PR DESCRIPTION
We were maintaining support for Python 3.6 due to some users still requiring that, they are still on older UCX-Py releases so they are ok with us updating to Python 3.8+ on newer releases and they will try upgrading to a newer Python release soon.