### PR TITLE
restore cudf dependency

### DIFF
--- a/ci/run_benchmark_pytests.sh
+++ b/ci/run_benchmark_pytests.sh
@@ -8,12 +8,5 @@ set -euo pipefail
 pushd /
 timeout 1m python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-async
 timeout 1m python -m ucp.benchmarks.send_recv -o cupy --server-dev 0 --client-dev 0 --reuse-alloc --backend ucp-core
-
-# TODO: run cudf_merge benchmark unconditionally once there are CUDA 13 cudf packages
-# ref: https://github.com/rapidsai/ucx-py/pull/1162#issuecomment-3210841342
-if [[ $(python -c "import cudf") ]]; then
-    timeout 1m python -m ucp.benchmarks.cudf_merge --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 2097152
-else
-    echo "'cudf' not installed, skipping cudf_merge benchmark"
-fi
+timeout 1m python -m ucp.benchmarks.cudf_merge --chunks-per-dev 4 --chunk-size 10000 --rmm-init-pool-size 2097152
 popd

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -255,27 +255,16 @@ dependencies:
           - matrix:
             packages:
               - numba-cuda[cu13]>=0.19.0,<0.20.0a0
-  # TODO: re-include cudf on CUDA 13 here once cudf CUDA 13 packages exist
-  # ref: https://github.com/rapidsai/ucx-py/pull/1162#issuecomment-3210841342
   depends_on_cudf:
     common:
+      - output_types: [conda]
+        packages:
+          - &cudf_unsuffixed cudf==25.10.*,>=0.0.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
           - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
     specific:
-      - output_types: [conda]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-            packages:
-              - &cudf_unsuffixed cudf==25.10.*,>=0.0.0a0
-          - matrix:
-              cuda: "13.*"
-            packages:
-          - matrix:
-            packages:
-              - *cudf_unsuffixed
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:
@@ -286,4 +275,5 @@ dependencies:
           - matrix:
               cuda: "13.*"
             packages:
+              - cudf-cu13==25.10.*,>=0.0.0a0
           - {matrix: null, packages: [*cudf_unsuffixed]}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/208

#1162 temporarily removed the `cudf` test-time dependency here, because there weren't yet CUDA 13 `cudf` packages.

Those now exist (https://github.com/rapidsai/cudf/pull/19768), so this restores that dependency.