### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   conda-python-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.13
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -37,7 +37,7 @@ jobs:
   upload-conda:
     needs: [conda-python-build]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@python-3.13
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -45,7 +45,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@python-3.13
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -57,7 +57,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@python-3.13
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
       - wheel-tests
       - telemetry-setup
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@python-3.13
     with:
       needs: ${{ toJSON(needs) }}
   telemetry-setup:
@@ -36,26 +36,26 @@ jobs:
   checks:
     secrets: inherit
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@python-3.13
     with:
       ignored_pr_jobs: telemetry-summarize
   conda-python-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@python-3.13
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@python-3.13
     with:
       build_type: pull-request
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@python-3.13
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
@@ -64,7 +64,7 @@ jobs:
   wheel-tests:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@python-3.13
     with:
       build_type: pull-request
       script: ci/test_wheel.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   conda-python-tests:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@python-3.13
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -28,7 +28,7 @@ jobs:
       container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
   wheel-tests:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@python-3.13
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -12,7 +12,7 @@ jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/breaking-change-alert.yaml@python-3.13
     with:
       sender_login: ${{ github.event.sender.login }}
       sender_avatar: ${{ github.event.sender.avatar_url }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -124,8 +124,12 @@ dependencies:
             packages:
               - python=3.12
           - matrix:
+              py: "3.13"
             packages:
-              - python>=3.10,<3.13
+              - python=3.13
+          - matrix:
+            packages:
+              - python>=3.10,<3.14
   build_python:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -93,11 +93,11 @@ Build Dependencies
 
     conda create -n ucx -c conda-forge \
         automake make libtool pkg-config \
-        "python=3.12" "setuptools>=64.0" "cython>=3.0.0"
+        "python=3.13" "setuptools>=64.0" "cython>=3.0.0"
 
 .. note::
     The Python version must be explicitly specified here, UCX-Py currently supports
-    Python versions 3.10, 3.11, and 3.12.
+    Python versions 3.10, 3.11, 3.12, and 3.13.
 
 Test Dependencies
 ^^^^^^^^^^^^^^^^^
@@ -218,8 +218,8 @@ Installing UCX-Py from source in a pip-only environment has additional limitatio
 UCX-Py with UCX from PyPI
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-CUDA-enabled builds of the UCX libraries are available from PyPI, under the names ``libucx-cu{11,12}``. 
-Notice that those builds do not currently include InfiniBand support, if InfiniBand is required you will 
+CUDA-enabled builds of the UCX libraries are available from PyPI, under the names ``libucx-cu{11,12}``.
+Notice that those builds do not currently include InfiniBand support, if InfiniBand is required you will
 need to provide a custom UCX install as described in the "UCX-Py with custom UCX install" section.
 
 To build UCX-Py using those UCX packages (to avoid needing to build UCX from source), run the following.


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/120

This PR adds support for Python 3.13.

## Notes for Reviewers

This is part of ongoing work to add Python 3.13 support across RAPIDS.
It temporarily introduces a build/test matrix including Python 3.13, from https://github.com/rapidsai/shared-workflows/pull/268.

A follow-up PR will revert back to pointing at the `branch-25.06` branch of `shared-workflows` once all
RAPIDS repos have added Python 3.13 support.

### This will fail until all dependencies have been updated to Python 3.13

CI here is expected to fail until all of this project's upstream dependencies support Python 3.13.

This can be merged whenever all CI jobs are passing.

