### PR TITLE
Remove entries for legacy UCX

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,19 +46,6 @@ def test_init_options_and_env():
     assert options == {"SEG_SIZE": "3M"}
 
 
-@pytest.mark.skipif(
-    ucp.get_ucx_version() >= (1, 12, 0),
-    reason="Beginning with UCX >= 1.12, it's only possible to validate "
-    "UCP options but not options from other modules such as UCT. "
-    "See https://github.com/openucx/ucx/issues/7519.",
-)
-def test_init_unknown_option():
-    ucp.reset()
-    options = {"UNKNOWN_OPTION": "3M"}
-    with pytest.raises(ucp.exceptions.UCXConfigError):
-        ucp.init(options)
-
-
 def test_init_invalid_option():
     ucp.reset()
     options = {"SEG_SIZE": "invalid-size"}

--- a/tests/test_from_worker_address_error.py
+++ b/tests/test_from_worker_address_error.py
@@ -152,14 +152,4 @@ def test_from_worker_address_error(error_type):
     client.join()
 
     assert not server.exitcode
-
-    if ucp.get_ucx_version() < (1, 12, 0) and client.exitcode == 1:
-        if all(t in error_type for t in ["timeout", "send"]):
-            pytest.xfail(
-                "Requires https://github.com/openucx/ucx/pull/7527 with rc/ud."
-            )
-        elif all(t in error_type for t in ["timeout", "recv"]):
-            pytest.xfail(
-                "Requires https://github.com/openucx/ucx/pull/7531 with rc/ud."
-            )
     assert not client.exitcode

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -50,11 +50,7 @@ if "UCX_RNDV_FRAG_MEM_TYPE" not in os.environ:
     logger.info("Setting UCX_RNDV_FRAG_MEM_TYPE=cuda")
     os.environ["UCX_RNDV_FRAG_MEM_TYPE"] = "cuda"
 
-if (
-    pynvml is not None
-    and "UCX_CUDA_COPY_MAX_REG_RATIO" not in os.environ
-    and get_ucx_version() >= (1, 12, 0)
-):
+if pynvml is not None and "UCX_CUDA_COPY_MAX_REG_RATIO" not in os.environ:
     try:
         pynvml.nvmlInit()
         device_count = pynvml.nvmlDeviceGetCount()
@@ -98,15 +94,9 @@ if (
     ):
         pass
 
-if "UCX_MAX_RNDV_RAILS" not in os.environ and get_ucx_version() >= (1, 12, 0):
+if "UCX_MAX_RNDV_RAILS" not in os.environ:
     logger.info("Setting UCX_MAX_RNDV_RAILS=1")
     os.environ["UCX_MAX_RNDV_RAILS"] = "1"
 
 
 __ucx_version__ = "%d.%d.%d" % get_ucx_version()
-
-if get_ucx_version() < (1, 11, 1):
-    raise ImportError(
-        f"Support for UCX {__ucx_version__} has ended. Please upgrade to "
-        "1.11.1 or newer."
-    )

--- a/ucp/_libs/tests/test_config.py
+++ b/ucp/_libs/tests/test_config.py
@@ -38,18 +38,6 @@ def test_init_options():
     assert config["SEG_SIZE"] == options["SEG_SIZE"]
 
 
-@pytest.mark.skipif(
-    ucx_api.get_ucx_version() >= (1, 12, 0),
-    reason="Beginning with UCX >= 1.12, it's only possible to validate "
-    "UCP options but not options from other modules such as UCT. "
-    "See https://github.com/openucx/ucx/issues/7519.",
-)
-def test_init_unknown_option():
-    options = {"UNKNOWN_OPTION": "3M"}
-    with pytest.raises(UCXConfigError):
-        ucx_api.UCXContext(options)
-
-
 def test_init_invalid_option():
     options = {"SEG_SIZE": "invalid-size"}
     with pytest.raises(UCXConfigError):


### PR DESCRIPTION
Remove various tests, documentation and general support for older, now unsupported UCX versions.