### PR TITLE
Use verify-alpha-spec hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
                 name: flake8-cython
                 args: ["--config=.flake8.cython"]
                 types: [cython]
+      - repo: https://github.com/rapidsai/pre-commit-hooks
+        rev: v0.3.0
+        hooks:
+              - id: verify-alpha-spec
+                args: [--fix, --rapids-version=24.08]
       - repo: https://github.com/rapidsai/dependency-file-generator
         rev: v1.13.11
         hooks:

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -51,3 +51,5 @@ for FILE in .github/workflows/*.yaml; do
 done
 
 echo "${NEXT_RAPIDS_FULL_TAG_PEP440}" > VERSION
+
+sed_runner "s/--rapids-version=[[:digit:]]\{2\}.[[:digit:]]\{2\}/--rapids-version=${NEXT_RAPIDS_SHORT_TAG}/g" .pre-commit-config.yaml


### PR DESCRIPTION
With the deployment of rapids-build-backend, we need to make sure our dependencies have alpha specs.

Contributes to https://github.com/rapidsai/build-planning/issues/31