### PR TITLE
Update rapidsai/pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
                 args: ["--config=.flake8.cython"]
                 types: [cython]
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v0.3.1
+        rev: v0.4.0
         hooks:
               - id: verify-alpha-spec
                 args:


### PR DESCRIPTION
This PR updates rapidsai/pre-commit-hooks to the version 0.4.0.
