### PR TITLE
Add argument to enable/disable endpoint error handling in benchmarks

### DIFF
--- a/ucp/benchmarks/backends/ucp_async.py
+++ b/ucp/benchmarks/backends/ucp_async.py
@@ -81,7 +81,11 @@ class UCXPyAsyncServer(BaseServer):
             await ep.close()
             lf.close()
 
-        lf = ucp.create_listener(server_handler, port=self.args.port)
+        lf = ucp.create_listener(
+            server_handler,
+            port=self.args.port,
+            endpoint_error_handling=self.args.error_handling,
+        )
         self.queue.put(lf.port)
 
         while not lf.closed():
@@ -114,7 +118,11 @@ class UCXPyAsyncClient(BaseClient):
 
         register_am_allocators(self.args)
 
-        ep = await ucp.create_endpoint(self.server_address, self.port)
+        ep = await ucp.create_endpoint(
+            self.server_address,
+            self.port,
+            endpoint_error_handling=self.args.error_handling,
+        )
 
         if self.args.enable_am:
             msg = xp.arange(self.args.n_bytes, dtype="u1")

--- a/ucp/benchmarks/backends/ucp_core.py
+++ b/ucp/benchmarks/backends/ucp_core.py
@@ -125,7 +125,7 @@ class UCXPyCoreServer(BaseServer):
             self.ep = ucx_api.UCXEndpoint.create_from_conn_request(
                 worker,
                 conn_request,
-                endpoint_error_handling=True,
+                endpoint_error_handling=self.args.error_handling,
             )
 
             # Wireup before starting to transfer data
@@ -229,7 +229,7 @@ class UCXPyCoreClient(BaseClient):
             worker,
             self.server_address,
             self.port,
-            endpoint_error_handling=True,
+            endpoint_error_handling=self.args.error_handling,
         )
 
         send_msg = xp.arange(self.args.n_bytes, dtype="u1")

--- a/ucp/benchmarks/send_recv.py
+++ b/ucp/benchmarks/send_recv.py
@@ -324,6 +324,12 @@ def parse_args():
         help="Only applies to 'ucp-core' backend: number of maximum outstanding "
         "operations, see --delay-progress. (Default: 32)",
     )
+    parser.add_argument(
+        "--error-handling",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Disable endpoint error handling.",
+    )
 
     args = parser.parse_args()
 

--- a/ucp/benchmarks/send_recv.py
+++ b/ucp/benchmarks/send_recv.py
@@ -328,7 +328,7 @@ def parse_args():
         "--error-handling",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Disable endpoint error handling.",
+        help="Enable endpoint error handling.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Some transports (e.g., `sm`) do not support endpoint error handling. To be able to benchmark them, add a new argument to benchmarks to enable or disable endpoint error handling.