### PR TITLE
Expose configuration of exchange peer info timeout

### DIFF
--- a/ucp/core.py
+++ b/ucp/core.py
@@ -35,7 +35,9 @@ def _get_ctx():
     return _ctx
 
 
-async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener, stream_timeout=5.0):
+async def exchange_peer_info(
+    endpoint, msg_tag, ctrl_tag, listener, connect_timeout=5.0
+):
     """Help function that exchange endpoint information"""
 
     # Pack peer information incl. a checksum
@@ -50,20 +52,20 @@ async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener, stream_timeo
     if listener is True:
         await asyncio.wait_for(
             comm.stream_send(endpoint, my_info_arr, my_info_arr.nbytes),
-            timeout=stream_timeout,
+            timeout=connect_timeout,
         )
         await asyncio.wait_for(
             comm.stream_recv(endpoint, peer_info_arr, peer_info_arr.nbytes),
-            timeout=stream_timeout,
+            timeout=connect_timeout,
         )
     else:
         await asyncio.wait_for(
             comm.stream_recv(endpoint, peer_info_arr, peer_info_arr.nbytes),
-            timeout=stream_timeout,
+            timeout=connect_timeout,
         )
         await asyncio.wait_for(
             comm.stream_send(endpoint, my_info_arr, my_info_arr.nbytes),
-            timeout=stream_timeout,
+            timeout=connect_timeout,
         )
 
     # Unpacking and sanity check of the peer information
