### PR TITLE
Use lib64 ucx if it exists

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -77,7 +77,14 @@ popd
 
 # Now copy in all the extra libraries that are only ever loaded at runtime
 pushd repair_dist/${underscore_package_name}_${RAPIDS_PY_CUDA_SUFFIX}.libs/ucx
-cp -P /usr/lib/ucx/* .
+if [[ -d /usr/lib64/ucx ]]; then
+    cp -P /usr/lib64/ucx/* .
+elif [[ -d /usr/lib/ucx ]]; then
+    cp -P /usr/lib/ucx/* .
+else
+    echo "Could not find ucx libraries"
+    exit 1
+fi
 
 # we link against <python>/lib/site-packages/${underscore_package_name}_${RAPIDS_PY_CUDA_SUFFIX}.lib/libuc{ptsm}
 # we also amend the rpath to search one directory above to *find* libuc{tsm}


### PR DESCRIPTION
Due to https://github.com/rapidsai/shared-workflows/pull/151 the arm builds are now on Rockylinux 8 instead of Ubuntu 20.04. On Rockylinux 8 the ucx library is installed to the /usr/lib64 directory instead of /usr/lib. This PR updates the wheel building script to support the alternate location.