### PR TITLE
Update cuDF's `assert_eq` import

### DIFF
--- a/debug-tests/client.py
+++ b/debug-tests/client.py
@@ -83,7 +83,7 @@ def client(env, port, func, verbose):
     # cuda_obj_generator = cloudpickle.loads(func)
     # pure_cuda_obj = cuda_obj_generator()
 
-    # from cudf.testing._utils import assert_eq
+    # from cudf.testing import assert_eq
     # import cupy as cp
 
     # if isinstance(rx_cuda_obj, cp.ndarray):

--- a/tests/test_custom_send_recv.py
+++ b/tests/test_custom_send_recv.py
@@ -111,7 +111,7 @@ async def test_send_recv_cudf(event_loop, g):
     typ = type(msg)
     res = typ.deserialize(ucx_header, cudf_buffer)
 
-    from cudf.testing._utils import assert_eq
+    from cudf.testing import assert_eq
 
     assert_eq(res, msg)
     await uu.comm.ep.close()

--- a/tests/test_send_recv_two_workers.py
+++ b/tests/test_send_recv_two_workers.py
@@ -82,7 +82,7 @@ def client(port, func, comm_api):
     if isinstance(rx_cuda_obj, cupy.ndarray):
         cupy.testing.assert_allclose(rx_cuda_obj, pure_cuda_obj)
     else:
-        from cudf.testing._utils import assert_eq
+        from cudf.testing import assert_eq
 
         assert_eq(rx_cuda_obj, pure_cuda_obj)
 


### PR DESCRIPTION
https://github.com/rapidsai/cudf/pull/16063 has updated the import location of `assert_eq` to the public `cudf.testing.assert_eq`, this change updates imports accordingly.