### PR TITLE
ensure update-version.sh updates pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
                   - --fix
                   - --rapids-version=25.02
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.16.0
+        rev: v1.17.0
         hooks:
               - id: rapids-dependency-file-generator
                 args: ["--clean"]

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -54,6 +54,10 @@ for FILE in dependencies.yaml conda/environments/*.yml; do
   done
 done
 
+for DEP in "${DEPENDENCIES[@]}"; do
+  sed_runner "/\"${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*\"/==${NEXT_RAPIDS_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" pyproject.toml
+done
+
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_RAPIDS_SHORT_TAG}/g" "${FILE}"
 done


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/136

This project's `update-version.sh` misses some RAPIDS dependencies in `pyproject.toml`. This fixes that.

Also updates to the latest `rapids-dependency-file-generator`.

## Notes for Reviewers

### How I tested this

```shell
git fetch upstream --tags
./ci/release/update-version.sh '0.43.00'
git grep -E '25\.2'
git grep -E '25\.02'
git grep -E '0\.42'
```