### PR TITLE
Dropping Python 3.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   conda-python-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@py-39
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   upload-conda:
     needs: [conda-python-build]
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@py-39
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -45,7 +45,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@py-39
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -61,7 +61,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-publish.yml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-publish.yml@py-39
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,26 +18,26 @@ jobs:
       - wheel-build
       - wheel-tests
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@py-39
   checks:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@py-39
   conda-python-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@py-39
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@py-39
     with:
       build_type: pull-request
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@py-39
     with:
       build_type: pull-request
       package-name: ucx_py
@@ -48,7 +48,7 @@ jobs:
   wheel-tests:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@py-39
     with:
       build_type: pull-request
       package-name: ucx_py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   conda-python-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@py-39
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}
@@ -24,7 +24,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@branch-23.06
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@py-39
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
     - libnuma1
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
     - libnuma1
 
 python:
-  version: 3.8
+  version: 3.9
   install:
     - method: pip
       path: .

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -54,10 +54,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.8"
-            packages:
-              - python=3.8
-          - matrix:
               py: "3.9"
             packages:
               - python=3.9
@@ -67,7 +63,7 @@ dependencies:
               - python=3.10
           - matrix:
             packages:
-              - python>=3.8,<3.11
+              - python>=3.9,<3.11
   run:
     common:
       - output_types: [conda, requirements]

--- a/docker/ucx-py-cuda11.5.yml
+++ b/docker/ucx-py-cuda11.5.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.8
+  - python=3.9
   - cudatoolkit=11.5
   - setuptools
   - cython>=0.29.14,<3.0.0a0

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -27,14 +27,14 @@ With GPU support:
 ::
 
     conda create -n ucx -c conda-forge -c rapidsai \
-      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.8
+      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.9
 
 Without GPU support:
 
 ::
 
     conda create -n ucx -c conda-forge -c rapidsai \
-      ucx-proc=*=cpu ucx ucx-py python=3.8
+      ucx-proc=*=cpu ucx ucx-py python=3.9
 
 
 Source
@@ -55,7 +55,7 @@ Build Dependencies
 
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
-        "python=3.8" setuptools "cython>=0.29.14,<3.0.0a0"
+        "python=3.9" setuptools "cython>=0.29.14,<3.0.0a0"
 
 Test Dependencies
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,14 +10,14 @@ With GPU support:
 ::
 
     conda create -n ucx -c conda-forge -c rapidsai \
-      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.8
+      cudatoolkit=<CUDA version> ucx-proc=*=gpu ucx ucx-py python=3.9
 
 Without GPU support:
 
 ::
 
     conda create -n ucx -c conda-forge -c rapidsai \
-      ucx-proc=*=cpu ucx ucx-py python=3.8
+      ucx-proc=*=cpu ucx ucx-py python=3.9
 
 For a more detailed guide on installation options please refer to the :doc:`install` page.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy",
     "pynvml >=11.4.1",


### PR DESCRIPTION
This PR drops Python 3.8 in favor of 3.9.