### PR TITLE
Use block style instead of flow style for pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,9 @@ repos:
         rev: v0.3.1
         hooks:
               - id: verify-alpha-spec
-                args: [--fix, --rapids-version=24.10]
+                args:
+                  - --fix
+                  - --rapids-version=24.10
       - repo: https://github.com/rapidsai/dependency-file-generator
         rev: v1.13.11
         hooks:


### PR DESCRIPTION
Since the --rapids-version argument will change from one release to the next, use a block style instead of a flow style to make merge conflicts less likely.