### PR TITLE
Moving wheel builds to specified location and uploading build artifacts to Github

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
+      package-type: python
+      wheel-name: ucx_py
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,6 +59,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
+      package-type: python
+      wheel-name: ucx_py
   wheel-tests:
     needs: wheel-build
     secrets: inherit

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 source rapids-date-string
 
+wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
+
 rapids-generate-version > ./VERSION
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
@@ -17,9 +19,8 @@ rapids-pip-retry wheel \
     --config-settings rapidsai.disable-cuda=false \
     .
 
-mkdir -p final_dist
 python -m auditwheel repair \
-    -w final_dist \
+    -w "${wheel_dir}" \
     --exclude "libucm.so.0" \
     --exclude "libucp.so.0" \
     --exclude "libucs.so.0" \
@@ -27,6 +28,6 @@ python -m auditwheel repair \
     --exclude "libuct.so.0" \
     dist/*
 
-./ci/validate_wheel.sh final_dist
+./ci/validate_wheel.sh "${wheel_dir}"
 
-RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python final_dist
+RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${wheel_dir}"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 
 source rapids-date-string
 
-wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
-
 rapids-generate-version > ./VERSION
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
@@ -20,7 +18,7 @@ rapids-pip-retry wheel \
     .
 
 python -m auditwheel repair \
-    -w "${wheel_dir}" \
+    -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     --exclude "libucm.so.0" \
     --exclude "libucp.so.0" \
     --exclude "libucs.so.0" \
@@ -28,6 +26,6 @@ python -m auditwheel repair \
     --exclude "libuct.so.0" \
     dist/*
 
-./ci/validate_wheel.sh "${wheel_dir}"
+./ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${wheel_dir}"
+RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

As part of these changes, all wheel builds need to be in a specified temporary directory indicated by the environment variable `RAPIDS_WHEEL_BLD_OUTPUT_DIR` set on the `ci-wheel` Docker image used for building wheels. This lets us upload all wheel artifacts seamlessly to Github Artifacts. 