### PR TITLE
require sphinx<8.2.0

### DIFF
--- a/conda/environments/builddocs.yml
+++ b/conda/environments/builddocs.yml
@@ -4,8 +4,8 @@ channels:
 - nvidia
 - conda-forge
 dependencies:
-# required for building docs
-- sphinx
+# the ceiling on sphinx can be removed when https://github.com/spatialaudio/nbsphinx/issues/825 is resolved
+- sphinx>=8.0,<8.2.0
 - sphinx-markdown-tables
 - sphinx_rtd_theme
 - sphinxcontrib-websupport


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/155

Fixes docs builds by temporarily putting a ceiling on `sphinx`.

## Notes for Reviewers

In case you're wondering why you don't see `dependencies.yaml` changes... this project uses readthedocs to builds its docs.

* builds: https://app.readthedocs.org/projects/ucx-py/builds/
* config: https://github.com/rapidsai/ucx-py/blob/674e731c21e3a85045239a943248b23dab019619/.readthedocs.yml#L16-L17