### PR TITLE
Remove ucx from explicit run reqs

### DIFF
--- a/conda/recipes/ucx-py/meta.yaml
+++ b/conda/recipes/ucx-py/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     {% for r in data.get("project", {}).get("dependencies", []) %}
     - {{ r }}
     {% endfor %}
-    - ucx
 
 test:
   imports:


### PR DESCRIPTION
The ucx run requirement should be inferred from the run exports of ucx since it is part of the host requirements. The run explicit requirement was added to fix upstream issues with ucx packaging that have since been fixed. All other patches were removed in https://github.com/rapidsai/ucx-py/pull/987, but this reversion was missed.