### PR TITLE
Undo manual pinning

### DIFF
--- a/conda/recipes/ucx-py/meta.yaml
+++ b/conda/recipes/ucx-py/meta.yaml
@@ -5,7 +5,6 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set py_version = environ['CONDA_PY'] %}
 {% set cuda_version = '.'.join(environ['RAPIDS_CUDA_VERSION'].split('.')[:2]) %}
-{% set cuda_major = cuda_version.split('.')[0] %}
 {% set date_string = environ['RAPIDS_DATE_STRING'] %}
 
 package:
@@ -28,13 +27,7 @@ requirements:
   host:
     - python
     - pip
-    {% if cuda_major == "11" %}
     - ucx
-    {% else %}
-    # Temporary pin because the subsequent build (h64cca9d_3) is missing proper
-    # CUDA support
-    - ucx==1.14.1=h195a15c_3
-    {% endif %}
     {% for r in data.get("build-system", {}).get("requires", []) %}
     - {{ r }}
     {% endfor %}
@@ -43,14 +36,7 @@ requirements:
     {% for r in data.get("project", {}).get("dependencies", []) %}
     - {{ r }}
     {% endfor %}
-    # Something seems wrong with the run export as well now
-    {% if cuda_major == "11" %}
     - ucx
-    {% else %}
-    # Temporary pin because the subsequent build (h64cca9d_3) is missing proper
-    # CUDA support
-    - ucx==1.14.1=h195a15c_3
-    {% endif %}
 
 test:
   imports:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -108,19 +108,9 @@ dependencies:
         packages:
           - numpy>=1.21
           - pynvml>=11.4.1
-    specific:
       - output_types: conda
-        matrices:
-          - matrix:
-              cuda: "12.0"
-            packages:
-              # Temporary pin because the subsequent build (h64cca9d_3) is
-              # missing proper CUDA support
-              - ucx==1.14.1=h195a15c_3
-          - matrix:
-              cuda: "11.8"
-            packages:
-              - ucx
+        packages:
+          - ucx
   test_python:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
This PR is a test to validate that upstream ucx builds are no longer broken, at which point we will also be able to remove this pinning.