### PR TITLE
Update flake8 to 7.1.1.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,14 @@
 [flake8]
-ignore = E901,E225,E226,E227,E999,E203,W503
+ignore = E203,E211,E225,E226,E227,E901,E999,W503,W504
+# E203: whitespace before ':' (black format differs for slices)
+# E211: whitespace before '(' (used in multi-line imports)
+# E225: Missing whitespace around operators (breaks cython casting syntax like <int>)
+# E226: Missing whitespace around arithmetic operators (breaks cython pointer syntax like int*)
+# E227: Missing whitespace around bitwise or shift operator (Can also break casting syntax)
+# E999: invalid syntax (works for Python, not Cython)
+# W503: line break before binary operator (breaks lines that start with a pointer)
+# W504: line break after binary operator (breaks lines that end with a pointer)
+
 exclude =
     .eggs,
     *.egg,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,18 +11,14 @@ repos:
         rev: 22.3.0
         hooks:
               - id: black
-      - repo: https://github.com/pycqa/flake8
-        rev: 5.0.4
+      - repo: https://github.com/PyCQA/flake8
+        rev: 7.1.1
         hooks:
               - id: flake8
-      - repo: https://github.com/pycqa/flake8
-        rev: 5.0.4
-        hooks:
-              - id: flake8
-                alias: flake8-cython
-                name: flake8-cython
-                args: ["--config=.flake8.cython"]
-                types: [cython]
+                args: ["--config=.flake8"]
+                types: [file]
+                types_or: [python, cython]
+                additional_dependencies: ["flake8-force"]
       - repo: https://github.com/rapidsai/pre-commit-hooks
         rev: v0.4.0
         hooks:


### PR DESCRIPTION
We need to update flake8 to fix a false-positive that appears with older flake8 versions on Python 3.12.

I also combined the flake8-cython configuration by using flake8-force. We have adopted this in all other RAPIDS repos, but it seems ucx-py was overlooked.
