### PR TITLE
Increase upper UCX pin to 1.19

### DIFF
--- a/conda/recipes/ucx-py/meta.yaml
+++ b/conda/recipes/ucx-py/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     {% endfor %}
   run:
     - python
-    - ucx >=1.15.0,<1.18.0
+    - ucx >=1.15.0,<1.19.0
     # 'libucx' wheel dependency is unnecessary... the 'ucx' conda-forge package is used here instead
     {% for req in data["project"]["dependencies"] if not req.startswith("libucx") %}
     - {{ req }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -190,7 +190,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - ucx>=1.15.0,<1.18
+          - ucx>=1.15.0,<1.19
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -203,12 +203,12 @@ dependencies:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - libucx-cu12>=1.15.0,<1.18
+              - libucx-cu12>=1.15.0,<1.19
           - matrix:
               cuda: "11.*"
               cuda_suffixed: "true"
             packages:
-              - libucx-cu11>=1.15.0,<1.18
+              - libucx-cu11>=1.15.0,<1.19
           # this fallback is intentionally empty... it simplifies building from source
           # without CUDA, e.g. 'pip install .'
           - matrix: null


### PR DESCRIPTION
Increase upper UCX pin to 1.19 to allow us supporting UCX 1.18 that is needed for RAPIDS 25.02.