### PR TITLE
Forward-merge branch-0.32 to branch-0.33

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -39,3 +39,6 @@ sed_runner "s/cudf=.*/cudf=${NEXT_RAPIDS_VERSION}/g" dependencies.yaml
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-action-workflows/ s/@.*/@branch-${NEXT_RAPIDS_VERSION}/g" "${FILE}"
 done
+
+sed_runner "s/^version = .*/version = \"${NEXT_FULL_TAG}\"/g" pyproject.toml
+sed_runner "s/^__version__ = .*/__version__ = \"${NEXT_FULL_TAG}\"/g" ucp/__init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires = [
 
 [project]
 name = "ucx-py"
-version = "0.31.0"
+version = "0.32.0"
 description = "Python Bindings for the Unified Communication X library (UCX)"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -85,7 +85,7 @@ if "UCX_MAX_RNDV_RAILS" not in os.environ and get_ucx_version() >= (1, 12, 0):
     os.environ["UCX_MAX_RNDV_RAILS"] = "1"
 
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"
 __ucx_version__ = "%d.%d.%d" % get_ucx_version()
 
 if get_ucx_version() < (1, 11, 1):


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.32` that creates a PR to keep `branch-0.33` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.