### PR TITLE
remove management of UCX system libraries in build scripts

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,19 +6,6 @@ set -euo pipefail
 package_name="ucx-py"
 underscore_package_name=$(echo "${package_name}" | tr "-" "_")
 
-# Clear out system ucx files to ensure that we're getting ucx from the wheel.
-rm -rf /usr/lib64/ucx
-rm -rf /usr/lib64/libucm.*
-rm -rf /usr/lib64/libucp.*
-rm -rf /usr/lib64/libucs.*
-rm -rf /usr/lib64/libucs_signal.*
-rm -rf /usr/lib64/libuct.*
-
-rm -rf /usr/include/ucm
-rm -rf /usr/include/ucp
-rm -rf /usr/include/ucs
-rm -rf /usr/include/uct
-
 source rapids-configure-sccache
 source rapids-date-string
 


### PR DESCRIPTION
For https://github.com/rapidsai/build-planning/issues/57, #1041 switched `ucx-py` over to `libucx` wheels. To test that that was working, it added some code to building scripts to remove system installations of UCX libraries.

That should no longer be necessary as of https://github.com/rapidsai/ci-imgs/pull/154.

This proposes removing that code for managing system dependencies of UCX libraries, to simplify those build scripts a bit.