### PR TITLE
Download build artifacts from Github for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,8 +52,8 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel.sh
+      package-name: ucx_py
       package-type: python
-      wheel-name: ucx_py
   wheel-publish:
     needs: wheel-build
     secrets: inherit
@@ -64,3 +64,4 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: ucx_py
+      package-type: python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,8 +59,8 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
+      package-name: ucx_py
       package-type: python
-      wheel-name: ucx_py
   wheel-tests:
     needs: wheel-build
     secrets: inherit

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -10,7 +10,7 @@ rapids-logger "Create test conda environment using artifacts from previous job"
 . /opt/conda/etc/profile.d/conda.sh
 
 UCX_PY_VERSION="$(head -1 ./VERSION)"
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -5,10 +5,10 @@ set -eoxu pipefail
 
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
-RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
+PYTHON_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 
 # echo to expand wildcard before adding `[extra]` requires for pip
-rapids-pip-retry install $(echo ./dist/ucx_py*.whl)[test]
+rapids-pip-retry install $(echo "${PYTHON_WHEELHOUSE}"/ucx_py*.whl)[test]
 
 cd tests
 timeout 10m python -m pytest --cache-clear -vs .


### PR DESCRIPTION
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

Updates conda and wheel artifact download source from S3 to GitHub across CI scripts, wherever applicable. 

Uses dynamic temporary paths for wheel downloads returned by `rapids-download-wheels-from-github` instead of using fixed directories, to streamline wheel downloads in the same way as conda downloads.

Also updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs. 