### PR TITLE
Increase min and max UCX pins to >=1.17 and <1.20, respectively

### DIFF
--- a/conda/recipes/ucx-py/conda_build_config.yaml
+++ b/conda/recipes/ucx-py/conda_build_config.yaml
@@ -5,4 +5,4 @@ cxx_compiler_version:
   - 14
 
 ucx:
-  - "==1.15.*"
+  - "==1.17.*"

--- a/conda/recipes/ucx-py/recipe.yaml
+++ b/conda/recipes/ucx-py/recipe.yaml
@@ -37,7 +37,7 @@ requirements:
     - numpy>=1.23,<3.0a0
     - pynvml>=12.0.0,<13.0.0a0
     - python
-    - ucx >=1.15.0,<1.19.0
+    - ucx >=1.17.0,<1.20.0
   ignore_run_exports:
     from_package:
       - ${{ compiler("c") }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -157,7 +157,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - ucx==1.15.0
+          - ucx==1.17.0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -165,14 +165,14 @@ dependencies:
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
       # very tight >=x.x.x,<x.x.(x+1) here allows for installation of
-      # post release like 1.15.0.post1
+      # post release like 1.17.0.post1
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - libucx-cu12>=1.15.0,<1.15.1
+              - libucx-cu12>=1.17.0,<1.17.1
           # this fallback is intentionally empty... it simplifies building from source
           # without CUDA, e.g. 'pip install .'
           - matrix: null
@@ -181,7 +181,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - ucx>=1.15.0,<1.19
+          - ucx>=1.17.0,<1.20
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -194,7 +194,7 @@ dependencies:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - libucx-cu12>=1.15.0,<1.19
+              - libucx-cu12>=1.17.0,<1.20
           # this fallback is intentionally empty... it simplifies building from source
           # without CUDA, e.g. 'pip install .'
           - matrix: null

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -102,17 +102,17 @@ Test Dependencies
         dask distributed cloudpickle
 
 
-UCX >= 1.15.0
+UCX >= 1.17.0
 ^^^^^^^^^^^^^
 
-Instructions for building UCX >= 1.15.0 (minimum version supported by UCX-Py), make sure to change ``git checkout v1.15.0`` to a newer version if desired:
+Instructions for building UCX >= 1.17.0 (minimum version supported by UCX-Py), make sure to change ``git checkout v1.17.0`` to a newer version if desired:
 
 ::
 
     conda activate ucx
     git clone https://github.com/openucx/ucx
     cd ucx
-    git checkout v1.15.0
+    git checkout v1.17.0
     ./autogen.sh
     mkdir build
     cd build
@@ -134,13 +134,13 @@ It is possible to enable InfiniBand support via the conda-forge rdma-core packag
     conda install -c conda-forge c-compiler cxx-compiler gcc_linux-64=11.* rdma-core=28.*
 
 
-After installing the necessary dependencies, it's now time to build UCX from source, make sure to change ``git checkout v1.15.0`` to a newer version if desired:
+After installing the necessary dependencies, it's now time to build UCX from source, make sure to change ``git checkout v1.17.0`` to a newer version if desired:
 
 ::
 
     git clone https://github.com/openucx/ucx
     cd ucx
-    git checkout v1.15.0
+    git checkout v1.17.0
     ./autogen.sh
     mkdir build
     cd build

--- a/ucp/__init__.py
+++ b/ucp/__init__.py
@@ -41,7 +41,7 @@ except ImportError:
 
 _ucx_version = get_ucx_version()
 
-__ucx_min_version__ = "1.15.0"
+__ucx_min_version__ = "1.17.0"
 __ucx_version__ = "%d.%d.%d" % _ucx_version
 
 if _ucx_version < tuple(int(i) for i in __ucx_min_version__.split(".")):


### PR DESCRIPTION
UCX 1.19 was released last week and we need to support it. Furthermore, we can tighten pins a little and just keep supporting up to a maximum of 3 minor versions, thus increasing to minimum pin 1.17 as well.