### PR TITLE
Remove nvidia and dask channels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
                   - --fix
                   - --rapids-version-file=RAPIDS_VERSION
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.18.1
+        rev: v1.19.0
         hooks:
               - id: rapids-dependency-file-generator
                 args: ["--clean"]


### PR DESCRIPTION
Now that we have dropped support for CUDA 11 we no longer require the nvidia channel.
With the changes in https://github.com/rapidsai/rapids-dask-dependency/pull/85, RAPIDS now only uses released versions of dask, so we no longer need the dask channel either.
Contributes to https://github.com/rapidsai/build-planning/issues/184
