### PR TITLE
Add environment-agnostic scripts for running pytests

### DIFF
--- a/ci/run_benchmark_pytests.sh
+++ b/ci/run_benchmark_pytests.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
-export UCX_TLS="${UCX_TLS:-tcp,cuda_copy}"
-
 # cd to root directory to prevent repo's `ucp` directory from being used
 # in subsequent commands
 pushd /

--- a/ci/run_benchmark_pytests.sh
+++ b/ci/run_benchmark_pytests.sh
@@ -3,9 +3,6 @@
 
 set -euo pipefail
 
-# Support invoking run_pytests.sh outside the script directory
-cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
-
 # cd to root directory to prevent repo's `ucp` directory from being used
 # in subsequent commands
 pushd /

--- a/ci/run_benchmark_pytests.sh
+++ b/ci/run_benchmark_pytests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+# Support invoking run_pytests.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
+
+export UCX_TLS="${UCX_TLS:-tcp,cuda_copy}"
+
+# cd to root directory to prevent repo's `ucp` directory from being used
+# in subsequent commands
+pushd /
+timeout 1m python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-async
+timeout 1m python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-core
+timeout 1m python -m ucp.benchmarks.cudf_merge --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 2097152
+popd

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Test with TCP/Sockets
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../tests/
-timeout 10m py.test --cache-clear -vs  "$@" .
+timeout 10m python -m pytest --cache-clear -vs  "$@" .
 
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../ucp/
-timeout 2m py.test --cache-clear -vs  "$@" ./_libs/tests
+timeout 2m python -m pytest --cache-clear -vs  "$@" ./_libs/tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 
-# Test with TCP/Sockets
 # Support invoking run_pytests.sh outside the script directory
-cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../tests/
-timeout 10m python -m pytest --cache-clear -vs  "$@" .
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
-# Support invoking run_pytests.sh outside the script directory
-cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../ucp/
-timeout 2m python -m pytest --cache-clear -vs  "$@" ./_libs/tests
+# Test with TCP/Sockets
+timeout 10m pytest --cache-clear -vs  "$@" tests
+timeout 2m pytest --cache-clear -vs  "$@" ucp/_libs/tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Test with TCP/Sockets
+# Support invoking run_pytests.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../tests/
+timeout 10m pytest --cache-clear -vs  "$@" .
+
+# Support invoking run_pytests.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../ucp/
+timeout 2m pytest --cache-clear -vs  "$@" ./_libs/tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
-# Test with TCP/Sockets
-timeout 10m pytest --cache-clear -vs  "$@" tests
-timeout 2m pytest --cache-clear -vs  "$@" ucp/_libs/tests
+export UCX_TLS="${UCX_TLS:-tcp,cuda_copy}"
+
+timeout 10m pytest --cache-clear -vs "$@" tests
+timeout 2m pytest --cache-clear -vs "$@" ucp/_libs/tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Test with TCP/Sockets
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../tests/
-timeout 10m python -m pytest --cache-clear -vs  "$@" .
+timeout 10m py.test --cache-clear -vs  "$@" .
 
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../ucp/
-timeout 2m python -m pytest --cache-clear -vs  "$@" ./_libs/tests
+timeout 2m py.test --cache-clear -vs  "$@" ./_libs/tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Test with TCP/Sockets
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../tests/
-timeout 10m pytest --cache-clear -vs  "$@" .
+timeout 10m python -m pytest --cache-clear -vs  "$@" .
 
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../ucp/
-timeout 2m pytest --cache-clear -vs  "$@" ./_libs/tests
+timeout 2m python -m pytest --cache-clear -vs  "$@" ./_libs/tests

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -6,7 +6,5 @@ set -euo pipefail
 # Support invoking run_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
-export UCX_TLS="${UCX_TLS:-tcp,cuda_copy}"
-
 timeout 10m pytest --cache-clear -vs "$@" tests
 timeout 2m pytest --cache-clear -vs "$@" ucp/_libs/tests

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -36,8 +36,8 @@ run_tests() {
 
   # Test with TCP/Sockets
   rapids-logger "TEST WITH TCP ONLY"
-  timeout 10m pytest --cache-clear -vs tests/
-  timeout 2m pytest --cache-clear -vs ucp/_libs/tests
+  # Support invoking test_python.sh outside the script directory
+  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/run_pytests.sh
 
   rapids-logger "Run local benchmark"
   # cd to root directory to prevent repo's `ucp` directory from being used

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -45,11 +45,7 @@ run_tests() {
   rapids-logger "Run local benchmark"
   # cd to root directory to prevent repo's `ucp` directory from being used
   # in subsequent commands
-  pushd /
-  timeout 1m python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-async
-  timeout 1m python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-core
-  timeout 1m python -m ucp.benchmarks.cudf_merge --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 2097152
-  popd
+  ./ci/run_benchmark_pytests.sh
 }
 
 rapids-logger "Downloading artifacts from previous jobs"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
 
 set -euo pipefail
+
+# Support invoking test_python.sh outside the script directory
+  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
@@ -36,8 +40,7 @@ run_tests() {
 
   # Test with TCP/Sockets
   rapids-logger "TEST WITH TCP ONLY"
-  # Support invoking test_python.sh outside the script directory
-  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/run_pytests.sh
+  ./run_pytests.sh
 
   rapids-logger "Run local benchmark"
   # cd to root directory to prevent repo's `ucp` directory from being used

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Support invoking test_python.sh outside the script directory
-  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -35,9 +35,6 @@ run_tests() {
   # list test directory
   ls tests/
 
-  # Setting UCX options
-  export UCX_TLS=tcp,cuda_copy
-
   # Test with TCP/Sockets
   rapids-logger "TEST WITH TCP ONLY"
   ./ci/run_pytests.sh

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Support invoking test_python.sh outside the script directory
-cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
@@ -40,7 +40,7 @@ run_tests() {
 
   # Test with TCP/Sockets
   rapids-logger "TEST WITH TCP ONLY"
-  ./run_pytests.sh
+  ./ci/run_pytests.sh
 
   rapids-logger "Run local benchmark"
   # cd to root directory to prevent repo's `ucp` directory from being used

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -10,5 +10,7 @@ RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-fr
 # echo to expand wildcard before adding `[extra]` requires for pip
 python -m pip install $(echo ./dist/ucx_py*.whl)[test]
 
-# Support invoking test_wheel.sh outside the script directory
-"$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/run_pytests.sh
+cd tests
+python -m pytest --cache-clear -vs .
+cd ../ucp
+python -m pytest --cache-clear -vs ./_libs/tests/

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -10,7 +10,5 @@ RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-fr
 # echo to expand wildcard before adding `[extra]` requires for pip
 python -m pip install $(echo ./dist/ucx_py*.whl)[test]
 
-cd tests
-python -m pytest --cache-clear -vs .
-cd ../ucp
-python -m pytest --cache-clear -vs ./_libs/tests/
+# Support invoking test_wheel.sh outside the script directory
+"$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/run_pytests.sh


### PR DESCRIPTION
This PR adds an environment-agnostic `run_pytests.sh` script, and updates `test_python.sh` to call it.

The `test_python.sh` script assumes it's running in our CI environment, and it does more than just run pytest.

This PR allows devs and downstream consumers to only run the tests, and skip the unrelated logic in `test_python.sh`.
