### PR TITLE
Forward-merge branch-0.35 to branch-0.36

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ on:
         default: nightly
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.35` that creates a PR to keep `branch-0.36` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.