### PR TITLE
Add support for Python 3.11

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -97,8 +97,12 @@ dependencies:
             packages:
               - python=3.10
           - matrix:
+              py: "3.11"
             packages:
-              - python>=3.9,<3.11
+              - python=3.11
+          - matrix:
+            packages:
+              - python>=3.9,<3.12
   build_python:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -61,11 +61,11 @@ Build Dependencies
 
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
-        "python=3.9" setuptools "cython>=3.0.0"
+        "python=3.11" setuptools "cython>=3.0.0"
 
 .. note::
     The Python version must be explicitly specified here, UCX-Py currently supports
-    only Python 3.9 and 3.10.
+    only Python 3.9, 3.10, and 3.11.
 
 Test Dependencies
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/3

This PR adds support for Python 3.11.

## Notes for Reviewers

This is part of ongoing work to add Python 3.11 support across RAPIDS.

The Python 3.11 CI workflows introduced in https://github.com/rapidsai/shared-workflows/pull/176 are *optional*... they are not yet required to run successfully for PRs to be merged.

This PR can be merged once all jobs are running successfully (including the non-required jobs for Python 3.11). The CI logs should be verified that the jobs are building and testing with Python 3.11.

See https://github.com/rapidsai/shared-workflows/pull/176 for more details.
