### PR TITLE
Remove script input from publish step in build.yaml.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,4 +62,3 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: ucx_py
-      script: ci/test_wheel.sh


### PR DESCRIPTION
Nightly tests failed because an extra `script` variable was passed to the wheel publish workflow.

Failures look like:
```
Invalid workflow file: .github/workflows/build.yaml#L65
The workflow is not valid. .github/workflows/build.yaml (Line: 65, Col: 15): Invalid input, script is not defined in the referenced workflow.
```

https://github.com/rapidsai/ucx-py/actions/runs/5664871243

Follow-up to #973.