### PR TITLE
Make final discontinuation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!CAUTION]
-> UCX-Py has been discontinued, version 0.45 (RAPIDS 25.08) was its last release and it will receive no further updates. Projects depending on UCX-Py are advised to migrate to [UCXX](https://github.com/rapidsai/ucxx) immediately. [UCXX documentation](https://docs.rapids.ai/api/ucxx/nightly/).
+> UCX-Py has been discontinued, version 0.45 (RAPIDS 25.08) was its last release and it will receive no further updates, see the [RAPIDS Support Notice 50](https://docs.rapids.ai/notices/rsn0050/) for details. Projects depending on UCX-Py are advised to migrate to [UCXX](https://github.com/rapidsai/ucxx) immediately. [UCXX documentation](https://docs.rapids.ai/api/ucxx/nightly/).
 
 [![https://ucx-py.readthedocs.io/en/latest/](https://readthedocs.org/projects/ucx-py/badge/ "ReadTheDocs")]( https://ucx-py.readthedocs.io/en/latest/ )
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-> [!WARNING]
-> UCX-Py is deprecated and will be phased out soon, version 0.45 (RAPIDS 25.08) is expected to be the last release. Projects that rely on UCX-Py are advised to migrate to [UCXX](https://github.com/rapidsai/ucxx) immediately.
+> [!CAUTION]
+> UCX-Py has been discontinued, version 0.45 (RAPIDS 25.08) was its last release and it will receive no further updates. Projects depending on UCX-Py are advised to migrate to [UCXX](https://github.com/rapidsai/ucxx) immediately. [UCXX documentation](https://docs.rapids.ai/api/ucxx/nightly/).
 
 [![https://ucx-py.readthedocs.io/en/latest/](https://readthedocs.org/projects/ucx-py/badge/ "ReadTheDocs")]( https://ucx-py.readthedocs.io/en/latest/ )
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
+# See file LICENSE for terms.
+#
 # -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
@@ -19,11 +22,8 @@
 
 # -- Project information -----------------------------------------------------
 
-# The full version, including alpha/beta/rc tags.
-from ucp import __version__ as release
-
 # The short X.Y version.
-version = ".".join(release.split(".")[:2])
+version = "0.45.0"
 
 project = "ucx-py"
 copyright = "2019-2021, NVIDIA"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ UCX-Py
 
 .. warning::
 
-    UCX-Py is deprecated, version 0.45 was its last release and it will receive no further updates. Users are advised to migrate to `UCXX <https://github.com/rapidsai/ucxx>`_ immediately. `UCXX documentation <https://docs.rapids.ai/api/ucxx/nightly/>`_.
+    UCX-Py has been discontinued, version 0.45 (RAPIDS 25.08) was its last release and it will receive no further updates. Projects depending on UCX-Py are advised to migrate to `UCXX <https://github.com/rapidsai/ucxx>`_ immediately. `UCXX documentation <https://docs.rapids.ai/api/ucxx/nightly/>`_.
 
 UCX-Py is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a low-level high-performance networking library.  UCX and UCX-Py supports several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ UCX-Py
 
 .. warning::
 
-    UCX-Py has been discontinued, version 0.45 (RAPIDS 25.08) was its last release and it will receive no further updates. Projects depending on UCX-Py are advised to migrate to `UCXX <https://github.com/rapidsai/ucxx>`_ immediately. `UCXX documentation <https://docs.rapids.ai/api/ucxx/nightly/>`_.
+    UCX-Py has been discontinued, version 0.45 (RAPIDS 25.08) was its last release and it will receive no further updates, see the `RAPIDS Support Notice 50 <https://docs.rapids.ai/notices/rsn0050/>`_ for details. Projects depending on UCX-Py are advised to migrate to `UCXX <https://github.com/rapidsai/ucxx>`_ immediately. `UCXX documentation <https://docs.rapids.ai/api/ucxx/nightly/>`_.
 
 UCX-Py is the Python interface for `UCX <https://github.com/openucx/ucx>`_, a low-level high-performance networking library.  UCX and UCX-Py supports several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -40,10 +40,6 @@ Change `cuda-version` to pin to a different CUDA minor version if you'd like.
 
 ::
 
-    # CUDA 13
-    conda create -n ucx -c conda-forge -c rapidsai \
-      cuda-version=13.0 ucx-py
-
     # CUDA 12
     conda create -n ucx -c conda-forge -c rapidsai \
       cuda-version=12.9 ucx-py
@@ -56,23 +52,19 @@ be done if desired (e.g., to test for new capabilities or bug fixes).
 PyPI
 ----
 
-PyPI installation is possible and currently supports CUDA versions
-``12`` and ``13``. Packages are compatible with CPU-only workloads and any one can
+PyPI installation is possible and currently supports CUDA version
+``12``. Packages are compatible with CPU-only workloads and any one can
 be chosen if the application doesn't use CUDA, but currently there are
 no pre-built CPU-only packages available, so the CUDA package must be
-installed instead. CUDA versions are differentiated by the suffix
-``-cuXY``, where ``XY`` must be replaced with the desired CUDA version.
+installed instead.
 
 ::
-
-    # CUDA 13
-    pip install ucx-py-cu13
 
     # CUDA 12
     pip install ucx-py-cu12
 
 UCX-Py has no direct dependency on CUDA, but the package specifies the
-``-cuXY`` prefix so that the correct ``libucx-cuXY`` package is selected.
+``-cu12`` prefix so that the correct ``libucx-cu12`` package is selected.
 This is also the reason why there are no CPU-only UCX-Py packages
 available at the moment, CPU-only builds of the UCX library are not
 currently available in PyPI.
@@ -217,7 +209,7 @@ Installing UCX-Py from source in a pip-only environment has additional limitatio
 UCX-Py with UCX from PyPI
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-CUDA-enabled builds of the UCX libraries are available from PyPI, under the names ``libucx-cu12`` (CUDA 12) and ``libucx-cu13`` (CUDA 13).
+CUDA-enabled builds of the UCX libraries are available from PyPI, under the name ``libucx-cu12`` (CUDA 12).
 Notice that those builds do not currently include InfiniBand support, if InfiniBand is required you will
 need to provide a custom UCX install as described in the "UCX-Py with custom UCX install" section.
 
@@ -232,8 +224,8 @@ To build UCX-Py using those UCX packages (to avoid needing to build UCX from sou
     # or for develop build
     pip install -v -e .
 
-This will automatically handle installing appropriate, compatible ``libucx-cu{12,13}`` packages for build-time and runtime use.
-When you run UCX-Py code installed this way, it will load UCX libraries from the installed ``libucx-cu{12,13}`` package.
+This will automatically handle installing appropriate, compatible ``libucx-cu12`` packages for build-time and runtime use.
+When you run UCX-Py code installed this way, it will load UCX libraries from the installed ``libucx-cu12`` package.
 
 UCX-Py packages are built against the oldest version of UCX that UCX-Py supports, and can run against a range
 of ABI-compatible UCX versions.
@@ -242,9 +234,6 @@ You can use packages from PyPI to customize the UCX version used at runtime.
 For example, to switch to using UCX 1.19 at runtime, run the following.
 
 ::
-
-    # CUDA 13
-    pip install 'libucx-cu13>=1.19.0,<1.20'
 
     # CUDA 12
     pip install 'libucx-cu12>=1.19.0,<1.20'
@@ -264,7 +253,7 @@ If a UCX system install is available, building and installing UCX-Py can be done
     # or for develop build
     pip install -v -e .
 
-To ensure that system install of UCX is always used at runtime (and not the ``libucx-cu{12,13}`` wheels), set the following
+To ensure that system install of UCX is always used at runtime (and not the ``libucx-cu12`` wheels), set the following
 environment variable in the runtime environment.
 
 ::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -231,12 +231,12 @@ UCX-Py packages are built against the oldest version of UCX that UCX-Py supports
 of ABI-compatible UCX versions.
 
 You can use packages from PyPI to customize the UCX version used at runtime.
-For example, to switch to using UCX 1.19 at runtime, run the following.
+For example, to switch to using UCX 1.18 at runtime, run the following.
 
 ::
 
     # CUDA 12
-    pip install 'libucx-cu12>=1.19.0,<1.20'
+    pip install 'libucx-cu12>=1.18.0,<1.19'
 
 
 UCX-Py with UCX system install

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -101,17 +101,17 @@ Test Dependencies
         dask distributed cloudpickle
 
 
-UCX >= 1.17.0
+UCX >= 1.15.0
 ^^^^^^^^^^^^^
 
-Instructions for building UCX >= 1.17.0 (minimum version supported by UCX-Py), make sure to change ``git checkout v1.17.0`` to a newer version if desired:
+Instructions for building UCX >= 1.15.0 (minimum version supported by UCX-Py), make sure to change ``git checkout v1.15.0`` to a newer version if desired:
 
 ::
 
     conda activate ucx
     git clone https://github.com/openucx/ucx
     cd ucx
-    git checkout v1.17.0
+    git checkout v1.15.0
     ./autogen.sh
     mkdir build
     cd build
@@ -133,13 +133,13 @@ It is possible to enable InfiniBand support via the conda-forge rdma-core packag
     conda install -c conda-forge c-compiler cxx-compiler gcc_linux-64=11.* rdma-core=28.*
 
 
-After installing the necessary dependencies, it's now time to build UCX from source, make sure to change ``git checkout v1.17.0`` to a newer version if desired:
+After installing the necessary dependencies, it's now time to build UCX from source, make sure to change ``git checkout v1.15.0`` to a newer version if desired:
 
 ::
 
     git clone https://github.com/openucx/ucx
     cd ucx
-    git checkout v1.17.0
+    git checkout v1.15.0
     ./autogen.sh
     mkdir build
     cd build


### PR DESCRIPTION
This is expected to be the last commit to UCX-Py. It updates the README and docs warnings to inform users that UCX-Py has been permanently discontinued. Along with it, this change removes CUDA 13 mentions from docs, since there will be no CUDA 13 packages released for UCX-Py, however, the functional changes to allow building with CUDA 13 are kept should those be needed for any reason in the near-term.