### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -107,10 +107,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.9"
-            packages:
-              - python=3.9
-          - matrix:
               py: "3.10"
             packages:
               - python=3.10
@@ -120,7 +116,7 @@ dependencies:
               - python=3.11
           - matrix:
             packages:
-              - python>=3.9,<3.12
+              - python>=3.10,<3.12
   build_python:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/docker/ucx-py-cuda11.5.yml
+++ b/docker/ucx-py-cuda11.5.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.9
+  - python=3.10
   - cudatoolkit=11.5
   - setuptools
   - cython>=3.0.0

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -89,7 +89,7 @@ Build Dependencies
 
 .. note::
     The Python version must be explicitly specified here, UCX-Py currently supports
-    only Python 3.9, 3.10, and 3.11.
+    only Python 3.10 and 3.11.
 
 Test Dependencies
 ^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.23,<3.0a0",
     "pynvml>=11.4.1",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/88

Finishes the work of dropping Python 3.9 support.

This project stopped building / testing against Python 3.9 as of https://github.com/rapidsai/shared-workflows/pull/235.
This PR updates configuration and docs to reflect that.

## Notes for Reviewers

### How I tested this

Checked that there were no remaining uses like this:

```shell
git grep -E '3\.9'
git grep '39'
git grep 'py39'
```

And similar for variations on Python 3.8 (to catch things that were missed the last time this was done).
