### PR TITLE
Remove setup env vars config

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,6 @@ jobs:
       cibw-before-build: 'cp {package}/.github/build-scripts/patch-wheel.sh /patch-wheel.sh'
       post-repair-amd64: "/patch-wheel.sh {dest_dir}/*.whl"
       post-repair-arm64: "/patch-wheel.sh {dest_dir}/*.whl"
-      uses-setup-env-vars: false
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,6 @@ jobs:
       cibw-before-build: 'cp {package}/.github/build-scripts/patch-wheel.sh /patch-wheel.sh'
       post-repair-amd64: "/patch-wheel.sh {dest_dir}/*.whl"
       post-repair-arm64: "/patch-wheel.sh {dest_dir}/*.whl"
-      uses-setup-env-vars: false
   wheel-tests:
     needs: wheel-build
     secrets: inherit


### PR DESCRIPTION
This setting now matches the default behavior of the shared-action-workflows repo