### PR TITLE
fix(docker): use versioned `-latest` tag for all `rapidsai` images

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -58,7 +58,11 @@ done
 
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_RAPIDS_SHORT_TAG}/g" "${FILE}"
+  sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
 
 echo "${NEXT_FULL_TAG_PEP440}" > VERSION
 echo "${NEXT_RAPIDS_SHORT_TAG}.00" > RAPIDS_VERSION
+
+# Update CI image tags of the form {rapids_version}-{something}
+sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" ./CONTRIBUTING.md


### PR DESCRIPTION
In rapidsai/build-planning#187 we switched the docker image tagging scheme
over to include the CalVer information.  This was done to allow us to make
changes to the images during burndown without breaking release pipelines.

This PR moves all of the existing `latest` tags to the newer versioned tag
`25.08-latest` and also modifies the `update_version.sh` script to bump
that version at branch creation time.

xref: https://github.com/rapidsai/build-planning/issues/187
