### PR TITLE
Use CUDA 12.9 in Conda, Devcontainers, Spark, GHA, etc.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -46,7 +46,7 @@ Change `cuda-version` to pin to a different CUDA minor version if you'd like.
 
     # CUDA 12
     conda create -n ucx -c conda-forge -c rapidsai \
-      cuda-version=12.8 ucx-py
+      cuda-version=12.9 ucx-py
 
 Starting with the UCX 1.14.1 conda-forge package,
 InfiniBand support is available again via rdma-core, thus building UCX


### PR DESCRIPTION
Addressing issues:
* https://github.com/rapidsai/build-planning/issues/195
* https://github.com/rapidsai/build-planning/issues/173

## Description

Use CUDA 12.9 throughout different build and test environments.