### PR TITLE
Use GCC 13 in CUDA 12 conda builds.

### DIFF
--- a/conda/recipes/ucx-py/conda_build_config.yaml
+++ b/conda/recipes/ucx-py/conda_build_config.yaml
@@ -1,7 +1,9 @@
 c_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 cxx_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 ucx:
   - "==1.15.*"


### PR DESCRIPTION
## Description
conda-forge is using GCC 13 for CUDA 12 builds. This PR updates CUDA 12 conda builds to use GCC 13, for alignment.

These PRs should be merged in a specific order, see https://github.com/rapidsai/build-planning/issues/129 for details.
