### PR TITLE
refactor dependency-file-generator handling of cupy, default to CUDA 12 in fallback dependency lists

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,11 +6,11 @@ build:
     python: "mambaforge-22.9"
   jobs:
     post_create_environment:
-      # explicitly passing matrix-entry so that 'libucx' is pulled in,
-      # and therefore tested in this no-CUDA environment
+      # explicitly passing matrix-entry so that 'libucx' (with appropriate CUDA suffix)
+      # is pulled in, and therefore tested in this no-CUDA environment
       - |
         pip install \
-          -C rapidsai.matrix-entry="cuda=12.2;cuda_suffixed=true" \
+          -C rapidsai.matrix-entry="cuda=12.x;cuda_suffixed=true" \
           .
 
 conda:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -150,12 +150,12 @@ dependencies:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix: {cuda: "12.*"}
-            packages: &cupy_packages_cu12
-              - cupy-cuda12x>=12.0.0
+            packages:
+              - &cupy_cu12 cupy-cuda12x>=12.0.0
           - matrix: {cuda: "11.*"}
             packages:
               - cupy-cuda11x>=12.0.0
-          - {matrix: null, packages: *cupy_packages_cu12}
+          - {matrix: null, packages: [*cupy_cu12]}
   depends_on_ucx_build:
     common:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -6,6 +6,7 @@ files:
       - checks
       - cuda
       - cuda_version
+      - depends_on_cupy
       - py_version
       - rapids_build_setuptools
       - run
@@ -14,6 +15,7 @@ files:
     output: none
     includes:
       - cuda_version
+      - depends_on_cupy
       - py_version
       - test_python
   checks:
@@ -52,6 +54,7 @@ files:
       table: project.optional-dependencies
       key: test
     includes:
+      - depends_on_cupy
       - test_python
 channels:
   - rapidsai
@@ -135,6 +138,24 @@ dependencies:
         packages:
           - numpy>=1.23,<2.0a0
           - pynvml>=11.4.1
+  depends_on_cupy:
+    common:
+      - output_types: conda
+        packages:
+          - cupy>=12.0.0
+    # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
+    #       other packages with -cu{nn}x suffixes in this file.
+    #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix: {cuda: "12.*"}
+            packages: &cupy_packages_cu12
+              - cupy-cuda12x>=12.0.0
+          - matrix: {cuda: "11.*"}
+            packages:
+              - cupy-cuda11x>=12.0.0
+          - {matrix: null, packages: *cupy_packages_cu12}
   depends_on_ucx_build:
     common:
       - output_types: conda
@@ -205,7 +226,6 @@ dependencies:
       - output_types: [conda]
         packages:
           - &cudf_unsuffixed cudf==24.10.*,>=0.0.0a0
-          - cupy>=12.0.0
     specific:
       - output_types: [requirements, pyproject]
         matrices:
@@ -214,30 +234,11 @@ dependencies:
               cuda_suffixed: "true"
             packages:
               - cudf-cu12==24.10.*,>=0.0.0a0
-              - &cupy_cu12 cupy-cuda12x>=12.0.0
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cudf_unsuffixed
-              # NOTE: cupy still has a "-cuda12x" suffix here, because it's suffixed
-              #       in DLFW builds
-              - *cupy_cu12
           - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
               - cudf-cu11==24.10.*,>=0.0.0a0
-              - &cupy_cu11 cupy-cuda11x>=12.0.0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "false"
-            packages:
-              - *cudf_unsuffixed
-              # NOTE: cupy still has a "-cuda11x" suffix here, because it's suffixed
-              #       in DLFW builds
-              - *cupy_cu11
           - matrix:
             packages:
               - *cudf_unsuffixed
-              - *cupy_cu11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 test = [
     "cloudpickle",
     "cudf==24.10.*,>=0.0.0a0",
-    "cupy-cuda11x>=12.0.0",
+    "cupy-cuda12x>=12.0.0",
     "dask",
     "distributed",
     "numba>=0.57",


### PR DESCRIPTION
Follow-up to #1057.

Implements the following suggestions based on review comments from @jakirkham and @bdice there:

* splits `cupy` out into its own list in `dependencies.yaml`, to allow removing some `cuda_suffixed: "false"` blocks that were otherwise redundant
* passes `--matrix-entry 'cuda=12.x'` in docs builds, to make it clearer that those builds are just trying to match `cuda: "12.*"` and are not at all dependent on any particular minor version of CUDA

Also proposes defaulting to `cupy-cuda12x` in `pyproject.toml`, as part of https://github.com/rapidsai/build-planning/issues/68.