### PR TITLE
Update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,11 @@
 version: 2
 
 build:
-  image: latest
-  apt_packages:
-    - libnuma1
+  os: "ubuntu-22.04"
+  tools:
+    python: "mambaforge-22.9"
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD deprecated `build.image` in favor of `build.os`, which we must update. See https://blog.readthedocs.com/use-build-os-config/ for details.