### PR TITLE
remove unnecessary sccache configuration, other small CI changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
                   - --fix
                   - --rapids-version=24.12
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.13.11
+        rev: v1.16.0
         hooks:
               - id: rapids-dependency-file-generator
                 args: ["--clean"]

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 
 rapids-configure-conda-channels
 
-source rapids-configure-sccache
-
 source rapids-date-string
 
 rapids-print-env
@@ -16,11 +14,7 @@ rapids-generate-version > ./VERSION
 rapids-logger "Begin py build"
 conda config --set path_conflict prevent
 
-sccache --show-zero-stats
-
 RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
   conda/recipes/ucx-py
-
-sccache --show-adv-stats
 
 rapids-upload-conda-to-s3 python

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,7 +16,11 @@ rapids-generate-version > ./VERSION
 rapids-logger "Begin py build"
 conda config --set path_conflict prevent
 
+sccache --show-zero-stats
+
 RAPIDS_PACKAGE_VERSION=$(head -1 ./VERSION) rapids-conda-retry mambabuild \
   conda/recipes/ucx-py
+
+sccache --show-adv-stats
 
 rapids-upload-conda-to-s3 python

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -13,7 +13,11 @@ rapids-generate-version > ./VERSION
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
+sccache --zero-stats
+
 python -m pip wheel . -w dist --no-deps --disable-pip-version-check --config-settings rapidsai.disable-cuda=false
+
+sccache --show-adv-stats
 
 mkdir -p final_dist
 python -m auditwheel repair \

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,8 +3,6 @@
 
 set -euo pipefail
 
-underscore_package_name=$(echo "${package_name}" | tr "-" "_")
-
 source rapids-date-string
 
 rapids-generate-version > ./VERSION
@@ -29,4 +27,4 @@ python -m auditwheel repair \
     --exclude "libuct.so.0" \
     dist/*
 
-RAPIDS_PY_WHEEL_NAME="${underscore_package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist
+RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -27,4 +27,4 @@ python -m auditwheel repair \
     --exclude "libuct.so.0" \
     dist/*
 
-RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 final_dist
+RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python final_dist

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,7 +3,6 @@
 
 set -euo pipefail
 
-package_name="ucx-py"
 underscore_package_name=$(echo "${package_name}" | tr "-" "_")
 
 source rapids-date-string

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,18 +6,13 @@ set -euo pipefail
 package_name="ucx-py"
 underscore_package_name=$(echo "${package_name}" | tr "-" "_")
 
-source rapids-configure-sccache
 source rapids-date-string
 
 rapids-generate-version > ./VERSION
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
-sccache --zero-stats
-
-python -m pip wheel . -w dist --no-deps --disable-pip-version-check --config-settings rapidsai.disable-cuda=false
-
-sccache --show-adv-stats
+python -m pip wheel -v . -w dist --no-deps --disable-pip-version-check --config-settings rapidsai.disable-cuda=false
 
 mkdir -p final_dist
 python -m auditwheel repair \


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/111

Proposes some small packaging/CI changes, matching similar changes being made across RAPIDS.

* updating to the latest `rapids-dependency-file-generator` (v1.16.0)
* removing unnecessary calls to `rapids-configure-sccache` (this project does not use `sccache`)

## Notes for Reviewers

I'd originally started this PR with the goal of printing `sccache` stats in builds here... but realized this project does not use `sccache`.

I chose not to pursue adding `sccache` here. The fact that this project doesn't use CMake means it'd take some effort to figure out how to inject `sccache` into the compilation (`CC` / `CXX` environment variables? something else?). Conda and wheel builds are only spending around 20 seconds actually compiling Cython code, so it doesn't seem worth the effort.