### PR TITLE
Forward-merge branch-0.31 to branch-0.32

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,7 +54,7 @@ jobs:
       build_type: pull-request
       package-name: ucx_py
       test-docker-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g"
-      test-before-arm64: "pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64"
+      test-before-arm64: "pip install 'cupy-cuda11x<12.0.0' -f https://pip.cupy.dev/aarch64"
       # skipped test context: https://github.com/rapidsai/ucx-py/pull/909
       test-unittest: "pytest -k 'not test_send_recv_am' --cache-clear -vs ./ucp/_libs/tests/ && pytest --cache-clear -vs ./tests"
       test-smoketest: "pytest -k 'not test_send_recv_am' --cache-clear -vs ./ucp/_libs/tests/ && pytest --cache-clear -vs ./tests"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,6 @@ jobs:
       sha: ${{ inputs.sha }}
       package-name: ucx_py
       test-docker-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g"
-      test-before-arm64: "pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64"
+      test-before-arm64: "pip install 'cupy-cuda11x<12.0.0' -f https://pip.cupy.dev/aarch64"
       # skipped test context: https://github.com/rapidsai/ucx-py/pull/909
       test-unittest: "pytest -k 'not test_send_recv_am' --cache-clear -vs ./ucp/_libs/tests/ && pytest --cache-clear -vs ./tests"

--- a/ci/release/apply_wheel_modifications.sh
+++ b/ci/release/apply_wheel_modifications.sh
@@ -6,7 +6,5 @@
 VERSION=${1}
 CUDA_SUFFIX=${2}
 
-sed -i "s/__version__ = .*/__version__ = \"${VERSION}\"/g" ucp/__init__.py
 sed -i "s/^version = .*/version = \"${VERSION}\"/g" pyproject.toml
-
 sed -i "s/^name = \"ucx-py\"/name = \"ucx-py${CUDA_SUFFIX}\"/g" pyproject.toml


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.31` that creates a PR to keep `branch-0.32` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.