### PR TITLE
Forward-merge branch-0.36 to branch-0.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ license-files = ["LICENSE"]
 zip-safe = false
 
 [tool.setuptools.packages.find]
-exclude=["tests*"]
+exclude=["*tests*"]
 
 [tool.setuptools.dynamic]
 version = {file = "ucp/VERSION"}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.36` that creates a PR to keep `branch-0.37` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.