### PR TITLE
make conda installs in CI stricter

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-RAPIDS_VERSION="$(rapids-version)"
+UCX_PY_VERSION="$(rapids-version)"
 
 rapids-dependency-file-generator \
   --output conda \
@@ -52,7 +52,7 @@ PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
 
 rapids-mamba-retry install \
   --channel "${PYTHON_CHANNEL}" \
-  "ucx-py=${RAPIDS_VERSION}"
+  "ucx-py=${UCX_PY_VERSION}"
 
 rapids-logger "Run tests with conda package"
 run_tests

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-UCX_PY_VERSION="$(rapids-version)"
+UCX_PY_VERSION="$(head -1 ./VERSION)"
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -9,6 +9,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
+RAPIDS_VERSION="$(rapids-version)"
+
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python \
@@ -50,7 +52,7 @@ PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
 
 rapids-mamba-retry install \
   --channel "${PYTHON_CHANNEL}" \
-  ucx-py
+  "ucx-py=${RAPIDS_VERSION}"
 
 rapids-logger "Run tests with conda package"
 run_tests


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/106

Proposes specifying the RAPIDS version in `conda install` calls that install CI artifacts, to reduce the risk of CI jobs picking up artifacts from other releases.