### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/conda/recipes/ucx-py/meta.yaml
+++ b/conda/recipes/ucx-py/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 {% set data = load_file_data("pyproject.toml") %}
 
@@ -51,7 +51,7 @@ test:
 
 about:
   home: {{ data["project"]["urls"]["Homepage"] }}
-  license: {{ data["project"]["license"]["text"] }}
+  license: {{ data["project"]["license"] }}
   license_file:
     {% for e in data["tool"]["setuptools"]["license-files"] %}
     - ../../../{{ e }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.23,<3.0a0",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
