### PR TITLE
Add package-name to wheel publish step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,8 +51,6 @@ jobs:
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
-      package-name: ucx_py
-      package-dir: .
       script: ci/build_wheel.sh
   wheel-publish:
     needs: wheel-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,8 @@ jobs:
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
+      package-name: ucx_py
+      package-dir: .
       script: ci/build_wheel.sh
   wheel-publish:
     needs: wheel-build
@@ -61,4 +63,5 @@ jobs:
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
+      package-name: ucx_py
       script: ci/test_wheel.sh


### PR DESCRIPTION
Nightly tests have been failing for some time because the required variables `package-name` and `package-dir` were not being supplied in the wheel build workflows.

Failures look like:
```
The workflow is not valid. .github/workflows/build.yaml (Line: 58, Col: 11): Input package-name is required, but not provided while calling. .github/workflows/build.yaml (Line: 64, Col: 15): Invalid input, script is not defined in the referenced workflow.
```

https://github.com/rapidsai/ucx-py/actions/runs/5652857349

With the recent changes to workflows, these parameters are no longer required for the build step, but the publish step still needs the `package-name`.