### PR TITLE
Forward-merge branch-0.33 to branch-0.34

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -36,16 +36,16 @@ run_tests() {
 
   # Test with TCP/Sockets
   rapids-logger "TEST WITH TCP ONLY"
-  pytest --cache-clear -vs tests/
-  pytest --cache-clear -vs ucp/_libs/tests
+  timeout 10m pytest --cache-clear -vs tests/
+  timeout 2m pytest --cache-clear -vs ucp/_libs/tests
 
   rapids-logger "Run local benchmark"
   # cd to root directory to prevent repo's `ucp` directory from being used
   # in subsequent commands
   pushd /
-  python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-async
-  python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-core
-  python -m ucp.benchmarks.cudf_merge --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 2097152
+  timeout 1m python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-async
+  timeout 1m python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-core
+  timeout 1m python -m ucp.benchmarks.cudf_merge --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 2097152
   popd
 }
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.33` that creates a PR to keep `branch-0.34` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.