### PR TITLE
add shellcheck to pre-commit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@ benchmarks/     @rapidsai/ucxpy-python-codeowners
 /.github/                @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners
 /.pre-commit-config.yaml @rapidsai/ci-codeowners
+/.shellcheckrc           @rapidsai/ci-codeowners
 
 #packaging code owners
 /.devcontainer/    @rapidsai/packaging-codeowners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,12 @@ repos:
                 types: [file]
                 types_or: [python, cython]
                 additional_dependencies: ["flake8-force"]
+      - repo: https://github.com/shellcheck-py/shellcheck-py
+        rev: v0.10.0.1
+        hooks:
+          - id: shellcheck
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v0.4.0
+        rev: v0.6.0
         hooks:
               - id: verify-copyright
               - id: verify-alpha-spec
@@ -28,7 +32,7 @@ repos:
                   - --fix
                   - --rapids-version=25.08
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.17.0
+        rev: v1.18.1
         hooks:
               - id: rapids-dependency-file-generator
                 args: ["--clean"]

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+# Disable file checks (otherwise every use of `gha-tools` will get flagged)
+disable=SC1091

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+
 ########################
 # ucx-py Version Updater #
 ########################
@@ -13,18 +15,14 @@ NEXT_FULL_TAG=$1
 
 # Get current version
 CURRENT_TAG=$(git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v')
-CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
-CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
-CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')
-CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
 
 #Get <major>.<minor> for next version
-NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
-NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
-NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
+NEXT_MAJOR=$(echo "${NEXT_FULL_TAG}" | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo "${NEXT_FULL_TAG}" | awk '{split($0, a, "."); print a[2]}')
+NEXT_SHORT_TAG="${NEXT_MAJOR}.${NEXT_MINOR}"
 
 # Get RAPIDS version associated w/ ucx-py version
-NEXT_RAPIDS_SHORT_TAG="$(curl -sL https://version.gpuci.io/ucx-py/${NEXT_SHORT_TAG})"
+NEXT_RAPIDS_SHORT_TAG="$(curl -sL "https://version.gpuci.io/ucx-py/${NEXT_SHORT_TAG}")"
 
 # Need to distutils-normalize the versions for some use cases
 NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_SHORT_TAG}'))")
