### PR TITLE
Add upper bound to prevent usage of numba 0.61.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -225,7 +225,7 @@ dependencies:
           - cloudpickle
           - rapids-dask-dependency==25.2.*,>=0.0.0a0
           - distributed
-          - numba>=0.57
+          - numba>=0.59.1,<0.61.0a0
           - pytest==7.*
           - pytest-asyncio
           - pytest-rerunfailures

--- a/docker/ucx-py-cuda11.5.yml
+++ b/docker/ucx-py-cuda11.5.yml
@@ -13,5 +13,5 @@ dependencies:
   - dask
   - distributed
   - cupy
-  - numba>=0.57
+  - numba>=0.59.1,<0.61.0a0
   - rmm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
     "cudf==25.2.*,>=0.0.0a0",
     "cupy-cuda12x>=12.0.0",
     "distributed",
-    "numba>=0.57",
+    "numba>=0.59.1,<0.61.0a0",
     "pytest-asyncio",
     "pytest-rerunfailures",
     "pytest==7.*",


### PR DESCRIPTION
Numba 0.61.0 just got released with couple of breaking changes, this pr is required to unblock the ci.

xref: https://github.com/rapidsai/cudf/pull/17777