### PR TITLE
Use `conda mambabuild` not `mamba mambabuild`

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -9,7 +9,7 @@ rapids-print-env
 
 rapids-logger "Begin py build"
 
-rapids-mamba-retry mambabuild \
+rapids-conda-retry mambabuild \
   conda/recipes/ucx-py
 
 rapids-upload-conda-to-s3 python


### PR DESCRIPTION
With the release of conda 23.7.3, `mamba mambabuild` stopped working. With boa installed, `conda mambabuild` uses the mamba solver, so just use that instead.

See also https://github.com/rapidsai/cudf/issues/14068.