@@ -35,7 +33,7 @@ echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
-    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+    sed -i.bak ''"$1"'' "$2" && rm -f "${2}".bak
 }
 
 DEPENDENCIES=(

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -9,7 +9,6 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 rapids-logger "Create test conda environment using artifacts from previous job"
 . /opt/conda/etc/profile.d/conda.sh
 
-UCX_PY_VERSION="$(head -1 ./VERSION)"
 PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-dependency-file-generator \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -5,11 +5,11 @@ set -eoxu pipefail
 
 source rapids-init-pip
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 PYTHON_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="ucx_py_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 
 # echo to expand wildcard before adding `[extra]` requires for pip
-rapids-pip-retry install $(echo "${PYTHON_WHEELHOUSE}"/ucx_py*.whl)[test]
+rapids-pip-retry install "$(echo "${PYTHON_WHEELHOUSE}"/ucx_py*.whl)[test]"
 
 cd tests
 timeout 10m python -m pytest --cache-clear -vs .

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -9,10 +9,10 @@ rapids-logger "validate packages with 'pydistcheck'"
 
 pydistcheck \
     --inspect \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"
 
 rapids-logger "validate packages with 'twine'"
 
 twine check \
     --strict \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"

--- a/docker/bench-all.sh
+++ b/docker/bench-all.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 set -e
 
 function logger {
-    echo -e "\n$@\n"
+    echo -e "\n${1}\n"
 }
 
 # Requires conda installed at /opt/conda and the ucx environment setup
@@ -13,8 +13,15 @@ source /opt/conda/etc/profile.d/conda.sh
 conda activate ucx
 
 cd ucx-py/
+
 # Benchmark using command-line provided transports or else default
-for tls in ${@:-"tcp" "all"}; do
+if [[ ${#@} -eq 0 ]]; then
+    transport_types=(tcp all)
+else
+    transport_types=("${@}")
+fi
+
+for tls in "${transport_types[@]}"; do
     export UCX_TLS=${tls}
     logger "Python pytest for ucx-py"
 

--- a/docker/build-ucx-py.sh
+++ b/docker/build-ucx-py.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 set -ex
 
 CONDA_HOME=${1:-"/opt/conda"}
 CONDA_ENV=${2:-"ucx"}
 
-source ${CONDA_HOME}/etc/profile.d/conda.sh
-source ${CONDA_HOME}/etc/profile.d/mamba.sh
-mamba activate ${CONDA_ENV}
+source "${CONDA_HOME}/etc/profile.d/conda.sh"
+source "${CONDA_HOME}/etc/profile.d/mamba.sh"
+mamba activate "${CONDA_ENV}"
 
 git clone https://github.com/rapidsai/ucx-py.git
 pip install -v ucx-py/

--- a/docker/build-ucx.sh
+++ b/docker/build-ucx.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 set -ex
 
 UCX_VERSION_TAG=${1:-"v1.13.0"}
@@ -6,20 +7,20 @@ CONDA_HOME=${2:-"/opt/conda"}
 CONDA_ENV=${3:-"ucx"}
 CUDA_HOME=${4:-"/usr/local/cuda"}
 # Send any remaining arguments to configure
-CONFIGURE_ARGS=${@:5}
+CONFIGURE_ARGS=("${@:5}")
 
-source ${CONDA_HOME}/etc/profile.d/conda.sh
-source ${CONDA_HOME}/etc/profile.d/mamba.sh
-mamba activate ${CONDA_ENV}
+source "${CONDA_HOME}/etc/profile.d/conda.sh"
+source "${CONDA_HOME}/etc/profile.d/mamba.sh"
+mamba activate "${CONDA_ENV}"
 
 git clone https://github.com/openucx/ucx.git
 
 cd ucx
-git checkout ${UCX_VERSION_TAG}
+git checkout "${UCX_VERSION_TAG}"
 ./autogen.sh
 mkdir build-linux && cd build-linux
-../contrib/configure-release --prefix=${CONDA_PREFIX} --with-sysroot --enable-cma \
+../contrib/configure-release --prefix="${CONDA_PREFIX}" --with-sysroot --enable-cma \
     --enable-mt --with-gnu-ld --with-rdmacm --with-verbs \
-    --with-cuda=${CUDA_HOME} \
-    ${CONFIGURE_ARGS}
+    --with-cuda="${CUDA_HOME}" \
+    "${CONFIGURE_ARGS[@]}"
 make -j install

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 set -e
 
 function logger {
-    echo -e "\n$@\n"
+    echo -e "\n${1}\n"
 }
 
 PYTHON_PREFIX=$(python -c "import distutils.sysconfig; print(distutils.sysconfig.PREFIX)")
@@ -25,17 +25,17 @@ pip list
 # BUILD - Build UCX master, UCX-Py and run tests
 ################################################################################
 logger "Build UCX master"
-cd $HOME
+cd "${HOME}"
 git clone https://github.com/openucx/ucx
 cd ucx
 ./autogen.sh
 ./contrib/configure-devel \
-    --prefix=$PYTHON_PREFIX \
+    --prefix="${PYTHON_PREFIX}" \
     --enable-gtest=no \
     --with-valgrind=no
 make -j install
 
-echo $PYTHON_PREFIX >> /etc/ld.so.conf.d/python.conf
+echo "${PYTHON_PREFIX}" >> /etc/ld.so.conf.d/python.conf
 ldconfig
 
 logger "UCX Version and Build Information"
@@ -46,7 +46,7 @@ ucx_info -v
 # TEST - Run pytests for ucx-py
 ################################################################################
 logger "Clone and Build UCX-Py"
-cd $HOME
+cd "${HOME}"
 git clone https://github.com/rapidsai/ucx-py
 cd ucx-py
 python setup.py build_ext --inplace


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/135

Adds `shellcheck` to `pre-commit`, to catch issues like unsafe access patterns, unused variables, etc. in shell scripts.

Fixes these:

```text
SC2034 (warning): UCX_PY_VERSION appears unused. Verify use (or export if used externally).
SC2034 (warning): CURRENT_SHORT_TAG appears unused. Verify use (or export if used externally).
SC2046 (warning): Quote this to prevent word splitting.
SC2068 (error): Double quote array expansions to avoid re-splitting elements.
SC2086 (info): Double quote to prevent globbing and word splitting.
SC2124 (warning): Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.
SC2145 (error): Argument mixes string and array. Use * or separate argument
```

Also updates other RAPIDS-specific pre-commit hooks to their latest versions.