### PR TITLE
Forward-merge branch-0.33 to branch-0.34

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,4 +62,3 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: ucx_py
-      script: ci/test_wheel.sh


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.33` that creates a PR to keep `branch-0.34` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.