@@ -74,7 +76,7 @@ async def exchange_peer_info(endpoint, msg_tag, ctrl_tag, listener, stream_timeo
 
     if expected_checksum != ret["checksum"]:
         raise RuntimeError(
-            f'Checksum invalid! {hex(expected_checksum)} != {hex(ret["checksum"])}'
+            f"Checksum invalid! {hex(expected_checksum)} != {hex(ret['checksum'])}"
         )
 
     return ret
@@ -157,6 +159,7 @@ async def _listener_handler_coroutine(conn_request, ctx, func, endpoint_error_ha
         msg_tag=msg_tag,
         ctrl_tag=ctrl_tag,
         listener=True,
+        connect_timeout=ctx.connect_timeout,
     )
     tags = {
         "msg_send": peer_info["msg_tag"],
@@ -216,7 +219,9 @@ class ApplicationContext:
     The context of the Asyncio interface of UCX.
     """
 
-    def __init__(self, config_dict={}, blocking_progress_mode=None):
+    def __init__(
+        self, config_dict={}, blocking_progress_mode=None, connect_timeout=None
+    ):
         self.progress_tasks = []
 
         # For now, a application context only has one worker
@@ -229,6 +234,13 @@ class ApplicationContext:
             self.blocking_progress_mode = False
         else:
             self.blocking_progress_mode = True
+
+        if "UCXPY_CONNECT_TIMEOUT" in os.environ:
+            self.connect_timeout = float(os.environ["UCXPY_CONNECT_TIMEOUT"])
+        elif connect_timeout is not None:
+            self.connect_timeout = connect_timeout
+        else:
+            self.connect_timeout = 5.0
 
         if self.blocking_progress_mode:
             self.epoll_fd = self.worker.init_blocking_progress_mode()
@@ -330,6 +342,7 @@ class ApplicationContext:
             msg_tag=msg_tag,
             ctrl_tag=ctrl_tag,
             listener=False,
+            connect_timeout=self.connect_timeout,
         )
         tags = {
             "msg_send": peer_info["msg_tag"],
@@ -896,7 +909,12 @@ class Endpoint:
 # The following functions initialize and use a single ApplicationContext instance
 
 
-def init(options={}, env_takes_precedence=False, blocking_progress_mode=None):
+def init(
+    options={},
+    env_takes_precedence=False,
+    blocking_progress_mode=None,
+    connect_timeout=None,
+):
     """Initiate UCX.
 
     Usually this is done automatically at the first API call
@@ -914,6 +932,10 @@ def init(options={}, env_takes_precedence=False, blocking_progress_mode=None):
         If None, blocking UCX progress mode is used unless the environment variable
         `UCXPY_NON_BLOCKING_MODE` is defined.
         Otherwise, if True blocking mode is used and if False non-blocking mode is used.
+    connect_timeout: float, optional
+        The timeout in seconds for exchanging endpoint information upon endpoint
+        establishment. If None, the default of 5 seconds is used, unless
+        `UCXPY_CONNECT_TIMEOUT` is defined, which takes precedence over this argument.
     """
     global _ctx
     if _ctx is not None:
@@ -935,7 +957,11 @@ def init(options={}, env_takes_precedence=False, blocking_progress_mode=None):
                 logger.debug(
                     f"Ignoring environment {env_k}={env_v}; using option {k}={v}"
                 )
-    _ctx = ApplicationContext(options, blocking_progress_mode=blocking_progress_mode)
+    _ctx = ApplicationContext(
+        options,
+        blocking_progress_mode=blocking_progress_mode,
+        connect_timeout=connect_timeout,
+    )
 
 
 def reset():

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -235,13 +235,10 @@ class ApplicationContext:
         else:
             self.blocking_progress_mode = True
 
-        if "UCXPY_CONNECT_TIMEOUT" in os.environ:
-            self.connect_timeout = float(os.environ["UCXPY_CONNECT_TIMEOUT"])
-        elif connect_timeout is not None:
-            self.connect_timeout = connect_timeout
+        if connect_timeout is None:
+            self.connect_timeout = float(os.get("UCXPY_CONNECT_TIMEOUT", 5))           
         else:
-            self.connect_timeout = 5.0
-
+            self.connect_timeout = connect_timeout
         if self.blocking_progress_mode:
             self.epoll_fd = self.worker.init_blocking_progress_mode()
             weakref.finalize(

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -236,7 +236,7 @@ class ApplicationContext:
             self.blocking_progress_mode = True
 
         if connect_timeout is None:
-            self.connect_timeout = float(os.get("UCXPY_CONNECT_TIMEOUT", 5))           
+            self.connect_timeout = float(os.get("UCXPY_CONNECT_TIMEOUT", 5))
         else:
             self.connect_timeout = connect_timeout
         if self.blocking_progress_mode:
@@ -932,8 +932,8 @@ def init(
         Otherwise, if True blocking mode is used and if False non-blocking mode is used.
     connect_timeout: float, optional
         The timeout in seconds for exchanging endpoint information upon endpoint
-        establishment. If None, the default of 5 seconds is used, unless
-        `UCXPY_CONNECT_TIMEOUT` is defined, which takes precedence over this argument.
+        establishment. If None, use the value from `UCXPY_CONNECT_TIMEOUT` if defined,
+        otherwise fallback to the default of 5 seconds.
     """
     global _ctx
     if _ctx is not None:

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -236,7 +236,7 @@ class ApplicationContext:
             self.blocking_progress_mode = True
 
         if connect_timeout is None:
-            self.connect_timeout = float(os.get("UCXPY_CONNECT_TIMEOUT", 5))
+            self.connect_timeout = float(os.environ.get("UCXPY_CONNECT_TIMEOUT", 5))
         else:
             self.connect_timeout = connect_timeout
         if self.blocking_progress_mode:

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -561,6 +561,7 @@ class Endpoint:
 
     def __init__(self, endpoint, ctx, tags=None):
         self._ep = endpoint
+        self._uid = self._ep.handle
         self._ctx = ctx
         self._send_count = 0  # Number of calls to self.send()
         self._recv_count = 0  # Number of calls to self.recv()
@@ -572,7 +573,7 @@ class Endpoint:
     @property
     def uid(self):
         """The unique ID of the underlying UCX endpoint"""
-        return self._ep.handle
+        return self._uid
 
     def closed(self):
         """Is this endpoint closed?"""


### PR DESCRIPTION
Add support to configure the timeout of messages during exchange peer info via constructor argument and environment variable.

This feature is important in Distributed (see https://github.com/rapidsai/ucx-py/pull/994 for details), more so on larger scale clusters. A new configuration variable will be added to allow controlling this feature via Dask config and environment variables.