### PR TITLE
Require Numba 0.57.0+ & NumPy 1.21.0+

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,7 +68,7 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - numpy
+          - numpy>=1.21
           - ucx
   test_python:
     common:
@@ -76,6 +76,6 @@ dependencies:
         packages:
           - cudf=23.06
           - cupy
-          - numba
+          - numba>=0.57
           - pytest
           - pytest-asyncio

--- a/docker/ucx-py-cuda11.5.yml
+++ b/docker/ucx-py-cuda11.5.yml
@@ -13,5 +13,5 @@ dependencies:
   - dask
   - distributed
   - cupy
-  - numba>=0.46
+  - numba>=0.57
   - rmm

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -64,7 +64,7 @@ Test Dependencies
 
     conda install -n ucx -c rapidsai -c nvidia -c conda-forge \
         pytest pytest-asyncio \
-        cupy "numba>=0.46" rmm \
+        cupy "numba>=0.57" rmm \
         distributed
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ authors = [
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.9"
 dependencies = [
-    "numpy",
+    "numpy >=1.21",
     "pynvml >=11.4.1",
 ]
 classifiers = [


### PR DESCRIPTION
Align with the rest of RAPIDS on these requirements. Also needed for CUDA 12 support.